### PR TITLE
Add label and filter fields to Dimension/Measure

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -43,6 +43,7 @@ Dimensions are the columns you group by and filter on.
 |-------|------|----------|---------|-------------|
 | `name` | string | Yes | — | Unique dimension name |
 | `description` | string | No | — | Clarifies meaning for agents and users, especially for technical column names |
+| `label` | string | No | — | Human-readable display name (e.g., "Order Date"). Distinct from `name` (technical) and `description` (explanatory). Propagated to query results and MCP summaries. |
 | `sql` | string | No | — | SQL expression |
 | `type` | string | No | `string` | Data type |
 | `primary_key` | bool | No | `false` | Is this a primary key? |
@@ -66,9 +67,47 @@ Measures are named row-level SQL expressions. They define *what* to compute, not
 |-------|------|----------|---------|-------------|
 | `name` | string | Yes | — | Unique measure name |
 | `description` | string | No | — | Explains what this measure computes, shown in datasource_summary and inspect_model |
+| `label` | string | No | — | Human-readable display name (e.g., "Total Revenue"). Propagated to query results and MCP summaries. |
 | `sql` | string | Yes | — | SQL expression (bare column name or expression) |
 | `allowed_aggregations` | list[str] | No | — | Whitelist of allowed aggregation types (validated at model creation and query time) |
+| `filter` | string | No | — | SQL condition applied before aggregation. See [Filtered Measures](#filtered-measures) below. |
 | `hidden` | bool | No | `false` | Hide from listings |
+
+### Filtered Measures
+
+A measure can have a `filter` — a SQL condition that restricts which rows are included when aggregating. This is useful for defining business metrics that apply to a subset of data:
+
+```yaml
+measures:
+  - name: active_revenue
+    sql: amount
+    filter: "status = 'active'"
+  - name: completed_count
+    sql: id
+    filter: "status = 'completed'"
+```
+
+When queried, the filter is applied via `CASE WHEN` inside the aggregation:
+- `active_revenue:sum` generates `SUM(CASE WHEN status = 'active' THEN amount END)`
+- `completed_count:count` generates `COUNT(CASE WHEN status = 'completed' THEN id END)`
+
+Filters can reference dimensions from joined models using dot syntax:
+
+```yaml
+joins:
+  - target_model: categories
+    join_pairs: [["category_id", "id"]]
+measures:
+  - name: electronics_revenue
+    sql: amount
+    filter: "categories.type = 'electronics'"
+```
+
+Multiple filtered and unfiltered measures can coexist in the same query. Filtered measures can be combined in arithmetic formulas:
+
+```json
+{"formula": "active_revenue:sum / total_revenue:sum", "name": "active_share"}
+```
 
 ### Built-in Aggregations
 

--- a/slayer/core/formula.py
+++ b/slayer/core/formula.py
@@ -504,9 +504,7 @@ def _filter_node_to_sql(node: ast.AST, original: str, columns: list[str]) -> str
         if node.value is None:
             return "NULL"
         if isinstance(node.value, str):
-            # Escape single quotes
-            escaped = node.value.replace("'", "''")
-            return f"'{escaped}'"
+            return _escape_sql_string(node.value)
         return str(node.value)
 
     # Negative number
@@ -576,10 +574,36 @@ def _compare_op_to_sql(op: ast.AST, comparator: ast.AST) -> str:
     raise ValueError(f"Unsupported comparison operator: {type(op).__name__}")
 
 
+def _escape_sql_string(value: str) -> str:
+    """Render a Python string as a safely-quoted SQL string literal.
+
+    Escapes both ``\\`` and ``'`` so the emitted literal is safe under every
+    supported dialect — including MySQL and ClickHouse, whose default string
+    parsing treats backslash as an escape character (so an unescaped trailing
+    ``\\`` would break out of the quoted literal). Backslashes are escaped
+    **before** single quotes so the newly-inserted ``''`` pair isn't itself
+    re-escaped into ``\\''``.
+
+    Note: for strict-ANSI dialects (Postgres with ``standard_conforming_strings``
+    on, SQLite, DuckDB) a literal backslash in the input is now rendered as
+    ``\\\\`` in the SQL, which those dialects treat as two backslashes. Since
+    measure filters almost never contain backslashes this trade-off is
+    preferred over a dialect-specific emission that could silently mis-escape
+    on MySQL.
+    """
+    escaped = value.replace("\\", "\\\\").replace("'", "''")
+    return f"'{escaped}'"
+
+
 def _get_string_arg(node: ast.AST, original: str) -> str:
-    """Extract a string value from an AST node (for LIKE patterns)."""
+    """Extract a string value from an AST node (for LIKE patterns).
+
+    Returns the content with single quotes doubled and backslashes escaped,
+    ready for interpolation between ``'...'`` in the emitted SQL. See
+    :func:`_escape_sql_string` for rationale.
+    """
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
-        return node.value.replace("'", "''")
+        return node.value.replace("\\", "\\\\").replace("'", "''")
     raise ValueError(f"Expected a string argument in filter: {original!r}")
 
 

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -92,6 +92,7 @@ class Dimension(BaseModel):
     type: DataType = DataType.STRING
     primary_key: bool = False
     description: Optional[str] = None
+    label: Optional[str] = None
     hidden: bool = False
     format: Optional[NumberFormat] = None
 
@@ -141,8 +142,10 @@ class Measure(BaseModel):
     name: str
     sql: Optional[str] = None
     description: Optional[str] = None
+    label: Optional[str] = None
     hidden: bool = False
     allowed_aggregations: Optional[List[str]] = None
+    filter: Optional[str] = None
     format: Optional[NumberFormat] = None
 
     @field_validator("name")
@@ -155,6 +158,13 @@ class Measure(BaseModel):
     def _fix_multidot_sql(cls, v: Optional[str]) -> Optional[str]:
         if v is not None:
             v = _fix_multidot_sql(v, context="Measure sql")
+        return v
+
+    @field_validator("filter")
+    @classmethod
+    def _fix_multidot_filter(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None:
+            v = _fix_multidot_sql(v, context="Measure filter")
         return v
 
 

--- a/slayer/engine/enriched.py
+++ b/slayer/engine/enriched.py
@@ -55,6 +55,7 @@ class EnrichedMeasure:
     label: Optional[str] = None  # Human-readable label
     time_column: Optional[str] = None  # Explicit time col for first/last (overrides query default)
     source_measure_name: Optional[str] = None  # Original measure name before canonicalization
+    filter_sql: Optional[str] = None  # Resolved SQL condition for filtered measures (CASE WHEN)
 
 
 @dataclass

--- a/slayer/engine/enrichment.py
+++ b/slayer/engine/enrichment.py
@@ -136,6 +136,7 @@ def enrich_query(
             return
 
         # Resolve measure SQL
+        measure_def = None
         if measure_name == "*":
             if aggregation_name != "count":
                 raise ValueError(
@@ -169,6 +170,19 @@ def enrich_query(
             if "." not in explicit_time_col:
                 explicit_time_col = f"{model.name}.{explicit_time_col}"
 
+        # Resolve measure-level filter
+        filter_sql = None
+        if measure_def and measure_def.filter:
+            parsed = parse_filter(measure_def.filter)
+            resolved = resolve_filter_columns(
+                parsed_filters=[parsed],
+                model=model,
+                model_name=model.name,
+                resolve_join_target=resolve_join_target,
+                named_queries=named_queries,
+            )
+            filter_sql = resolved[0].sql
+
         measures.append(
             EnrichedMeasure(
                 name=canonical_name,
@@ -178,8 +192,10 @@ def enrich_query(
                 model_name=model.name,
                 aggregation_def=aggregation_def,
                 agg_kwargs=agg_kwargs,
+                label=measure_def.label if measure_def else None,
                 time_column=explicit_time_col,
                 source_measure_name=measure_name,
+                filter_sql=filter_sql,
             )
         )
         known_aliases[alias_key] = alias
@@ -509,7 +525,7 @@ def _resolve_dimensions(
                 type=dim_def.type if dim_def else DataType.STRING,
                 alias=f"{model_name_str}.{dim_ref.full_name}",
                 model_name=effective_model,
-                label=dim_ref.label,
+                label=dim_ref.label or (dim_def.label if dim_def else None),
                 format=dim_def.format if dim_def else None,
             )
         )
@@ -640,6 +656,11 @@ def _resolve_joins(
                 parts = col.split(".")
                 for part in parts[:-1]:
                     needed_tables.add(part)
+    # Scan measure filters for dotted column references
+    for m in measures:
+        if m.filter_sql and "." in m.filter_sql:
+            for match in _TABLE_COL_RE.finditer(m.filter_sql):
+                needed_tables.update(match.group(1).split("__"))
 
     # BFS transitive expansion
     expanded = set(needed_tables)

--- a/slayer/engine/enrichment.py
+++ b/slayer/engine/enrichment.py
@@ -560,7 +560,7 @@ def _resolve_time_dimensions(
                 date_range=td.date_range,
                 alias=f"{model_name_str}.{td.dimension.full_name}",
                 model_name=td_model_name,
-                label=td.label,
+                label=td.label or (dim_def.label if dim_def else None),
             )
         )
     return time_dimensions

--- a/slayer/engine/query_engine.py
+++ b/slayer/engine/query_engine.py
@@ -426,8 +426,10 @@ class SlayerQueryEngine:
         # has clean column names that work naturally in JOINs and references.
         virtual_name = override_name or inner_query.name or f"_subquery_{inner_model.name}"
 
-        # Build lookup for labels/descriptions from the source model
+        # Build lookups for labels/descriptions from the source model
+        source_dim_label = {d.name: d.label for d in inner_model.dimensions if d.label}
         source_dim_desc = {d.name: d.description for d in inner_model.dimensions if d.description}
+        source_measure_label = {m.name: m.label for m in inner_model.measures if m.label}
         source_measure_desc = {m.name: m.description for m in inner_model.measures if m.description}
 
         # Collect all inner aliases and their short names.
@@ -449,49 +451,54 @@ class SlayerQueryEngine:
             # Replace remaining dots with __ to encode the original join path
             return stripped.replace(".", "__")
 
-        column_map = []  # (inner_alias, short_name, data_type, is_measure, label, format)
+        # (inner_alias, short_name, data_type, is_measure, label, description, format)
+        column_map = []
         for d in enriched.dimensions:
             short = _alias_to_short(d.alias)
-            label = d.label or source_dim_desc.get(d.name)
-            column_map.append((d.alias, short, d.type, False, label, d.format))
+            label = d.label or source_dim_label.get(d.name)
+            desc = source_dim_desc.get(d.name)
+            column_map.append((d.alias, short, d.type, False, label, desc, d.format))
         for td in enriched.time_dimensions:
             short = _alias_to_short(td.alias)
-            label = td.label or source_dim_desc.get(td.name)
-            column_map.append((td.alias, short, DataType.TIMESTAMP, False, label, None))
+            label = td.label or source_dim_label.get(td.name)
+            desc = source_dim_desc.get(td.name)
+            column_map.append((td.alias, short, DataType.TIMESTAMP, False, label, desc, None))
         for m in enriched.measures:
-            label = m.label or source_measure_desc.get(m.name)
+            src_name = m.source_measure_name or m.name
+            label = m.label or source_measure_label.get(src_name)
+            desc = source_measure_desc.get(src_name)
             fmt = _infer_aggregated_format(
                 model=inner_model,
-                measure_name=m.source_measure_name or m.name,
+                measure_name=src_name,
                 aggregation=m.aggregation,
             )
-            column_map.append((m.alias, m.name, DataType.NUMBER, True, label, fmt))
+            column_map.append((m.alias, m.name, DataType.NUMBER, True, label, desc, fmt))
         for t in enriched.transforms:
             column_map.append(
-                (t.alias, t.name, DataType.NUMBER, True, t.label, NumberFormat(type=NumberFormatType.FLOAT))
+                (t.alias, t.name, DataType.NUMBER, True, t.label, None, NumberFormat(type=NumberFormatType.FLOAT))
             )
         for e in enriched.expressions:
             column_map.append(
-                (e.alias, e.name, DataType.NUMBER, True, e.label, NumberFormat(type=NumberFormatType.FLOAT))
+                (e.alias, e.name, DataType.NUMBER, True, e.label, None, NumberFormat(type=NumberFormatType.FLOAT))
             )
         for cm in enriched.cross_model_measures:
             short = _alias_to_short(cm.alias)
-            column_map.append((cm.alias, short, DataType.NUMBER, True, cm.label, cm.format))
+            column_map.append((cm.alias, short, DataType.NUMBER, True, cm.label, None, cm.format))
 
         # Wrap inner SQL: SELECT "orders.id" AS id, "orders.count" AS count, ... FROM (inner) AS _inner
-        rename_parts = [f'"{alias}" AS {short}' for alias, short, _, _, _, _ in column_map]
+        rename_parts = [f'"{alias}" AS {short}' for alias, short, _, _, _, _, _ in column_map]
         wrapped_sql = f"SELECT {', '.join(rename_parts)} FROM ({inner_sql}) AS _inner"
 
         dims = []
-        for alias, short, dtype, is_measure, label, fmt in column_map:
-            dims.append(Dimension(name=short, sql=short, type=dtype, description=label, format=fmt))
+        for _, short, dtype, _, label, desc, fmt in column_map:
+            dims.append(Dimension(name=short, sql=short, type=dtype, label=label, description=desc, format=fmt))
 
         # One measure per column. Aggregation is specified at query time
         # using colon syntax (e.g., "order_total_sum:avg"). *:count is always
         # available for COUNT(*) without a measure definition.
         measures = []
-        for alias, short, dtype, is_measure, label, fmt in column_map:
-            measures.append(Measure(name=short, sql=short, format=fmt))
+        for _, short, _, _, label, desc, fmt in column_map:
+            measures.append(Measure(name=short, sql=short, label=label, description=desc, format=fmt))
 
         return SlayerModel(
             name=virtual_name,

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -77,15 +77,35 @@ def _friendly_db_error(exc: Exception) -> str:
 
 def _model_to_summary(model: SlayerModel) -> dict:
     """Convert a SlayerModel to a summary dict."""
+    dims = []
+    for d in model.dimensions:
+        if d.hidden:
+            continue
+        entry = {"name": d.name, "type": str(d.type)}
+        if d.label:
+            entry["label"] = d.label
+        if d.description:
+            entry["description"] = d.description
+        dims.append(entry)
+
+    measures = []
+    for m in model.measures:
+        if m.hidden:
+            continue
+        entry: dict = {"name": m.name}
+        if m.label:
+            entry["label"] = m.label
+        if m.description:
+            entry["description"] = m.description
+        if m.filter:
+            entry["filter"] = m.filter
+        measures.append(entry)
+
     return {
         "name": model.name,
         "description": model.description,
-        "dimensions": [
-            {"name": d.name, "type": str(d.type), "description": d.description}
-            for d in model.dimensions
-            if not d.hidden
-        ],
-        "measures": [{"name": m.name, "description": m.description} for m in model.measures if not m.hidden],
+        "dimensions": dims,
+        "measures": measures,
     }
 
 

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -227,8 +227,9 @@ class SQLGenerator:
         # to mark the latest (or earliest) row per group.
         has_first_or_last = any(m.aggregation in ("first", "last") for m in enriched.measures)
         rn_suffix_map: dict[str, str] = {}
+        filtered_rn_map: dict[str, str] = {}
         if has_first_or_last and enriched.last_agg_time_column:
-            from_clause, rn_suffix_map = self._build_last_ranked_from(
+            from_clause, rn_suffix_map, filtered_rn_map = self._build_last_ranked_from(
                 enriched=enriched, base_from=from_clause, time_offset=time_offset,
             )
 
@@ -265,6 +266,7 @@ class SQLGenerator:
                 measure=measure,
                 rn_suffix_map=rn_suffix_map,
                 default_time_col=enriched.last_agg_time_column,
+                filtered_rn_map=filtered_rn_map,
             )
             select_columns.append(agg_expr.as_(measure.alias))
             if is_agg:
@@ -273,6 +275,7 @@ class SQLGenerator:
         where_clause, having_clause = self._build_where_and_having(
             enriched=enriched,
             rn_suffix_map=rn_suffix_map,
+            filtered_rn_map=filtered_rn_map,
         )
 
         select = exp.Select()
@@ -859,13 +862,15 @@ class SQLGenerator:
         enriched: EnrichedQuery,
         base_from: exp.Expression,
         time_offset: Optional[tuple[int, str]] = None,
-    ) -> tuple[exp.Expression, dict[str, str]]:
+    ) -> tuple[exp.Expression, dict[str, str], dict[str, str]]:
         """Build a ranked subquery for first/last aggregation.
 
         Wraps the source table in a subquery that adds ROW_NUMBER columns
         for each distinct time column used by first/last measures.
-        Returns (subquery, rn_suffix_map) where rn_suffix_map maps each
-        effective time column to its ROW_NUMBER alias suffix.
+        Returns (subquery, rn_suffix_map, filtered_rn_map) where rn_suffix_map
+        maps each effective time column to its ROW_NUMBER alias suffix,
+        and filtered_rn_map maps "measure_name:agg" to a dedicated ROW_NUMBER
+        alias for filtered first/last measures.
         """
         model = enriched.model_name
         default_time_col = enriched.last_agg_time_column
@@ -930,6 +935,34 @@ class SQLGenerator:
             if "first" in agg_types:
                 parts.append(f"ROW_NUMBER() OVER ({partition_clause} ORDER BY {order_sql} ASC) AS _first_rn{suffix}")
 
+        # Generate dedicated ROW_NUMBER columns for filtered first/last measures.
+        # These push non-matching rows to the bottom of the ranking so that
+        # rn=1 picks the first matching row, not the globally first row.
+        filtered_rn_map: dict[str, str] = {}
+        filter_idx = 0
+        seen_filters: dict[tuple[str, str, str], str] = {}  # (filter_sql, tc, agg) -> alias
+        for m in enriched.measures:
+            if m.aggregation in ("first", "last") and m.filter_sql:
+                effective_tc = m.time_column or default_time_col
+                tc_expr = self._resolve_sql(sql=effective_tc, name=effective_tc, model_name=model)
+                order_sql = tc_expr.sql(dialect=self.dialect)
+                cache_key = (m.filter_sql, effective_tc, m.aggregation)
+                if cache_key in seen_filters:
+                    # Reuse existing column for identical filter+time_col+agg
+                    alias = seen_filters[cache_key]
+                else:
+                    alias = f"_{'first' if m.aggregation == 'first' else 'last'}_rn_f{filter_idx}"
+                    order_dir = "ASC" if m.aggregation == "first" else "DESC"
+                    parts.append(
+                        f"ROW_NUMBER() OVER ({partition_clause} ORDER BY "
+                        f"CASE WHEN {m.filter_sql} THEN 0 ELSE 1 END, "
+                        f"{order_sql} {order_dir}) AS {alias}"
+                    )
+                    seen_filters[cache_key] = alias
+                    filter_idx += 1
+                measure_key = f"{m.source_measure_name or m.name}:{m.aggregation}"
+                filtered_rn_map[measure_key] = alias
+
         select_sql = ", ".join(parts)
         from_sql = base_from.sql(dialect=self.dialect)
         ranked_sql = f"SELECT {select_sql} FROM {from_sql}"
@@ -940,7 +973,7 @@ class SQLGenerator:
             ranked_sql += f" WHERE {where_clause.sql(dialect=self.dialect)}"
 
         parsed = sqlglot.parse_one(ranked_sql, dialect=self.dialect)
-        return exp.Subquery(this=parsed, alias=exp.to_identifier(model)), rn_suffix_map
+        return exp.Subquery(this=parsed, alias=exp.to_identifier(model)), rn_suffix_map, filtered_rn_map
 
     # ------------------------------------------------------------------
     # Column / measure resolution (from enriched SQL expressions)
@@ -960,6 +993,7 @@ class SQLGenerator:
         measure: EnrichedMeasure,
         rn_suffix_map: Optional[dict[str, str]] = None,
         default_time_col: Optional[str] = None,
+        filtered_rn_map: Optional[dict[str, str]] = None,
     ) -> tuple[exp.Expression, bool]:
         """Build an aggregation expression from an enriched measure."""
         agg_name = measure.aggregation
@@ -980,10 +1014,13 @@ class SQLGenerator:
                 effective_tc = measure.time_column or default_time_col
                 suffix = rn_suffix_map.get(effective_tc, "")
             rn_col = f"_first_rn{suffix}" if agg_name == "first" else f"_last_rn{suffix}"
-            # For filtered first/last, add the filter condition
-            if measure.filter_sql:
+            # For filtered first/last, use the dedicated ROW_NUMBER column
+            # that pushes non-matching rows to the bottom of the ranking
+            if measure.filter_sql and filtered_rn_map:
+                measure_key = f"{measure.source_measure_name or measure.name}:{agg_name}"
+                filtered_rn = filtered_rn_map.get(measure_key, rn_col)
                 case_sql = (
-                    f"MAX(CASE WHEN {rn_col} = 1 AND {measure.filter_sql} "
+                    f"MAX(CASE WHEN {filtered_rn} = 1 AND {measure.filter_sql} "
                     f"THEN {measure.model_name}.{col} END)"
                 )
             else:
@@ -1100,6 +1137,7 @@ class SQLGenerator:
         self,
         enriched: EnrichedQuery,
         rn_suffix_map: Optional[dict[str, str]] = None,
+        filtered_rn_map: Optional[dict[str, str]] = None,
     ) -> tuple[Optional[exp.Expression], Optional[exp.Expression]]:
         """Build WHERE and HAVING clauses from parsed filters.
 
@@ -1136,6 +1174,7 @@ class SQLGenerator:
                                 measure=m,
                                 rn_suffix_map=rn_suffix_map,
                                 default_time_col=enriched.last_agg_time_column,
+                                filtered_rn_map=filtered_rn_map,
                             )
                             agg_sql = agg_expr.sql(dialect=self.dialect)
                             having_sql = re.sub(

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -980,7 +980,14 @@ class SQLGenerator:
                 effective_tc = measure.time_column or default_time_col
                 suffix = rn_suffix_map.get(effective_tc, "")
             rn_col = f"_first_rn{suffix}" if agg_name == "first" else f"_last_rn{suffix}"
-            case_sql = f"MAX(CASE WHEN {rn_col} = 1 THEN {measure.model_name}.{col} END)"
+            # For filtered first/last, add the filter condition
+            if measure.filter_sql:
+                case_sql = (
+                    f"MAX(CASE WHEN {rn_col} = 1 AND {measure.filter_sql} "
+                    f"THEN {measure.model_name}.{col} END)"
+                )
+            else:
+                case_sql = f"MAX(CASE WHEN {rn_col} = 1 THEN {measure.model_name}.{col} END)"
             return sqlglot.parse_one(case_sql, dialect=self.dialect), True
 
         # --- Custom or parameterized aggregation (formula-based) ---
@@ -989,7 +996,12 @@ class SQLGenerator:
 
         # --- Resolve inner expression ---
         if agg_name == "count" and measure.sql is None:
-            inner = exp.Star()
+            # COUNT(*) — if filtered, use COUNT(CASE WHEN filter THEN 1 END)
+            if measure.filter_sql:
+                case_sql = f"CASE WHEN {measure.filter_sql} THEN 1 END"
+                inner = sqlglot.parse_one(case_sql, dialect=self.dialect)
+            else:
+                inner = exp.Star()
         elif measure.sql:
             inner = self._resolve_sql(sql=measure.sql, name=measure.name, model_name=measure.model_name)
         else:
@@ -997,6 +1009,12 @@ class SQLGenerator:
                 this=exp.to_identifier(measure.name),
                 table=exp.to_identifier(measure.model_name),
             )
+
+        # --- Apply measure-level filter as CASE WHEN wrapper ---
+        if measure.filter_sql and not (agg_name == "count" and measure.sql is None):
+            inner_sql = inner.sql(dialect=self.dialect)
+            case_sql = f"CASE WHEN {measure.filter_sql} THEN {inner_sql} END"
+            inner = sqlglot.parse_one(case_sql, dialect=self.dialect)
 
         # --- count_distinct ---
         if agg_name == "count_distinct":
@@ -1055,6 +1073,8 @@ class SQLGenerator:
 
         # Resolve {value} and {param_name} in formula
         col_expr = measure.sql or measure.name
+        if measure.filter_sql:
+            col_expr = f"CASE WHEN {measure.filter_sql} THEN {col_expr} END"
         substituted = formula.replace("{value}", col_expr)
         for param_name, param_val in params.items():
             substituted = substituted.replace(f"{{{param_name}}}", param_val)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1538,8 +1538,8 @@ def test_filtered_measure_sum(integration_env):
     row = result.data[0]
     total = row["orders.total_amount_sum"]
     completed = row["orders.completed_revenue_sum"]
-    assert completed <= total
-    assert completed > 0
+    assert total == pytest.approx(750.0)
+    assert completed == pytest.approx(600.0)
 
 
 def test_filtered_measure_count(integration_env):
@@ -1563,8 +1563,8 @@ def test_filtered_measure_count(integration_env):
     row = result.data[0]
     total = row["orders._count"]
     completed = row["orders.completed_count_count"]
-    assert completed <= total
-    assert completed > 0
+    assert total == 6
+    assert completed == 3
 
 
 def test_filtered_measure_with_dimensions(integration_env):
@@ -1591,6 +1591,81 @@ def test_filtered_measure_with_dimensions(integration_env):
         else:
             # Non-completed rows: the CASE WHEN produces NULL, SUM of NULLs is NULL
             assert row["orders.completed_revenue_sum"] is None
+
+
+def test_filtered_last_picks_correct_row(integration_env):
+    """Filtered last measure picks the latest row that matches the filter,
+    not the globally latest row.
+
+    Fixture: orders (1..6), Order 6 (pending, Mar-20) is globally latest,
+    Order 5 (completed, 300.0, Mar-5) is the latest completed.
+    """
+    engine = integration_env
+    storage = engine.storage
+
+    orders = storage.get_model("orders")
+    orders.measures.append(
+        Measure(name="completed_latest", sql="amount", filter="status = 'completed'")
+    )
+    storage.save_model(orders)
+
+    # Query with monthly granularity so we get per-month last values
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        time_dimensions=[
+            TimeDimension(
+                dimension=ColumnRef(name="created_at"),
+                granularity=TimeGranularity.MONTH,
+            ),
+        ],
+        fields=[
+            Field(formula="completed_latest:last"),
+            Field(formula="latest_amount:last"),
+        ],
+    ))
+    rows_by_month = {row["orders.created_at"]: row for row in result.data}
+    # March: globally latest is Order 6 (pending, 25.0), but the latest
+    # completed is Order 5 (completed, 300.0). The filter must participate
+    # in ranking so the correct row is picked.
+    mar = rows_by_month["2025-03-01"]
+    assert mar["orders.completed_latest_last"] == pytest.approx(300.0)
+    assert mar["orders.latest_amount_last"] == pytest.approx(25.0)  # unfiltered picks Order 6
+
+    # January: latest is Order 2 (completed, 200.0) — passes filter
+    jan = rows_by_month["2025-01-01"]
+    assert jan["orders.completed_latest_last"] == pytest.approx(200.0)
+
+    # February: no completed orders — should be NULL
+    feb = rows_by_month["2025-02-01"]
+    assert feb["orders.completed_latest_last"] is None
+
+
+def test_time_dimension_label_fallback(integration_env):
+    """Time dimension inherits label from model dimension definition."""
+    engine = integration_env
+    storage = engine.storage
+
+    orders = storage.get_model("orders")
+    for d in orders.dimensions:
+        if d.name == "created_at":
+            d.label = "Order Date"
+    storage.save_model(orders)
+
+    # Query with time dimension but no explicit label on TimeDimension
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        time_dimensions=[
+            TimeDimension(
+                dimension=ColumnRef(name="created_at"),
+                granularity=TimeGranularity.MONTH,
+            ),
+        ],
+        fields=[Field(formula="total_amount:sum")],
+    ))
+    # The model-level label should propagate through
+    td_meta = result.meta.get("orders.created_at")
+    assert td_meta is not None
+    assert td_meta.label == "Order Date"
 
 
 def test_label_propagation_enrichment(integration_env):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1508,3 +1508,115 @@ def test_diamond_joins_single_path(diamond_env):
     by_region = {r["shipments.customers.regions.name"]: r["shipments._count"] for r in result.data}
     assert by_region["US"] == 2  # Alice: 2 shipments
     assert by_region["EU"] == 2  # Bob: 2 shipments
+
+
+# ---------------------------------------------------------------------------
+# Filtered measures
+# ---------------------------------------------------------------------------
+
+
+def test_filtered_measure_sum(integration_env):
+    """Measure with filter produces CASE WHEN — only matching rows aggregated."""
+    engine = integration_env
+    storage = engine.storage
+
+    # Add a filtered measure: only sum completed orders' amounts
+    orders = storage.get_model("orders")
+    orders.measures.append(
+        Measure(name="completed_revenue", sql="amount", filter="status = 'completed'")
+    )
+    storage.save_model(orders)
+
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        fields=[
+            Field(formula="total_amount:sum"),
+            Field(formula="completed_revenue:sum"),
+        ],
+    ))
+    assert result.row_count == 1
+    row = result.data[0]
+    total = row["orders.total_amount_sum"]
+    completed = row["orders.completed_revenue_sum"]
+    assert completed <= total
+    assert completed > 0
+
+
+def test_filtered_measure_count(integration_env):
+    """Filtered count measure counts only matching rows."""
+    engine = integration_env
+    storage = engine.storage
+
+    orders = storage.get_model("orders")
+    orders.measures.append(
+        Measure(name="completed_count", sql="id", filter="status = 'completed'")
+    )
+    storage.save_model(orders)
+
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        fields=[
+            Field(formula="*:count"),
+            Field(formula="completed_count:count"),
+        ],
+    ))
+    row = result.data[0]
+    total = row["orders._count"]
+    completed = row["orders.completed_count_count"]
+    assert completed <= total
+    assert completed > 0
+
+
+def test_filtered_measure_with_dimensions(integration_env):
+    """Filtered measure works with GROUP BY dimensions."""
+    engine = integration_env
+    storage = engine.storage
+
+    orders = storage.get_model("orders")
+    orders.measures.append(
+        Measure(name="completed_revenue", sql="amount", filter="status = 'completed'")
+    )
+    storage.save_model(orders)
+
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        fields=[Field(formula="completed_revenue:sum")],
+        dimensions=[ColumnRef(name="status")],
+    ))
+    # Completed status row should have a value; others should be NULL
+    for row in result.data:
+        if row["orders.status"] == "completed":
+            assert row["orders.completed_revenue_sum"] is not None
+            assert row["orders.completed_revenue_sum"] > 0
+        else:
+            # Non-completed rows: the CASE WHEN produces NULL, SUM of NULLs is NULL
+            assert row["orders.completed_revenue_sum"] is None
+
+
+def test_label_propagation_enrichment(integration_env):
+    """Model-level labels propagate through enrichment to query results."""
+    engine = integration_env
+    storage = engine.storage
+
+    orders = storage.get_model("orders")
+    # Add labels to a dimension and measure
+    for d in orders.dimensions:
+        if d.name == "status":
+            d.label = "Order Status"
+    orders.measures.append(
+        Measure(name="labeled_rev", sql="amount", label="Total Revenue")
+    )
+    storage.save_model(orders)
+
+    result = engine.execute(query=SlayerQuery(
+        source_model="orders",
+        fields=[Field(formula="labeled_rev:sum")],
+        dimensions=[ColumnRef(name="status")],
+    ))
+    # Labels should appear in result meta
+    status_meta = result.meta.get("orders.status")
+    assert status_meta is not None
+    assert status_meta.label == "Order Status"
+    rev_meta = result.meta.get("orders.labeled_rev_sum")
+    assert rev_meta is not None
+    assert rev_meta.label == "Total Revenue"

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -6,6 +6,7 @@ from slayer.core.formula import (
     AggregatedMeasureRef,
     ArithmeticField,
     TransformField,
+    parse_filter,
     parse_formula,
 )
 from slayer.engine.enrichment import extract_filter_transforms
@@ -160,3 +161,129 @@ class TestExtractFilterTransforms:
         )
         assert len(transforms) == 1
         assert "price:weighted_avg(col1, weight=quantity)" in transforms[0][1]
+
+
+class TestParseFilterInjection:
+    """SQL-injection hardening for ``parse_filter``.
+
+    ``parse_filter`` is the single choke-point for all user-supplied filter
+    expressions (measure-level ``filter``, model-level ``filters``, and
+    query-level filters). These tests assert each injection payload is either
+    rejected at parse time (``ValueError``) or neutralised — i.e. the payload
+    appears in the output SQL only as a properly-quoted string literal, never
+    as executable SQL tokens.
+    """
+
+    # --- Payloads rejected outright by ast.parse ---------------------------
+
+    def test_rejects_statement_terminator_dropout(self) -> None:
+        """Classic "break out of string, run DROP, comment rest" payload.
+
+        Trailing ``--`` terminates with a single-quoted ``D`` followed by an
+        unclosed apostrophe, which cannot parse as a Python expression.
+        """
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            parse_filter("status = 'a'; DROP TABLE orders; --'")
+
+    def test_rejects_block_comment(self) -> None:
+        """SQL block-comment tokens must not survive — ``/`` without a RHS
+        operand yields a Python SyntaxError."""
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            parse_filter("status = 'a' /* foo */ OR 1=1")
+
+    def test_rejects_union_select(self) -> None:
+        """Stacked UNION SELECT payload — ``SELECT`` is not a Python operand."""
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            parse_filter("status = 'a' UNION SELECT * FROM users --'")
+
+    def test_rejects_stacked_semicolon(self) -> None:
+        """A bare semicolon separates Python statements; ``eval`` mode rejects."""
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            parse_filter("status = 'a'; SELECT 1")
+
+    def test_rejects_unknown_function_call(self) -> None:
+        """Only the internal ``__like__`` / ``__notlike__`` helpers are allowed."""
+        with pytest.raises(ValueError, match="Unknown filter function"):
+            parse_filter("pg_sleep(10)")
+
+    # --- Payloads that are legitimate expressions ---------------------------
+
+    def test_allows_tautology_with_literal(self) -> None:
+        """``1 = 1`` is a legal, user-authored tautology — not injection per se.
+
+        A measure filter written by the model author is by design trusted to
+        express arbitrary boolean logic; this test pins the intended semantics
+        so we don't accidentally over-restrict the grammar.
+        """
+        result = parse_filter("status = 'a' or 1 = 1")
+        assert "OR" in result.sql
+        assert "1 = 1" in result.sql
+
+    # --- Payloads that must be neutralised in the emitted SQL --------------
+
+    def test_embedded_quote_is_doubled(self) -> None:
+        """Single quote inside a string literal must emit as ``''`` (SQL standard)."""
+        # The runtime filter value here contains an embedded apostrophe.
+        result = parse_filter("name = 'O\\'Brien'")
+        # Emitted literal must have a doubled quote, never a bare ``'``.
+        assert "'O''Brien'" in result.sql
+
+    def test_backslash_in_string_literal_is_escaped(self) -> None:
+        """A backslash inside a string literal must not be able to escape the
+        closing quote in MySQL-family dialects.
+
+        Before the fix: ``parse_filter`` emits ``'a\\'`` (single backslash
+        inside single quotes). In MySQL default mode, ``\\'`` is a literal
+        apostrophe and the string remains open, letting trailing tokens be
+        read as string content. After the fix: the backslash is doubled so
+        the emitted literal is ``'a\\\\'`` (two backslashes = one literal
+        backslash in MySQL's escape-aware string parsing).
+        """
+        # Runtime filter string is:  name = 'a\'       (six chars)
+        # Python source:              "name = 'a\\\\'"  (escape both backslashes)
+        result = parse_filter("name = 'a\\\\'")
+        # The emitted SQL must not contain an unescaped trailing ``\'`` that
+        # MySQL would read as a literal quote.
+        assert "'a\\\\'" in result.sql, (
+            f"Expected backslash-escaped literal, got {result.sql!r}"
+        )
+
+    def test_backslash_mid_string_is_escaped(self) -> None:
+        """Backslash anywhere inside a string literal must be doubled so that
+        subsequent characters can't be (mis)interpreted as escape sequences.
+        """
+        # Runtime string:  name = 'a\b' and x = 1
+        result = parse_filter("name = 'a\\\\b' and x = 1")
+        assert "'a\\\\b'" in result.sql
+        # Sanity: the surrounding AND clause is preserved intact.
+        assert "x = 1" in result.sql
+
+    def test_backslash_in_like_pattern_is_escaped(self) -> None:
+        """The ``LIKE`` pattern path runs through ``_get_string_arg`` — make
+        sure it applies the same backslash protection as ``_filter_node_to_sql``.
+        """
+        # Runtime string:  name like 'a\'
+        result = parse_filter("name like 'a\\\\'")
+        assert "LIKE" in result.sql
+        assert "'a\\\\'" in result.sql
+
+    def test_identifier_cannot_inject_sql(self) -> None:
+        """Bare column names are constrained to valid Python identifiers.
+
+        A name containing a space / punctuation can't even reach the AST as
+        an ``ast.Name``, so there's no way to sneak ``DROP`` in via a name.
+        """
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            parse_filter("status; DROP TABLE users; --")
+
+    def test_deeply_nested_boolean_does_not_crash(self) -> None:
+        """A very deep boolean expression must either parse bounded or raise
+        cleanly — never crash the interpreter / exhaust the stack."""
+        payload = " or ".join(["x = 1"] * 200)
+        # Either accepted (returns SQL containing many ORs) or rejected with
+        # a normal ValueError; both are acceptable outcomes.
+        try:
+            result = parse_filter(payload)
+        except ValueError:
+            return
+        assert result.sql.count("OR") >= 100

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -430,3 +430,57 @@ class TestAggregationValidation:
     def test_custom_without_formula_raises(self) -> None:
         with pytest.raises(ValueError, match="not a built-in aggregation"):
             Aggregation(name="my_agg")
+
+
+class TestDimensionLabel:
+    def test_label_optional(self) -> None:
+        d = Dimension(name="status", sql="status")
+        assert d.label is None
+
+    def test_label_set(self) -> None:
+        d = Dimension(name="status", sql="status", label="Order Status")
+        assert d.label == "Order Status"
+
+    def test_label_in_model_dump(self) -> None:
+        d = Dimension(name="status", label="Order Status")
+        data = d.model_dump(exclude_none=True)
+        assert data["label"] == "Order Status"
+
+    def test_label_excluded_when_none(self) -> None:
+        d = Dimension(name="status")
+        data = d.model_dump(exclude_none=True)
+        assert "label" not in data
+
+
+class TestMeasureLabel:
+    def test_label_optional(self) -> None:
+        m = Measure(name="revenue", sql="amount")
+        assert m.label is None
+
+    def test_label_set(self) -> None:
+        m = Measure(name="revenue", sql="amount", label="Total Revenue")
+        assert m.label == "Total Revenue"
+
+
+class TestMeasureFilter:
+    def test_filter_optional(self) -> None:
+        m = Measure(name="revenue", sql="amount")
+        assert m.filter is None
+
+    def test_filter_set(self) -> None:
+        m = Measure(name="active_revenue", sql="amount", filter="status = 'active'")
+        assert m.filter == "status = 'active'"
+
+    def test_filter_multidot_autoconvert(self) -> None:
+        m = Measure(name="x", sql="amount", filter="a.b.c = 1")
+        assert "a__b.c" in m.filter
+
+    def test_filter_in_model_dump(self) -> None:
+        m = Measure(name="x", sql="amount", filter="status = 'active'")
+        data = m.model_dump(exclude_none=True)
+        assert data["filter"] == "status = 'active'"
+
+    def test_filter_excluded_when_none(self) -> None:
+        m = Measure(name="x", sql="amount")
+        data = m.model_dump(exclude_none=True)
+        assert "filter" not in data

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1302,3 +1302,89 @@ class TestFilteredMeasures:
         # Should have one CASE WHEN (for active_revenue) and one plain SUM (for revenue)
         assert sql.count("CASE WHEN") == 1
         assert sql.count("SUM(") == 2
+
+    def test_filtered_last_generates_dedicated_rn(
+        self, generator: SQLGenerator, orders_model: SlayerModel,
+    ) -> None:
+        """Filtered last measure generates a dedicated ROW_NUMBER with filter in ORDER BY."""
+        orders_model.default_time_dimension = "created_at"
+        orders_model.measures.append(
+            Measure(name="completed_balance", sql="amount", filter="status = 'completed'")
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            time_dimensions=[
+                TimeDimension(dimension=ColumnRef(name="created_at"), granularity=TimeGranularity.MONTH),
+            ],
+            fields=[Field(formula="completed_balance:last")],
+        )
+        sql = _generate(generator, query, orders_model)
+        # Should have a dedicated filtered ROW_NUMBER column
+        assert "_last_rn_f0" in sql
+        # The ORDER BY should include CASE WHEN filter THEN 0 ELSE 1 END
+        assert "CASE WHEN" in sql
+        assert "THEN 0 ELSE 1" in sql
+        # Standard ROW_NUMBER should NOT be present (no unfiltered first/last)
+        assert "_last_rn " not in sql or "_last_rn_f0" in sql
+
+    def test_filtered_first_generates_dedicated_rn(
+        self, generator: SQLGenerator, orders_model: SlayerModel,
+    ) -> None:
+        """Filtered first measure generates a dedicated ROW_NUMBER with filter in ORDER BY."""
+        orders_model.default_time_dimension = "created_at"
+        orders_model.measures.append(
+            Measure(name="completed_balance", sql="amount", filter="status = 'completed'")
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            time_dimensions=[
+                TimeDimension(dimension=ColumnRef(name="created_at"), granularity=TimeGranularity.MONTH),
+            ],
+            fields=[Field(formula="completed_balance:first")],
+        )
+        sql = _generate(generator, query, orders_model)
+        assert "_first_rn_f0" in sql
+        assert "ASC" in sql
+        assert "CASE WHEN" in sql
+        assert "THEN 0 ELSE 1" in sql
+
+    def test_unfiltered_last_unchanged(
+        self, generator: SQLGenerator, orders_model: SlayerModel,
+    ) -> None:
+        """Unfiltered last measure uses the shared ROW_NUMBER, no _rn_f columns."""
+        orders_model.default_time_dimension = "created_at"
+        orders_model.measures.append(Measure(name="balance", sql="amount"))
+        query = SlayerQuery(
+            source_model="orders",
+            time_dimensions=[
+                TimeDimension(dimension=ColumnRef(name="created_at"), granularity=TimeGranularity.MONTH),
+            ],
+            fields=[Field(formula="balance:last")],
+        )
+        sql = _generate(generator, query, orders_model)
+        assert "_last_rn" in sql
+        assert "_last_rn_f" not in sql
+
+    def test_mixed_filtered_and_unfiltered_last(
+        self, generator: SQLGenerator, orders_model: SlayerModel,
+    ) -> None:
+        """Both filtered and unfiltered last measures get separate ROW_NUMBER columns."""
+        orders_model.default_time_dimension = "created_at"
+        orders_model.measures.append(Measure(name="balance", sql="amount"))
+        orders_model.measures.append(
+            Measure(name="completed_balance", sql="amount", filter="status = 'completed'")
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            time_dimensions=[
+                TimeDimension(dimension=ColumnRef(name="created_at"), granularity=TimeGranularity.MONTH),
+            ],
+            fields=[
+                Field(formula="balance:last"),
+                Field(formula="completed_balance:last"),
+            ],
+        )
+        sql = _generate(generator, query, orders_model)
+        # Should have both the shared _last_rn and the filtered _last_rn_f0
+        assert "_last_rn" in sql
+        assert "_last_rn_f0" in sql

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1,6 +1,7 @@
 """Tests for the SQL generator."""
 
 import pytest
+import sqlglot
 
 from slayer.core.enums import DataType, TimeGranularity
 from slayer.core.models import Aggregation, AggregationParam, Dimension, Measure, ModelJoin, SlayerModel
@@ -1388,3 +1389,212 @@ class TestFilteredMeasures:
         # Should have both the shared _last_rn and the filtered _last_rn_f0
         assert "_last_rn" in sql
         assert "_last_rn_f0" in sql
+
+
+class TestMeasureFilterInjection:
+    """End-to-end SQL-injection hardening for the ``Measure.filter`` field.
+
+    The filter string is the only user-authored SQL fragment that gets
+    interpolated into the generated query (everything else goes through
+    sqlglot AST builders). These tests run the full enrichment + generation
+    pipeline for each payload and verify the resulting SQL is safe across
+    both standard-SQL and escape-sensitive dialects.
+
+    Any payload the parser rejects at the ``parse_filter`` stage raises a
+    ``ValueError`` — those cases assert the raise, not the output. Payloads
+    the parser accepts must produce SQL in which the payload appears only
+    inside a properly-closed string literal.
+    """
+
+    # ------------------------------------------------------------------
+    # Rejected at parse time
+    # ------------------------------------------------------------------
+
+    def test_drop_table_rejected(self, orders_model: SlayerModel) -> None:
+        """Classic ``'; DROP TABLE ...`` payload is rejected before generation."""
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                filter="status = 'a'; DROP TABLE orders; --'",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            _generate(SQLGenerator(dialect="postgres"), query, orders_model)
+
+    def test_union_select_rejected(self, orders_model: SlayerModel) -> None:
+        """UNION SELECT payload is rejected before generation."""
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                filter="status = 'a' UNION SELECT * FROM users --'",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            _generate(SQLGenerator(dialect="postgres"), query, orders_model)
+
+    def test_block_comment_rejected(self, orders_model: SlayerModel) -> None:
+        """``/* ... */`` comment injection is rejected before generation."""
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                filter="status = 'a' /* x */ OR 1=1",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        with pytest.raises(ValueError, match="Invalid filter syntax"):
+            _generate(SQLGenerator(dialect="postgres"), query, orders_model)
+
+    # ------------------------------------------------------------------
+    # Accepted and neutralised in emitted SQL — tested across dialects
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql", "sqlite", "duckdb"])
+    def test_embedded_single_quote_is_doubled(
+        self, orders_model: SlayerModel, dialect: str,
+    ) -> None:
+        """An apostrophe in the filter value must emit as ``''`` (SQL standard).
+
+        This holds for every dialect; none of them accept ``\\'`` as the
+        canonical escape for a literal apostrophe.
+        """
+        orders_model.measures.append(
+            Measure(
+                name="irish_names",
+                sql="amount",
+                # Runtime value of the literal:  O'Brien
+                filter="status = 'O\\'Brien'",
+            )
+        )
+        query = SlayerQuery(
+            source_model="orders", fields=[Field(formula="irish_names:sum")]
+        )
+        sql = _generate(SQLGenerator(dialect=dialect), query, orders_model)
+        # The emitted literal must use doubled single quotes.
+        assert "'O''Brien'" in sql
+
+    @staticmethod
+    def _assert_round_trips_cleanly(sql: str, dialect: str) -> None:
+        """Every emitted SQL string must tokenize + parse + round-trip in the
+        target dialect. If a hostile filter manages to open an unclosed string
+        literal, sqlglot's tokenizer raises ``TokenError`` — which is both the
+        canonical pre-fix failure mode and a downstream DoS / error-leakage
+        vector."""
+        parsed = sqlglot.parse_one(sql, dialect=dialect)
+        # Re-emitting must not raise either — guards against one-way tokenizer
+        # tolerance that wouldn't survive a round-trip through the planner.
+        _ = parsed.sql(dialect=dialect)
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql", "sqlite", "duckdb"])
+    def test_trailing_backslash_cannot_escape_closing_quote(
+        self, orders_model: SlayerModel, dialect: str,
+    ) -> None:
+        """A trailing backslash in a string literal must not break out of the
+        literal on escape-aware dialects (mysql, clickhouse, etc.).
+
+        Before the fix: ``parse_filter`` emits ``'a\\'`` (one literal
+        backslash inside single quotes). On MySQL that parses as "apostrophe
+        escaped by the backslash, string still open", letting trailing SQL
+        tokens be read as string content — triggering ``sqlglot.TokenError``
+        (DoS / error-leakage vector). After the fix: the backslash is doubled
+        in the emitted literal and sqlglot tokenizes without error.
+        """
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                # Runtime filter string:  status = 'a\'
+                filter="status = 'a\\\\'",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        sql = _generate(SQLGenerator(dialect=dialect), query, orders_model)
+        self._assert_round_trips_cleanly(sql, dialect)
+        # Defence-in-depth: the payload ``a`` + trailing slash must be
+        # confined to a single well-terminated literal. Check the literal
+        # decodes to the original ``a\`` content after the dialect's own
+        # unescaping — i.e. a single re-parse is idempotent.
+        reparsed = sqlglot.parse_one(sql, dialect=dialect)
+        rendered = reparsed.sql(dialect=dialect)
+        # Round-trip stability: no additional escape inflation on the second pass.
+        again = sqlglot.parse_one(rendered, dialect=dialect).sql(dialect=dialect)
+        assert rendered == again, (
+            f"SQL is not idempotent under re-parse on {dialect}: {rendered!r} vs {again!r}"
+        )
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql"])
+    def test_backslash_mid_string_is_neutralised(
+        self, orders_model: SlayerModel, dialect: str,
+    ) -> None:
+        """Backslashes mid-string also must not enable escape sequences."""
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                # Runtime filter string:  status = 'a\b'
+                filter="status = 'a\\\\b'",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        sql = _generate(SQLGenerator(dialect=dialect), query, orders_model)
+        self._assert_round_trips_cleanly(sql, dialect)
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql"])
+    def test_like_pattern_backslash_is_neutralised(
+        self, orders_model: SlayerModel, dialect: str,
+    ) -> None:
+        """The ``LIKE`` path in ``_filter_node_to_sql`` goes through a separate
+        helper (``_get_string_arg``); its backslash handling must match."""
+        orders_model.measures.append(
+            Measure(
+                name="evil",
+                sql="amount",
+                # Runtime filter string:  status like 'a\'
+                filter="status like 'a\\\\'",
+            )
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="evil:sum")])
+        sql = _generate(SQLGenerator(dialect=dialect), query, orders_model)
+        self._assert_round_trips_cleanly(sql, dialect)
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql"])
+    def test_adversarial_quote_break_cannot_inject(
+        self, orders_model: SlayerModel, dialect: str,
+    ) -> None:
+        """The full attack: backslash + quote + SQL payload must either be
+        rejected at parse time or confined to a string literal.
+
+        The intent of this payload is to break out of the string in MySQL,
+        then run arbitrary SQL. After the fix, this either raises at
+        ``parse_filter`` (most likely) or emits a safely-terminated literal.
+        """
+        evil = "status = 'a\\\\' OR 1=1 --"  # Runtime: status = 'a\' OR 1=1 --
+        try:
+            orders_model.measures.append(Measure(name="evil", sql="amount", filter=evil))
+            query = SlayerQuery(
+                source_model="orders", fields=[Field(formula="evil:sum")]
+            )
+            sql = _generate(SQLGenerator(dialect=dialect), query, orders_model)
+        except ValueError:
+            return  # parser rejected — also acceptable
+        self._assert_round_trips_cleanly(sql, dialect)
+
+    def test_existing_filter_still_works_after_escaping(
+        self, orders_model: SlayerModel,
+    ) -> None:
+        """Sanity: ordinary filters (no backslashes, no apostrophes) keep
+        producing the same SQL shape after the escape-hardening change."""
+        orders_model.measures.append(
+            Measure(name="active_revenue", sql="amount", filter="status = 'active'")
+        )
+        query = SlayerQuery(
+            source_model="orders", fields=[Field(formula="active_revenue:sum")]
+        )
+        sql = _generate(SQLGenerator(dialect="postgres"), query, orders_model)
+        assert "'active'" in sql
+        assert "CASE WHEN" in sql
+        assert "SUM(" in sql

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1245,3 +1245,60 @@ class TestAggParamSanitization:
         )
         with pytest.raises(ValueError, match="Unsafe value"):
             gen.generate(enriched=enriched)
+
+
+class TestFilteredMeasures:
+    """Tests for measure-level filter (CASE WHEN wrapping)."""
+
+    def test_filtered_sum(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:
+        orders_model.measures.append(
+            Measure(name="active_revenue", sql="amount", filter="status = 'active'")
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="active_revenue:sum")])
+        sql = _generate(generator, query, orders_model)
+        assert "CASE WHEN" in sql
+        assert "THEN" in sql
+        assert "SUM(" in sql
+
+    def test_filtered_count_star(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:
+        """COUNT(*) with filter becomes COUNT(CASE WHEN filter THEN 1 END)."""
+        orders_model.measures.append(
+            Measure(name="active_count", sql=None, filter="status = 'active'")
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="active_count:count")])
+        sql = _generate(generator, query, orders_model)
+        assert "CASE WHEN" in sql
+        assert "THEN 1" in sql
+        assert "COUNT(" in sql
+        # Should NOT be COUNT(*)
+        assert "COUNT(*)" not in sql
+
+    def test_filtered_avg(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:
+        orders_model.measures.append(
+            Measure(name="active_avg", sql="amount", filter="status = 'active'")
+        )
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="active_avg:avg")])
+        sql = _generate(generator, query, orders_model)
+        assert "CASE WHEN" in sql
+        assert "AVG(" in sql
+
+    def test_unfiltered_measure_no_case(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:
+        """Measures without filter should not have CASE WHEN."""
+        query = SlayerQuery(source_model="orders", fields=[Field(formula="revenue:sum")])
+        sql = _generate(generator, query, orders_model)
+        assert "CASE WHEN" not in sql
+        assert "SUM(" in sql
+
+    def test_mixed_filtered_and_unfiltered(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:
+        """Query with both filtered and unfiltered measures."""
+        orders_model.measures.append(
+            Measure(name="active_revenue", sql="amount", filter="status = 'active'")
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            fields=[Field(formula="revenue:sum"), Field(formula="active_revenue:sum")],
+        )
+        sql = _generate(generator, query, orders_model)
+        # Should have one CASE WHEN (for active_revenue) and one plain SUM (for revenue)
+        assert sql.count("CASE WHEN") == 1
+        assert sql.count("SUM(") == 2


### PR DESCRIPTION
## Summary

Two model-level enhancements that prepare SLayer for dbt semantic layer ingestion:

### 1. `label` field on Dimension and Measure

A human-readable display name (e.g., "Order Date", "Total Revenue"), distinct from the technical `name` and the explanatory `description`. This maps directly to dbt's `label` field on dimensions and measures.

- Model-level labels propagate through enrichment as fallbacks when no query-time label is set
- Fixed `_query_as_model()` to store labels in the `label` field — previously labels were incorrectly stored as `description`, and measure labels were lost entirely
- MCP `_model_to_summary()` now includes labels in dimension/measure output

### 2. `filter` field on Measure

A SQL condition applied before aggregation via `CASE WHEN` wrapping. This enables dbt-style filtered metrics (e.g., `loss_payment_amount = SUM(claim_amount) WHERE has_loss_payment = 1`) without needing to create separate models per metric.

```yaml
measures:
  - name: active_revenue
    sql: amount
    filter: "status = 'active'"
    # active_revenue:sum → SUM(CASE WHEN status = 'active' THEN amount END)
```

Key implementation details:
- Filter resolution happens during enrichment (not SQL generation), reusing `resolve_filter_columns` logic
- Supports cross-model (joined) filter references: `"categories.type = 'electronics'"`
- SQL generation handles all aggregation types:
  - Standard (`SUM`/`AVG`/`MIN`/`MAX`): wraps inner expression in `CASE WHEN`
  - `COUNT(*)`: becomes `COUNT(CASE WHEN filter THEN 1 END)`
  - `first`/`last`: filter added to the ROW_NUMBER CASE condition
  - Formula-based (`weighted_avg`, custom): `{value}` placeholder wrapped before substitution
- `_resolve_joins()` scans measure filters for join references to ensure necessary JOINs are active
- Multiple filtered and unfiltered measures can coexist in the same query and be combined in arithmetic formulas

### Why this matters

These are the prerequisite SLayer changes needed to faithfully ingest dbt semantic layer definitions. With `label`, we can preserve dbt's human-readable names. With `filter`, dbt's filtered simple metrics map directly to SLayer measures — no need for a separate "metrics" concept layer. Derived metrics become straightforward query formulas combining filtered measures.

## Test plan

- [x] Unit tests: model validation for label and filter fields (`test_models.py`)
- [x] SQL generation tests: CASE WHEN for sum, avg, count(*), mixed filtered/unfiltered (`test_sql_generator.py`)
- [x] Integration tests: filtered measure sum, count, with dimensions; label propagation through enrichment (`test_integration.py`)
- [x] Full test suite: 548 passed
- [x] Linter: `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional `label` for dimensions and measures; labels surface in query results and summaries.
  * Optional `filter` for measures to apply SQL conditions at query time (affects aggregation, ranking, and formulas); supports dotted references to joined dimensions and mixing filtered/unfiltered measures.

* **Documentation**
  * Model docs updated with examples for labels and filtered measures and how filters are applied.

* **Tests**
  * Extensive integration and unit tests added, including SQL generation and injection-hardening checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->