### PR TITLE
Rename PyPI package to semantic-slayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="docs/images/slayer-hero.png" alt="SLayer — AI agent operating a semantic layer" width="700">
 </p>
 
-[![PyPI](https://img.shields.io/pypi/v/agentic-slayer?label=PyPI)](https://pypi.org/project/agentic-slayer/)
-[![Python](https://img.shields.io/pypi/pyversions/agentic-slayer)](https://pypi.org/project/agentic-slayer/)
-[![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://agentic-slayer.readthedocs.io/)
+[![PyPI](https://img.shields.io/pypi/v/semantic-slayer?label=PyPI)](https://pypi.org/project/semantic-slayer/)
+[![Python](https://img.shields.io/pypi/pyversions/semantic-slayer)](https://pypi.org/project/semantic-slayer/)
+[![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://semantic-slayer.readthedocs.io/)
 [![License](https://img.shields.io/github/license/MotleyAI/slayer)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/MotleyAI/slayer?style=social)](https://github.com/MotleyAI/slayer/stargazers)
 
@@ -47,12 +47,12 @@ When AI agents write raw SQL, things break in production — hallucinated column
 
 ```bash
 # Install with everything (all interfaces + all database drivers)
-pip install agentic-slayer[all]
+pip install semantic-slayer[all]
 
 # Or install with specific database drivers
-pip install agentic-slayer[postgres]     # PostgreSQL (psycopg2)
-pip install agentic-slayer[mysql]        # MySQL / MariaDB (pymysql)
-pip install agentic-slayer[clickhouse]   # ClickHouse (clickhouse-sqlalchemy)
+pip install semantic-slayer[postgres]     # PostgreSQL (psycopg2)
+pip install semantic-slayer[mysql]        # MySQL / MariaDB (pymysql)
+pip install semantic-slayer[clickhouse]   # ClickHouse (clickhouse-sqlalchemy)
 
 # Start the HTTP server
 slayer serve --models-dir ./my_models

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -48,9 +48,9 @@ These databases are verified by integration tests and runnable Docker examples. 
 
 | Type | Install Extra | Connection Driver | Example |
 |------|---------------|-------------------|---------|
-| `postgres` / `postgresql` | `pip install agentic-slayer[postgres]` | `postgresql://` | `postgresql://user:pass@localhost:5432/db` |
-| `mysql` / `mariadb` | `pip install agentic-slayer[mysql]` | `mysql+pymysql://` | `mysql+pymysql://user:pass@localhost:3306/db` |
-| `clickhouse` | `pip install agentic-slayer[clickhouse]` | `clickhouse+http://` | `clickhouse+http://user:pass@localhost:8123/db` |
+| `postgres` / `postgresql` | `pip install semantic-slayer[postgres]` | `postgresql://` | `postgresql://user:pass@localhost:5432/db` |
+| `mysql` / `mariadb` | `pip install semantic-slayer[mysql]` | `mysql+pymysql://` | `mysql+pymysql://user:pass@localhost:3306/db` |
+| `clickhouse` | `pip install semantic-slayer[clickhouse]` | `clickhouse+http://` | `clickhouse+http://user:pass@localhost:8123/db` |
 | `sqlite` | (built-in) | `sqlite:///` | `sqlite:///path/to/db.sqlite` |
 
 ### Additional support

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,22 +4,22 @@
 
 ```bash
 # Full install (all extras + all database drivers)
-pip install agentic-slayer[all]
+pip install semantic-slayer[all]
 
 # Base install (REST API + CLI included by default, no database drivers)
-pip install agentic-slayer
+pip install semantic-slayer
 
 # Optional extras
-pip install agentic-slayer[client]       # Python SDK (httpx + pandas)
-pip install agentic-slayer[mcp]          # MCP server
+pip install semantic-slayer[client]       # Python SDK (httpx + pandas)
+pip install semantic-slayer[mcp]          # MCP server
 
 # Database driver extras
-pip install agentic-slayer[postgres]     # PostgreSQL (psycopg2)
-pip install agentic-slayer[mysql]        # MySQL / MariaDB (pymysql)
-pip install agentic-slayer[clickhouse]   # ClickHouse (clickhouse-sqlalchemy)
+pip install semantic-slayer[postgres]     # PostgreSQL (psycopg2)
+pip install semantic-slayer[mysql]        # MySQL / MariaDB (pymysql)
+pip install semantic-slayer[clickhouse]   # ClickHouse (clickhouse-sqlalchemy)
 ```
 
-Extras can be combined: `pip install agentic-slayer[mcp,postgres]`
+Extras can be combined: `pip install semantic-slayer[mcp,postgres]`
 
 ## Connect a Database
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 A lightweight, open-source semantic layer by [MotleyAI](https://github.com/motleyai). Instead of writing raw SQL, agents describe what data they want — measures, dimensions, filters — and SLayer generates and executes the query.
 
-[GitHub](https://github.com/MotleyAI/slayer) · [PyPI](https://pypi.org/project/agentic-slayer/) · [Getting Started](getting-started.md)
+[GitHub](https://github.com/MotleyAI/slayer) · [PyPI](https://pypi.org/project/semantic-slayer/) · [Getting Started](getting-started.md)
 
 ## Key Features
 
@@ -16,7 +16,7 @@ A lightweight, open-source semantic layer by [MotleyAI](https://github.com/motle
 ## Quick Install
 
 ```bash
-pip install agentic-slayer[all]
+pip install semantic-slayer[all]
 ```
 
 ## How It Works

--- a/docs/interfaces/python-client.md
+++ b/docs/interfaces/python-client.md
@@ -5,7 +5,7 @@ The Python SDK supports both **remote mode** (connects to a running server) and 
 ## Installation
 
 ```bash
-pip install agentic-slayer[client]   # httpx + pandas
+pip install semantic-slayer[client]   # httpx + pandas
 ```
 
 ## Usage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: SLayer
 site_description: A lightweight semantic layer for AI agents
-site_url: https://agentic-slayer.readthedocs.io
+site_url: https://semantic-slayer.readthedocs.io
 repo_url: https://github.com/motleyai/slayer
 repo_name: motleyai/slayer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "agentic-slayer"
+name = "semantic-slayer"
 version = "0.1.0"
 description = "A lightweight, agent-first semantic layer for AI agents"
 authors = ["MotleyAI"]
@@ -21,7 +21,7 @@ classifiers = [
 
 [tool.poetry.urls]
 Repository = "https://github.com/MotleyAI/slayer"
-Documentation = "https://agentic-slayer.readthedocs.io/"
+Documentation = "https://semantic-slayer.readthedocs.io/"
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -36,7 +36,7 @@ class SlayerClient:
         try:
             import httpx
         except ImportError:
-            raise ImportError("Client requires httpx: pip install agentic-slayer[client]")
+            raise ImportError("Client requires httpx: pip install semantic-slayer[client]")
         with httpx.Client() as client:
             resp = client.request(method=method, url=f"{self.url}{path}", json=json)
             resp.raise_for_status()
@@ -53,7 +53,7 @@ class SlayerClient:
         try:
             import pandas as pd
         except ImportError:
-            raise ImportError("DataFrame support requires pandas: pip install agentic-slayer[client]")
+            raise ImportError("DataFrame support requires pandas: pip install semantic-slayer[client]")
         data = self.query(query=query)
         return pd.DataFrame(data)
 

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -126,7 +126,7 @@ def create_mcp_server(storage: StorageBackend):
     try:
         from mcp.server.fastmcp import FastMCP
     except ImportError:
-        raise ImportError("MCP support requires the 'mcp' extra: pip install agentic-slayer[mcp]")
+        raise ImportError("MCP support requires the 'mcp' extra: pip install semantic-slayer[mcp]")
 
     mcp = FastMCP(
         "SLayer",


### PR DESCRIPTION
## Summary
- Rename the PyPI package from `agentic-slayer` to `semantic-slayer` across all 9 files containing references
- Updates `pyproject.toml` package name and docs URL, badge URLs in README, all `pip install` commands in docs, `mkdocs.yml` site URL, and error message hints in Python source

## Test plan
- [x] `grep -r "agentic-slayer"` returns zero matches
- [x] `poetry install -E all` installs as `semantic-slayer`
- [x] All 279 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated all installation instructions, quickstart guides, and datasource documentation to reference the new package name `semantic-slayer`.
  * Updated documentation links and site URLs to point to the new package resources.

* **Chores**
  * Updated package metadata and error messages to reflect the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->