### PR TITLE
Default storage path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,11 +29,11 @@ poetry run pytest tests/integration/test_integration_duckdb.py -m integration
 # Run a specific test file
 poetry run pytest tests/test_sql_generator.py -v
 
-# Start API server
-poetry run slayer serve --storage ./slayer_data
+# Start API server (uses platform default storage path, override with --storage)
+poetry run slayer serve
 
 # Start MCP server
-poetry run slayer mcp --storage ./slayer_data
+poetry run slayer mcp
 
 # Lint
 poetry run ruff check slayer/ tests/
@@ -82,7 +82,7 @@ poetry run ruff check slayer/ tests/
 
 ## CLI
 
-- All commands accept `--storage` (directory for YAML, `.db` file for SQLite). Legacy `--models-dir` still works.
+- All commands accept `--storage` (directory for YAML, `.db` file for SQLite). Defaults to platform-appropriate path (`~/.local/share/slayer` on Linux, `~/Library/Application Support/slayer` on macOS). Override with `$SLAYER_STORAGE` env var. Legacy `--models-dir` still works.
 - `slayer query` supports `--dry-run` (preview SQL) and `--explain` (execution plan, dialect-aware).
 - `slayer datasources create-inline` supports `--password-stdin` for secure credential input.
 - `slayer datasources test` verifies connectivity.

--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ See the [documentation page for storage backends](https://motley-slayer.readthed
 |   2   | Multi-stage queries                             |   ✅    |
 |   3   | Cross-model measures                            |   ✅    |
 |   4   | Aggregation at query time                       |   ✅    |
-|   5   | Unpivoting                                      |   ❌    |
-|   6   | Smart output formatting (currency, percentages) |   ❌    |
+|   5   | Smart output formatting (currency, percentages) |   ✅    |
+|   6   | Unpivoting                                      |   ❌    |
 |   7   | Auto-propagating filters                        |   ❌    |
 |   8   | Asof joins                                      |   ❌    |
 |   9   | Chart generation (eCharts)                      |   ❌    |

--- a/docs/configuration/storage.md
+++ b/docs/configuration/storage.md
@@ -2,6 +2,18 @@
 
 SLayer uses a storage backend to persist model and datasource configurations.
 
+## Default Location
+
+When no `--storage` flag or `$SLAYER_STORAGE` env var is set, SLayer uses a platform-appropriate default:
+
+| Platform | Default path |
+|---|---|
+| Linux | `~/.local/share/slayer` (or `$XDG_DATA_HOME/slayer`) |
+| macOS | `~/Library/Application Support/slayer` |
+| Windows | `%LOCALAPPDATA%\slayer` |
+
+This means `slayer serve` works out of the box with no flags. Override with `--storage` or `$SLAYER_STORAGE`.
+
 ## Available Backends
 
 ### YAMLStorage (default)

--- a/docs/getting-started/mcp.md
+++ b/docs/getting-started/mcp.md
@@ -13,13 +13,13 @@ Install [uv](https://docs.astral.sh/uv/getting-started/installation/) — the fa
 Register SLayer as an MCP server — Claude Code will spawn it automatically when needed:
 
 ```bash
-claude mcp add slayer -- uvx --from motley-slayer slayer mcp --storage ./slayer_data
+claude mcp add slayer -- uvx --from motley-slayer slayer mcp
 ```
 
 For databases other than SQLite, add the driver extra (see [full list](../configuration/datasources.md#database-drivers)):
 
 ```bash
-claude mcp add slayer -- uvx --from 'motley-slayer[postgres]' slayer mcp --storage ./slayer_data
+claude mcp add slayer -- uvx --from 'motley-slayer[postgres]' slayer mcp
 ```
 
 ### Other agents (JSON config)
@@ -31,7 +31,7 @@ Most MCP-compatible agents accept a JSON server configuration. Add this to your 
   "mcpServers": {
     "slayer": {
       "command": "uvx",
-      "args": ["--from", "motley-slayer[postgres]", "slayer", "mcp", "--storage", "./slayer_data"]
+      "args": ["--from", "motley-slayer[postgres]", "slayer", "mcp"]
     }
   }
 }
@@ -96,5 +96,5 @@ If you prefer a traditional install instead of `uvx`:
 
 ```bash
 uv tool install 'motley-slayer[postgres]'
-claude mcp add slayer -- slayer mcp --storage ./slayer_data
+claude mcp add slayer -- slayer mcp
 ```

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -1,15 +1,15 @@
 """CLI entry point for SLayer."""
 
 import argparse
-import os
 import sys
 
 from slayer.async_utils import run_sync
+from slayer.storage.base import default_storage_path
 
-_STORAGE_DEFAULT = os.environ.get("SLAYER_STORAGE", os.environ.get("SLAYER_MODELS_DIR", "./slayer_data"))
+_STORAGE_DEFAULT = default_storage_path()
 _STORAGE_HELP = (
     "Storage path: directory for YAML storage, or .db/.sqlite file for SQLite storage "
-    "(default: $SLAYER_STORAGE or $SLAYER_MODELS_DIR or ./slayer_data)"
+    f"(default: {_STORAGE_DEFAULT})"
 )
 
 

--- a/slayer/storage/base.py
+++ b/slayer/storage/base.py
@@ -1,9 +1,37 @@
 """Abstract storage protocol and factory."""
 
+import os
+import sys
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 from slayer.core.models import DatasourceConfig, SlayerModel
+
+
+def default_storage_path() -> str:
+    """Return the platform-appropriate default storage directory.
+
+    Resolution order:
+    1. $SLAYER_STORAGE environment variable (if set)
+    2. $SLAYER_MODELS_DIR environment variable (legacy, if set)
+    3. Platform default:
+       - Linux: $XDG_DATA_HOME/slayer (defaults to ~/.local/share/slayer)
+       - macOS: ~/Library/Application Support/slayer
+       - Windows: %LOCALAPPDATA%/slayer
+    """
+    env = os.environ.get("SLAYER_STORAGE") or os.environ.get("SLAYER_MODELS_DIR")
+    if env:
+        return env
+
+    if os.name == "nt":
+        base = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    elif sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    else:
+        base = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+
+    return str(base / "slayer")
 
 
 class StorageBackend(ABC):

--- a/slayer/storage/base.py
+++ b/slayer/storage/base.py
@@ -1,7 +1,6 @@
 """Abstract storage protocol and factory."""
 
 import os
-import sys
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
@@ -25,10 +24,10 @@ def default_storage_path() -> str:
         return env
 
     if os.name == "nt":
+        # Windows
         base = Path(os.getenv("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
-    elif sys.platform == "darwin":
-        base = Path.home() / "Library" / "Application Support"
     else:
+        # MacOS, Linux, etc.
         base = Path(os.getenv("XDG_DATA_HOME", Path.home() / ".local" / "share"))
 
     return str(base / "slayer")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-specific default storage locations (Linux, macOS, Windows) with ability to override via $SLAYER_STORAGE; CLI now displays the resolved default.

* **Documentation**
  * Simplified API and MCP startup examples—no explicit storage flag required.
  * Added storage configuration guide with default-location mapping and updated MCP registration examples.

* **Roadmap**
  * Marked "Smart output formatting" as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->