### PR TITLE
DEV-1261: Meta fields

### DIFF
--- a/.claude/skills/slayer-query.md
+++ b/.claude/skills/slayer-query.md
@@ -66,7 +66,7 @@ filters=[
 
 ```python
 engine = SlayerQueryEngine(storage=storage)
-result = engine.execute(query=query)  # SlayerResponse with .data, .columns, .row_count, .sql, .meta
+result = engine.execute(query=query)  # SlayerResponse with .data, .columns, .row_count, .sql, .attributes
 ```
 
 ## Cross-Model Measures
@@ -109,4 +109,4 @@ engine.execute(query=[inner, outer])
 
 ## Result Format
 
-Column keys use `model_name.column_name` format: `"orders.count"`, `"orders.revenue_sum"`. For multi-hop joined dimensions, the full path is included: `"orders.customers.regions.name"`. Response includes `meta` dict mapping column aliases to `FieldMetadata` objects (currently has `label` field).
+Column keys use `model_name.column_name` format: `"orders.count"`, `"orders.revenue_sum"`. For multi-hop joined dimensions, the full path is included: `"orders.customers.regions.name"`. Response includes `attributes` with nested `dimensions` and `measures` dicts, each mapping column aliases to `FieldMetadata` objects (label, format).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ poetry run ruff check slayer/ tests/
 - Imports at the top of files
 - SQL generation uses sqlglot AST building (not string concatenation)
 - Dimension/measure SQL uses bare column names (e.g., `"amount"`); use `model_name.column_name` for complex expressions (e.g., `"orders.amount * orders.quantity"`)
+- Models, dimensions, and measures have an optional `extra: Dict[str, Any]` field for arbitrary user-defined JSON metadata. Persisted in storage, editable via MCP (`edit_model`), HTTP API, and CLI.
 - **Measures and aggregations are separate concepts**: Measures are named row-level SQL expressions (e.g., `{name: "revenue", sql: "amount"}`). Aggregations (sum, avg, count, etc.) are specified at query time using **colon syntax**: `"revenue:sum"`, `"*:count"`, `"price:weighted_avg(weight=quantity)"`. Built-in aggregations: sum, avg, min, max, count, count_distinct, first, last, weighted_avg, median. Custom aggregations can be defined at model level in the `aggregations` list.
 - **`*:count`** for COUNT(*) — `*` means "all rows", `count` is just a regular aggregation. `col:count` = COUNT(col) for non-nulls. No magic "count" keyword.
 - Measures can have `allowed_aggregations` whitelist — validated at model creation and query time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ poetry run ruff check slayer/ tests/
 - Imports at the top of files
 - SQL generation uses sqlglot AST building (not string concatenation)
 - Dimension/measure SQL uses bare column names (e.g., `"amount"`); use `model_name.column_name` for complex expressions (e.g., `"orders.amount * orders.quantity"`)
-- Models, dimensions, and measures have an optional `extra: Dict[str, Any]` field for arbitrary user-defined JSON metadata. Persisted in storage, editable via MCP (`edit_model`), HTTP API, and CLI.
+- Models, dimensions, and measures have an optional `meta: Dict[str, Any]` field for arbitrary user-defined JSON metadata. Persisted in storage, editable via MCP (`edit_model`), HTTP API, and CLI.
 - **Measures and aggregations are separate concepts**: Measures are named row-level SQL expressions (e.g., `{name: "revenue", sql: "amount"}`). Aggregations (sum, avg, count, etc.) are specified at query time using **colon syntax**: `"revenue:sum"`, `"*:count"`, `"price:weighted_avg(weight=quantity)"`. Built-in aggregations: sum, avg, min, max, count, count_distinct, first, last, weighted_avg, median. Custom aggregations can be defined at model level in the `aggregations` list.
 - **`*:count`** for COUNT(*) — `*` means "all rows", `count` is just a regular aggregation. `col:count` = COUNT(col) for non-nulls. No magic "count" keyword.
 - Measures can have `allowed_aggregations` whitelist — validated at model creation and query time

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ poetry run pytest tests/integration/test_integration_duckdb.py -m integration
 poetry run pytest tests/test_sql_generator.py -v
 
 # Start API server
-poetry run slayer serve --models-dir ./slayer_data
+poetry run slayer serve --storage ./slayer_data
 
 # Start MCP server
-poetry run slayer mcp --models-dir ./slayer_data
+poetry run slayer mcp --storage ./slayer_data
 
 # Lint
 poetry run ruff check slayer/ tests/
@@ -55,8 +55,10 @@ poetry run ruff check slayer/ tests/
 - **Backward compat**: old `type` field on measures (e.g., `type: sum`) is still accepted (deprecated). Bare measure names in formulas (e.g., `"revenue"`) work when the measure has a deprecated `type` — emits `DeprecationWarning`.
 - Queries support `fields` — list of `{"formula": "...", "name": "...", "label": "..."}` parsed by `slayer/core/formula.py`. `label` is an optional human-readable display name (also supported on `ColumnRef` and `TimeDimension`)
 - **Result column naming**: `revenue:sum` → `orders.revenue_sum` (colon becomes underscore). `*:count` → `orders.count` (star-colon prefix stripped). When converting queries to models (`create_model_from_query`), the same colon-to-underscore mapping applies.
+- **Response attributes**: `SlayerResponse.attributes` is a `ResponseAttributes` with `.dimensions` and `.measures` dicts, each mapping column alias → `FieldMetadata(label, format)`. Split by type so consumers can distinguish dimension metadata from measure metadata.
 - Available formula transforms: cumsum, time_shift, change, change_pct, rank, last (FIRST_VALUE window), lag, lead. time_shift, change, and change_pct always use self-join CTEs (no edge NULLs, gap-safe). time_shift uses row-number-based join without granularity, date-arithmetic-based with granularity. lag/lead use LAG/LEAD window functions directly (more efficient but produce NULLs at edges)
 - Filters can reference computed field names or contain inline transform expressions (e.g., `"change(revenue:sum) > 0"`, `"last(change(revenue:sum)) < 0"`). These are auto-extracted as hidden fields and applied as post-filters on the outer query
+- Filters support `{variable}` placeholders substituted from `query.variables: Dict[str, Any]`. Values must be str/number, inserted as-is. `{{`/`}}` for literal braces. Undefined variables raise errors.
 - Models can have explicit `joins` to other models (LEFT JOINs). Cross-model measures use dotted syntax with colon aggregation (`customers.revenue:sum`) and multi-hop (`customers.regions.name`). Joins are auto-resolved by walking the join graph. Transforms work on cross-model measures (`cumsum(customers.revenue:sum)`)
 - **Path-based table aliases**: Joined tables use `__`-delimited path aliases in SQL to disambiguate diamond joins. In queries, dots denote paths (`customers.regions.name`); in model SQL definitions, `__` denotes the table alias (`customers__regions.name`). For diamond joins (same table reached via different paths, e.g., `orders → customers → regions` AND `orders → warehouses → regions`), each path gets a unique alias (`customers__regions` vs `warehouses__regions`). Ingestion auto-detects diamond joins via FK graph BFS
 - `SlayerQuery.source_model` accepts a model name, inline `SlayerModel`, or `ModelExtension` (extends a model with extra dims/measures/joins). `create_model_from_query()` saves a query as a permanent model
@@ -69,6 +71,22 @@ poetry run ruff check slayer/ tests/
 - Result column keys use `model_name.column_name` format (e.g., `"orders.count"`). For multi-hop joined dimensions, the full path is included: `"orders.customers.regions.name"`
 - Datasource configs support `${ENV_VAR}` references resolved at read time
 - Integration tests are marked with `@pytest.mark.integration` and skip when DB is unavailable
+
+## Async Architecture
+
+- **Engine is async-first**: `SlayerQueryEngine.execute()` is `async`. Use `execute_sync()` for CLI/notebooks/scripts.
+- **Storage backends are async**: All `StorageBackend` methods are `async def`. YAMLStorage uses sync I/O inside async (fast local files). SQLiteStorage uses `asyncio.to_thread`. Future Postgres storage can use true async (asyncpg).
+- **SQL client**: Uses native async drivers for Postgres (`asyncpg`) and MySQL (`aiomysql`). Falls back to `asyncio.to_thread` for SQLite, DuckDB, ClickHouse. Connection pools are cached per `SlayerSQLClient` instance.
+- **Tests use `pytest-asyncio`** with `asyncio_mode = "auto"` — test functions can be `async def` and `await` directly.
+- **Sync wrappers**: `run_sync()` in `async_utils.py` bridges async→sync for CLI and MCP tools. Handles both "no event loop" and "inside Jupyter" cases.
+
+## CLI
+
+- All commands accept `--storage` (directory for YAML, `.db` file for SQLite). Legacy `--models-dir` still works.
+- `slayer query` supports `--dry-run` (preview SQL) and `--explain` (execution plan, dialect-aware).
+- `slayer datasources create-inline` supports `--password-stdin` for secure credential input.
+- `slayer datasources test` verifies connectivity.
+- MCP `query()` tool has a `format` parameter: `"markdown"` (default), `"json"`, or `"csv"`.
 
 ## Database Support
 
@@ -84,7 +102,7 @@ SLayer uses sqlglot for dialect-aware SQL generation. Databases are supported at
 **Tier 2 — code-covered** (unit tests for SQL generation, no live instance verification):
 - Snowflake, BigQuery, Redshift, Trino/Presto, Databricks/Spark, MS SQL Server, Oracle
 
-Dialect mapping lives in `query_engine.py:_dialect_for_type()`. Dialect-specific SQL lives in `generator.py` — mainly `_build_date_trunc` (SQLite branch) and `_build_time_offset_expr` (date arithmetic for shifted CTEs). Calendar-based time shifts use timestamp offset inside DATE_TRUNC with simple equality joins (no per-dialect join logic). All other SQL differences are handled by sqlglot transpilation. When adding a new dialect: add it to `_dialect_for_type`, add a `_build_time_offset_expr` branch if it doesn't use Postgres-style `INTERVAL`, and add parametrized tests in `TestMultiDialectGeneration`.
+Dialect mapping lives in `query_engine.py:_dialect_for_type()`. Dialect-specific SQL lives in `generator.py` — mainly `_build_date_trunc` (SQLite branch) and `_build_time_offset_expr` (date arithmetic for shifted CTEs). Calendar-based time shifts use timestamp offset inside DATE_TRUNC with simple equality joins (no per-dialect join logic). All other SQL differences are handled by sqlglot transpilation. When adding a new dialect: add it to `_dialect_for_type`, add a `_build_time_offset_expr` branch if it doesn't use Postgres-style `INTERVAL`, and add parametrised tests in `TestMultiDialectGeneration`.
 
 ## Testing
 
@@ -124,3 +142,14 @@ To auto-fix fixable issues:
 ```bash
 poetry run ruff check --fix slayer/ tests/
 ```
+
+## Documentation Requirements
+
+**ALWAYS update documentation when making API or user-facing changes.** Check and update ALL of these locations:
+
+1. **`CLAUDE.md`** — Key Conventions, Async Architecture, CLI, Database Support sections
+2. **`docs/`** — concept docs (`models.md`, `queries.md`, `formulas.md`, `ingestion.md`), getting-started guides, reference docs
+3. **`.claude/skills/`** — `slayer-query.md`, `slayer-models.md`, `slayer-overview.md`
+4. **`docs/configuration/`** — datasources, storage backends
+
+When renaming a field, adding a parameter, or changing response structure, **grep all docs and skills** for the old name and update every occurrence.

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -48,7 +48,7 @@ Dimensions are the columns you group by and filter on.
 | `type` | string | No | `string` | Data type |
 | `primary_key` | bool | No | `false` | Is this a primary key? |
 | `hidden` | bool | No | `false` | Hide from listings |
-| `extra` | dict | No | — | Arbitrary JSON metadata (e.g., `{"source": "CRM", "team": "analytics"}`) |
+| `meta` | dict | No | — | Arbitrary JSON metadata (e.g., `{"source": "CRM", "team": "analytics"}`) |
 
 ### Dimension Types
 
@@ -73,7 +73,7 @@ Measures are named row-level SQL expressions. They define *what* to compute, not
 | `allowed_aggregations` | list[str] | No | — | Whitelist of allowed aggregation types (validated at model creation and query time) |
 | `filter` | string | No | — | SQL condition applied before aggregation. See [Filtered Measures](#filtered-measures) below. |
 | `hidden` | bool | No | `false` | Hide from listings |
-| `extra` | dict | No | — | Arbitrary JSON metadata |
+| `meta` | dict | No | — | Arbitrary JSON metadata |
 
 ### Filtered Measures
 
@@ -261,7 +261,7 @@ See the [multistage queries example](../examples/06_multistage_queries/multistag
 | `description` | string | No | — | Helps agents and users understand the model |
 | `hidden` | bool | No | `false` | Hide from model listings |
 | `default_time_dimension` | string | No | — | Default time dimension name for time-dependent formulas (e.g. `"created_at"`) |
-| `extra` | dict | No | — | Arbitrary JSON metadata (e.g., `{"owner": "analytics", "version": 2}`) |
+| `meta` | dict | No | — | Arbitrary JSON metadata (e.g., `{"owner": "analytics", "version": 2}`) |
 
 ## Result Column Format
 

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -48,6 +48,7 @@ Dimensions are the columns you group by and filter on.
 | `type` | string | No | `string` | Data type |
 | `primary_key` | bool | No | `false` | Is this a primary key? |
 | `hidden` | bool | No | `false` | Hide from listings |
+| `extra` | dict | No | — | Arbitrary JSON metadata (e.g., `{"source": "CRM", "team": "analytics"}`) |
 
 ### Dimension Types
 
@@ -72,6 +73,7 @@ Measures are named row-level SQL expressions. They define *what* to compute, not
 | `allowed_aggregations` | list[str] | No | — | Whitelist of allowed aggregation types (validated at model creation and query time) |
 | `filter` | string | No | — | SQL condition applied before aggregation. See [Filtered Measures](#filtered-measures) below. |
 | `hidden` | bool | No | `false` | Hide from listings |
+| `extra` | dict | No | — | Arbitrary JSON metadata |
 
 ### Filtered Measures
 
@@ -259,6 +261,7 @@ See the [multistage queries example](../examples/06_multistage_queries/multistag
 | `description` | string | No | — | Helps agents and users understand the model |
 | `hidden` | bool | No | `false` | Hide from model listings |
 | `default_time_dimension` | string | No | — | Default time dimension name for time-dependent formulas (e.g. `"created_at"`) |
+| `extra` | dict | No | — | Arbitrary JSON metadata (e.g., `{"owner": "analytics", "version": 2}`) |
 
 ## Result Column Format
 

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -73,7 +73,7 @@ Query results are returned as a `SlayerResponse`:
 | `columns` | list[str] | Column names in `model_name.column_name` format (e.g., `"orders.count"`, `"orders.customers.regions.name"` for multi-hop) |
 | `row_count` | int | Number of rows |
 | `sql` | string | The generated SQL (useful for debugging) |
-| `meta` | dict[str, FieldMetadata] | Column alias → field metadata (currently contains `label`; more fields coming soon) |
+| `attributes` | ResponseAttributes | Field metadata split by type: `attributes.dimensions` and `attributes.measures`, each a dict of column alias → FieldMetadata (label, format) |
 
 ```json
 {

--- a/docs/getting-started/python.md
+++ b/docs/getting-started/python.md
@@ -72,7 +72,7 @@ result.data        # list of row dicts
 result.columns     # list of column names
 result.row_count   # number of rows
 result.sql         # generated SQL (when dry_run or explain is set)
-result.meta        # dict of column name → FieldMetadata (labels, etc.)
+result.attributes  # ResponseAttributes with .dimensions and .measures dicts
 ```
 
 ## Remote mode (client → server)

--- a/docs/interfaces/python-client.md
+++ b/docs/interfaces/python-client.md
@@ -81,7 +81,7 @@ engine = SlayerQueryEngine(storage=storage)
 result = engine.execute(query=query)
 # result.data      — list of row dicts
 # result.columns   — list of column names
-# result.meta      — dict mapping column names to FieldMetadata (label, and more coming soon)
+# result.attributes — ResponseAttributes with .dimensions and .measures dicts (column → FieldMetadata)
 #
 # client.query() returns SlayerResponse with all fields above
 # client.sql(query) returns just the generated SQL string

--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -81,7 +81,7 @@ engine = SlayerQueryEngine(storage=storage)
 result = engine.execute(query=query)
 # result.data      — list of row dicts
 # result.columns   — list of column names
-# result.meta      — dict mapping column names to FieldMetadata (label, and more coming soon)
+# result.attributes — ResponseAttributes with .dimensions and .measures dicts (column → FieldMetadata)
 #
 # client.query() returns SlayerResponse with all fields above
 # client.sql(query) returns just the generated SQL string

--- a/slayer/api/server.py
+++ b/slayer/api/server.py
@@ -81,10 +81,12 @@ def create_app(storage: StorageBackend) -> FastAPI:
             def _convert_meta(d: dict) -> Dict[str, FieldMetadataResponse]:
                 return {k: FieldMetadataResponse(label=v.label, format=v.format) for k, v in d.items()}
 
-            attributes = AttributesResponse(
-                dimensions=_convert_meta(attrs.dimensions),
-                measures=_convert_meta(attrs.measures),
-            ) if attrs.dimensions or attrs.measures else None
+            attributes = None
+            if attrs and (attrs.dimensions or attrs.measures):
+                attributes = AttributesResponse(
+                    dimensions=_convert_meta(attrs.dimensions),
+                    measures=_convert_meta(attrs.measures),
+                )
             response = QueryResponse(
                 data=result.data,
                 row_count=result.row_count,

--- a/slayer/api/server.py
+++ b/slayer/api/server.py
@@ -36,12 +36,17 @@ class FieldMetadataResponse(BaseModel):
     format: Optional[NumberFormat] = None
 
 
+class AttributesResponse(BaseModel):
+    dimensions: Dict[str, FieldMetadataResponse] = {}
+    measures: Dict[str, FieldMetadataResponse] = {}
+
+
 class QueryResponse(BaseModel):
     data: List[Dict[str, Any]]
     row_count: int
     columns: List[str]
     sql: Optional[str] = None
-    meta: Optional[Dict[str, FieldMetadataResponse]] = None
+    attributes: Optional[AttributesResponse] = None
 
 
 class IngestRequest(BaseModel):
@@ -71,19 +76,20 @@ def create_app(storage: StorageBackend) -> FastAPI:
                 request.model_dump(exclude_none=True)
             )
             result = await engine.execute(query=slayer_query)
-            meta = (
-                {
-                    k: FieldMetadataResponse(label=v.label, format=v.format)
-                    for k, v in result.meta.items()
-                }
-                if result.meta
-                else None
-            )
+            attrs = result.attributes
+
+            def _convert_meta(d: dict) -> Dict[str, FieldMetadataResponse]:
+                return {k: FieldMetadataResponse(label=v.label, format=v.format) for k, v in d.items()}
+
+            attributes = AttributesResponse(
+                dimensions=_convert_meta(attrs.dimensions),
+                measures=_convert_meta(attrs.measures),
+            ) if attrs.dimensions or attrs.measures else None
             response = QueryResponse(
                 data=result.data,
                 row_count=result.row_count,
                 columns=result.columns,
-                meta=meta,
+                attributes=attributes,
             )
             if slayer_query.dry_run or slayer_query.explain:
                 response.sql = result.sql

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -63,14 +63,21 @@ class SlayerClient:
     @staticmethod
     def _parse_response(result: dict) -> SlayerResponse:
         """Parse an API JSON response into a SlayerResponse."""
-        meta = {}
-        for k, v in (result.get("meta") or {}).items():
-            meta[k] = FieldMetadata(label=v.get("label"))
+        from slayer.engine.query_engine import ResponseAttributes
+
+        def _parse_meta_dict(d: dict) -> Dict[str, FieldMetadata]:
+            return {k: FieldMetadata(label=v.get("label")) for k, v in (d or {}).items()}
+
+        attrs_raw = result.get("attributes") or {}
+        attributes = ResponseAttributes(
+            dimensions=_parse_meta_dict(attrs_raw.get("dimensions")),
+            measures=_parse_meta_dict(attrs_raw.get("measures")),
+        )
         return SlayerResponse(
             data=result["data"],
             columns=result.get("columns") or [],
             sql=result.get("sql"),
-            meta=meta,
+            attributes=attributes,
         )
 
     # ----- Async API -----

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from slayer.core.query import SlayerQuery
-from slayer.engine.query_engine import FieldMetadata, SlayerResponse
+from slayer.engine.query_engine import FieldMetadata, ResponseAttributes, SlayerResponse
 
 logger = logging.getLogger(__name__)
 
@@ -63,10 +63,16 @@ class SlayerClient:
     @staticmethod
     def _parse_response(result: dict) -> SlayerResponse:
         """Parse an API JSON response into a SlayerResponse."""
-        from slayer.engine.query_engine import ResponseAttributes
+        from slayer.core.format import NumberFormat
 
         def _parse_meta_dict(d: dict) -> Dict[str, FieldMetadata]:
-            return {k: FieldMetadata(label=v.get("label")) for k, v in (d or {}).items()}
+            out = {}
+            for k, v in (d or {}).items():
+                fmt = None
+                if v.get("format"):
+                    fmt = NumberFormat.model_validate(v["format"])
+                out[k] = FieldMetadata(label=v.get("label"), format=fmt)
+            return out
 
         attrs_raw = result.get("attributes") or {}
         attributes = ResponseAttributes(

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import re
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -95,6 +95,7 @@ class Dimension(BaseModel):
     label: Optional[str] = None
     hidden: bool = False
     format: Optional[NumberFormat] = None
+    extra: Optional[Dict[str, Any]] = None
 
     @field_validator("name")
     @classmethod
@@ -147,6 +148,7 @@ class Measure(BaseModel):
     allowed_aggregations: Optional[List[str]] = None
     filter: Optional[str] = None
     format: Optional[NumberFormat] = None
+    extra: Optional[Dict[str, Any]] = None
 
     @field_validator("name")
     @classmethod
@@ -205,6 +207,7 @@ class SlayerModel(BaseModel):
     default_time_dimension: Optional[str] = None
     description: Optional[str] = None
     hidden: bool = False
+    extra: Optional[Dict[str, Any]] = None
 
     @field_validator("filters")
     @classmethod

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -95,7 +95,7 @@ class Dimension(BaseModel):
     label: Optional[str] = None
     hidden: bool = False
     format: Optional[NumberFormat] = None
-    extra: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
     @field_validator("name")
     @classmethod
@@ -148,7 +148,7 @@ class Measure(BaseModel):
     allowed_aggregations: Optional[List[str]] = None
     filter: Optional[str] = None
     format: Optional[NumberFormat] = None
-    extra: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
     @field_validator("name")
     @classmethod
@@ -207,7 +207,7 @@ class SlayerModel(BaseModel):
     default_time_dimension: Optional[str] = None
     description: Optional[str] = None
     hidden: bool = False
-    extra: Optional[Dict[str, Any]] = None
+    meta: Optional[Dict[str, Any]] = None
 
     @field_validator("filters")
     @classmethod

--- a/slayer/engine/query_engine.py
+++ b/slayer/engine/query_engine.py
@@ -68,13 +68,25 @@ class FieldMetadata:
 
 
 @dataclass
+class ResponseAttributes:
+    """Field metadata for a query response, split by type."""
+
+    dimensions: Dict[str, FieldMetadata] = field(default_factory=dict)
+    measures: Dict[str, FieldMetadata] = field(default_factory=dict)
+
+    def get(self, column: str) -> Optional[FieldMetadata]:
+        """Look up metadata for a column across both dicts."""
+        return self.dimensions.get(column) or self.measures.get(column)
+
+
+@dataclass
 class SlayerResponse:
     """Response from a SLayer query."""
 
     data: List[Dict[str, Any]]
     columns: List[str] = field(default_factory=list)
     sql: Optional[str] = None
-    meta: Dict[str, FieldMetadata] = field(default_factory=dict)
+    attributes: ResponseAttributes = field(default_factory=ResponseAttributes)
 
     def __post_init__(self):
         if not self.columns and self.data:
@@ -88,7 +100,7 @@ class SlayerResponse:
         """Format a single cell value using column format metadata if available."""
         if value is None:
             return ""
-        fm = self.meta.get(column)
+        fm = self.attributes.get(column)
         if fm and fm.format and isinstance(value, (int, float, decimal.Decimal)):
             return format_number(value=value, format_spec=fm.format)
         return str(value)
@@ -187,14 +199,15 @@ class SlayerQueryEngine:
         sql = generator.generate(enriched=enriched)
         logger.debug("Generated SQL:\n%s", sql)
 
-        # Collect field metadata from enriched query
-        meta: Dict[str, FieldMetadata] = {}
+        # Collect field metadata from enriched query, split by type
+        dim_meta: Dict[str, FieldMetadata] = {}
+        measure_meta: Dict[str, FieldMetadata] = {}
         for d in enriched.dimensions:
             if d.label or d.format:
-                meta[d.alias] = FieldMetadata(label=d.label, format=d.format)
+                dim_meta[d.alias] = FieldMetadata(label=d.label, format=d.format)
         for td in enriched.time_dimensions:
             if td.label:
-                meta[td.alias] = FieldMetadata(label=td.label)
+                dim_meta[td.alias] = FieldMetadata(label=td.label)
         for m in enriched.measures:
             measure_fmt = _infer_aggregated_format(
                 model=model,
@@ -202,20 +215,21 @@ class SlayerQueryEngine:
                 aggregation=m.aggregation,
             )
             if m.label or measure_fmt:
-                meta[m.alias] = FieldMetadata(label=m.label, format=measure_fmt)
+                measure_meta[m.alias] = FieldMetadata(label=m.label, format=measure_fmt)
         for e in enriched.expressions:
-            meta[e.alias] = FieldMetadata(
+            measure_meta[e.alias] = FieldMetadata(
                 label=e.label,
                 format=NumberFormat(type=NumberFormatType.FLOAT),
             )
         for t in enriched.transforms:
-            meta[t.alias] = FieldMetadata(
+            measure_meta[t.alias] = FieldMetadata(
                 label=t.label,
                 format=NumberFormat(type=NumberFormatType.FLOAT),
             )
         for cm in enriched.cross_model_measures:
             if cm.label or cm.format:
-                meta[cm.alias] = FieldMetadata(label=cm.label, format=cm.format)
+                measure_meta[cm.alias] = FieldMetadata(label=cm.label, format=cm.format)
+        attributes = ResponseAttributes(dimensions=dim_meta, measures=measure_meta)
 
         # Derive expected column names from the enriched query, excluding internal aliases
         # (_inner_* from nested transforms, _ft* from filter transform extraction)
@@ -230,7 +244,7 @@ class SlayerQueryEngine:
 
         # dry_run: return SQL without executing
         if query.dry_run:
-            return SlayerResponse(data=[], columns=expected_columns, sql=sql, meta=meta)
+            return SlayerResponse(data=[], columns=expected_columns, sql=sql, attributes=attributes)
 
         # Execute — reuse SQL client (and its connection pool) per datasource
         ds_key = datasource.get_connection_string()
@@ -242,11 +256,11 @@ class SlayerQueryEngine:
         if query.explain:
             explain_sql = _build_explain_sql(dialect=dialect, sql=sql)
             rows = await client.execute(sql=explain_sql)
-            return SlayerResponse(data=rows, sql=sql, meta=meta)
+            return SlayerResponse(data=rows, sql=sql, attributes=attributes)
 
         rows = await client.execute(sql=sql)
         columns = expected_columns if not rows else []  # fallback for empty results; [] triggers auto-derive
-        return SlayerResponse(data=rows, columns=columns, sql=sql, meta=meta)
+        return SlayerResponse(data=rows, columns=columns, sql=sql, attributes=attributes)
 
     def execute_sync(self, query: "SlayerQuery | dict | list[SlayerQuery | dict]") -> SlayerResponse:
         """Synchronous wrapper for execute(). For CLI, notebooks, and scripts."""

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -21,6 +21,7 @@ from slayer.storage.base import StorageBackend
 logger = logging.getLogger(__name__)
 
 VALID_DIMENSION_TYPES = {"string", "time", "date", "boolean", "number"}
+_UNSET = object()  # Sentinel to distinguish "not provided" from "explicitly set to None"
 
 
 def _test_connection(ds: DatasourceConfig) -> tuple[bool, str]:
@@ -448,6 +449,7 @@ def create_mcp_server(storage: StorageBackend):
         add_filters: Optional[List[str]] = None,
         remove_filters: Optional[List[str]] = None,
         remove: Optional[Dict[str, List[str]]] = None,
+        extra: Optional[Dict[str, Any]] = _UNSET,
     ) -> str:
         """Edit an existing model in a single call — update metadata, upsert dimensions/measures/aggregations/joins,
         manage filters, and remove entities.
@@ -460,6 +462,7 @@ def create_mcp_server(storage: StorageBackend):
             sql_table: Database table name.
             sql: Custom SQL expression for the model source.
             hidden: Whether this model is hidden from discovery.
+            extra: Arbitrary JSON metadata for the model (replaces existing extra). Pass null/None to clear.
             dimensions: Dimensions to create or update (upsert by name). Each dict: {"name": "col", "type": "string", "sql": "col", "description": "...", "primary_key": false, "hidden": false}.
                 If a dimension with this name exists, only the provided fields are updated; omitted fields keep current values.
                 Types: string, number, time, date, boolean.
@@ -509,6 +512,9 @@ def create_mcp_server(storage: StorageBackend):
         if hidden is not None:
             model.hidden = hidden
             changes.append(f"set hidden to {hidden}")
+        if extra is not _UNSET:
+            model.extra = extra
+            changes.append("updated extra" if extra is not None else "cleared extra")
 
         # --- Phase 2: Removals ---
         if remove:

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -209,8 +209,8 @@ def create_mcp_server(storage: StorageBackend):
             output = _format_output(result=result, fmt=fmt)
             if show_sql and result.sql:
                 output = f"SQL:\n{result.sql}\n\n{output}"
-            if result.meta:
-                output += "\n\n" + _format_meta(meta=result.meta)
+            if result.attributes and (result.attributes.dimensions or result.attributes.measures):
+                output += "\n\n" + _format_attributes(attributes=result.attributes)
             return output
         except Exception as e:
             if isinstance(e, (sa.exc.OperationalError, sa.exc.DatabaseError)):
@@ -449,7 +449,7 @@ def create_mcp_server(storage: StorageBackend):
         add_filters: Optional[List[str]] = None,
         remove_filters: Optional[List[str]] = None,
         remove: Optional[Dict[str, List[str]]] = None,
-        extra: Optional[Dict[str, Any]] = _UNSET,
+        meta: Optional[Dict[str, Any]] = _UNSET,
     ) -> str:
         """Edit an existing model in a single call — update metadata, upsert dimensions/measures/aggregations/joins,
         manage filters, and remove entities.
@@ -462,7 +462,7 @@ def create_mcp_server(storage: StorageBackend):
             sql_table: Database table name.
             sql: Custom SQL expression for the model source.
             hidden: Whether this model is hidden from discovery.
-            extra: Arbitrary JSON metadata for the model (replaces existing extra). Pass null/None to clear.
+            meta: Arbitrary JSON metadata for the model (replaces existing meta). Pass null/None to clear.
             dimensions: Dimensions to create or update (upsert by name). Each dict: {"name": "col", "type": "string", "sql": "col", "description": "...", "primary_key": false, "hidden": false}.
                 If a dimension with this name exists, only the provided fields are updated; omitted fields keep current values.
                 Types: string, number, time, date, boolean.
@@ -512,9 +512,9 @@ def create_mcp_server(storage: StorageBackend):
         if hidden is not None:
             model.hidden = hidden
             changes.append(f"set hidden to {hidden}")
-        if extra is not _UNSET:
-            model.extra = extra
-            changes.append("updated extra" if extra is not None else "cleared extra")
+        if meta is not _UNSET:
+            model.meta = meta
+            changes.append("updated meta" if meta is not None else "cleared meta")
 
         # --- Phase 2: Removals ---
         if remove:
@@ -957,10 +957,10 @@ def _format_output(result: SlayerResponse, fmt: str) -> str:
     return _format_json(data=result.data, columns=result.columns)
 
 
-def _format_meta(meta: Dict[str, Any]) -> str:
-    """Format field metadata as a compact section."""
-    lines = ["Column metadata:"]
-    for col, fm in meta.items():
+def _format_field_meta(entries: Dict[str, Any]) -> List[str]:
+    """Format a dict of field metadata entries into lines."""
+    lines = []
+    for col, fm in entries.items():
         parts = []
         if fm.label:
             parts.append(f"label={fm.label}")
@@ -973,6 +973,18 @@ def _format_meta(meta: Dict[str, Any]) -> str:
             parts.append(f"format=({', '.join(fmt_parts)})")
         if parts:
             lines.append(f"  {col}: {', '.join(parts)}")
-    if len(lines) == 1:
-        return ""  # No metadata to show
-    return "\n".join(lines)
+    return lines
+
+
+def _format_attributes(attributes) -> str:
+    """Format response attributes as a compact section."""
+    lines = []
+    dim_lines = _format_field_meta(attributes.dimensions)
+    if dim_lines:
+        lines.append("Dimension attributes:")
+        lines.extend(dim_lines)
+    measure_lines = _format_field_meta(attributes.measures)
+    if measure_lines:
+        lines.append("Measure attributes:")
+        lines.extend(measure_lines)
+    return "\n".join(lines) if lines else ""

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1663,7 +1663,7 @@ async def test_time_dimension_label_fallback(integration_env):
         fields=[Field(formula="total_amount:sum")],
     ))
     # The model-level label should propagate through
-    td_meta = result.meta.get("orders.created_at")
+    td_meta = result.attributes.dimensions.get("orders.created_at")
     assert td_meta is not None
     assert td_meta.label == "Order Date"
 
@@ -1689,9 +1689,9 @@ async def test_label_propagation_enrichment(integration_env):
         dimensions=[ColumnRef(name="status")],
     ))
     # Labels should appear in result meta
-    status_meta = result.meta.get("orders.status")
+    status_meta = result.attributes.dimensions.get("orders.status")
     assert status_meta is not None
     assert status_meta.label == "Order Status"
-    rev_meta = result.meta.get("orders.labeled_rev_sum")
+    rev_meta = result.attributes.measures.get("orders.labeled_rev_sum")
     assert rev_meta is not None
     assert rev_meta.label == "Total Revenue"

--- a/tests/test_format_propagation.py
+++ b/tests/test_format_propagation.py
@@ -103,31 +103,37 @@ class TestFieldMetadata:
 
 
 class TestMcpFormatMeta:
-    """Tests for _format_meta in MCP server."""
+    """Tests for _format_attributes in MCP server."""
 
     def test_format_meta_includes_precision_and_symbol(self):
-        from slayer.mcp.server import _format_meta
+        from slayer.engine.query_engine import ResponseAttributes
+        from slayer.mcp.server import _format_attributes
 
-        meta = {
-            "orders.revenue_sum": FieldMetadata(
-                label="Revenue",
-                format=NumberFormat(type=NumberFormatType.CURRENCY, precision=2, symbol="€"),
-            ),
-        }
-        result = _format_meta(meta=meta)
+        attrs = ResponseAttributes(
+            measures={
+                "orders.revenue_sum": FieldMetadata(
+                    label="Revenue",
+                    format=NumberFormat(type=NumberFormatType.CURRENCY, precision=2, symbol="€"),
+                ),
+            },
+        )
+        result = _format_attributes(attributes=attrs)
         assert "type=currency" in result
         assert "precision=2" in result
         assert "symbol=€" in result
 
     def test_format_meta_omits_none_fields(self):
-        from slayer.mcp.server import _format_meta
+        from slayer.engine.query_engine import ResponseAttributes
+        from slayer.mcp.server import _format_attributes
 
-        meta = {
-            "orders.count": FieldMetadata(
-                format=NumberFormat(type=NumberFormatType.INTEGER),
-            ),
-        }
-        result = _format_meta(meta=meta)
+        attrs = ResponseAttributes(
+            measures={
+                "orders.count": FieldMetadata(
+                    format=NumberFormat(type=NumberFormatType.INTEGER),
+                ),
+            },
+        )
+        result = _format_attributes(attributes=attrs)
         assert "type=integer" in result
         assert "precision" not in result
         assert "symbol" not in result


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models, dimensions, and measures can include an optional JSON "meta" field; metadata is persisted and can be created, updated, or cleared via MCP, HTTP API, and CLI.
* **API Changes**
  * Query responses now expose field metadata under an "attributes" object split into "dimensions" and "measures" when present.
* **Documentation**
  * Docs updated with examples and usage notes for the optional "meta" field.
* **Tests**
  * Integration and formatting tests updated to the new attributes structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->