### PR TITLE
Log underlying DBAPI exception + SQL excerpt on transient DB retries

### DIFF
--- a/slayer/sql/client.py
+++ b/slayer/sql/client.py
@@ -333,7 +333,8 @@ async def _execute_with_retry_async(
             # warning is actionable. `exc.orig` carries the driver's
             # exception (e.g. sqlite3.OperationalError("database is locked"));
             # without it the warning was uninformative.
-            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            sql_lines = (sql or "").strip().splitlines()
+            sql_excerpt = sql_lines[0][:120] if sql_lines else "<empty sql>"
             logger.warning(
                 "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
                 attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,
@@ -393,7 +394,8 @@ async def _execute_with_retry_threaded(
             # warning is actionable. `exc.orig` carries the driver's
             # exception (e.g. sqlite3.OperationalError("database is locked"));
             # without it the warning was uninformative.
-            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            sql_lines = (sql or "").strip().splitlines()
+            sql_excerpt = sql_lines[0][:120] if sql_lines else "<empty sql>"
             logger.warning(
                 "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
                 attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,
@@ -428,7 +430,8 @@ def _execute_with_retry_sync(
         except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
             if attempt == max_attempts - 1:
                 raise
-            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            sql_lines = (sql or "").strip().splitlines()
+            sql_excerpt = sql_lines[0][:120] if sql_lines else "<empty sql>"
             logger.warning(
                 "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
                 attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,

--- a/slayer/sql/client.py
+++ b/slayer/sql/client.py
@@ -326,10 +326,18 @@ async def _execute_with_retry_async(
                 db_type=db_type,
                 timeout_seconds=timeout_seconds,
             )
-        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError):
+        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
             if attempt == max_attempts - 1:
                 raise
-            logger.warning("Transient DB error on attempt %d, retrying in %.1fs", attempt + 1, delay)
+            # Log the underlying DBAPI message + a SQL excerpt so the
+            # warning is actionable. `exc.orig` carries the driver's
+            # exception (e.g. sqlite3.OperationalError("database is locked"));
+            # without it the warning was uninformative.
+            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            logger.warning(
+                "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
+                attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,
+            )
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_delay)
 
@@ -378,10 +386,18 @@ async def _execute_with_retry_threaded(
                 db_type,
                 timeout_seconds,
             )
-        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError):
+        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
             if attempt == max_attempts - 1:
                 raise
-            logger.warning("Transient DB error on attempt %d, retrying in %.1fs", attempt + 1, delay)
+            # Log the underlying DBAPI message + a SQL excerpt so the
+            # warning is actionable. `exc.orig` carries the driver's
+            # exception (e.g. sqlite3.OperationalError("database is locked"));
+            # without it the warning was uninformative.
+            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            logger.warning(
+                "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
+                attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,
+            )
             await asyncio.sleep(delay)
             delay = min(delay * 2, max_delay)
 
@@ -409,10 +425,14 @@ def _execute_with_retry_sync(
                 db_type=db_type,
                 timeout_seconds=timeout_seconds,
             )
-        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError):
+        except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
             if attempt == max_attempts - 1:
                 raise
-            logger.warning("Transient DB error on attempt %d, retrying in %.1fs", attempt + 1, delay)
+            sql_excerpt = (sql or "").strip().splitlines()[0][:120]
+            logger.warning(
+                "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s",
+                attempt + 1, delay, getattr(exc, "orig", exc), sql_excerpt,
+            )
             time.sleep(delay)
             delay = min(delay * 2, max_delay)
 

--- a/tests/test_sql_client.py
+++ b/tests/test_sql_client.py
@@ -1,6 +1,17 @@
-"""Tests for SQL client type code mapping."""
+"""Tests for SQL client helpers (type code mapping, retry-warning formatting)."""
 
-from slayer.sql.client import _map_type_code
+import logging
+
+import pytest
+import sqlalchemy.exc
+
+from slayer.sql import client as sql_client
+from slayer.sql.client import (
+    _execute_with_retry_async,
+    _execute_with_retry_sync,
+    _execute_with_retry_threaded,
+    _map_type_code,
+)
 
 
 class TestMapTypeCode:
@@ -84,3 +95,117 @@ class TestMapTypeCode:
     def test_mysql_decimal_oid(self) -> None:
         """MySQL MYSQL_TYPE_DECIMAL = 0."""
         assert _map_type_code(0, db_type="mysql") == "number"
+
+
+def _make_op_error() -> sqlalchemy.exc.OperationalError:
+    """A minimal OperationalError that mimics a transient driver failure."""
+    return sqlalchemy.exc.OperationalError(
+        "SELECT 1", {}, Exception("database is locked"),
+    )
+
+
+class TestRetryEmptySqlExcerpt:
+    """Empty/whitespace SQL must not raise IndexError when the retry warning fires.
+
+    Regression test for the bug where `(sql or "").strip().splitlines()[0]`
+    crashed inside the except handler, masking the real transient DB error.
+    """
+
+    @pytest.mark.parametrize("sql", ["", "   \n  "])
+    async def test_async_empty_sql_logs_placeholder_and_retries(
+        self,
+        sql: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        calls = {"n": 0}
+
+        async def fake_execute(**kwargs: object) -> list:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _make_op_error()
+            return [{"ok": 1}]
+
+        monkeypatch.setattr(sql_client, "_execute_sql_async", fake_execute)
+
+        with caplog.at_level(logging.WARNING, logger="slayer.sql.client"):
+            result = await _execute_with_retry_async(
+                sql=sql,
+                engine=None,
+                db_type="postgres",
+                initial_delay=0.0,
+                max_delay=0.0,
+            )
+
+        assert result == [{"ok": 1}]
+        assert calls["n"] == 2
+        assert any(
+            "Transient DB error" in rec.getMessage() and "<empty sql>" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    @pytest.mark.parametrize("sql", ["", "   \n  "])
+    async def test_threaded_empty_sql_logs_placeholder_and_retries(
+        self,
+        sql: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        calls = {"n": 0}
+
+        def fake_execute(*args: object, **kwargs: object) -> list:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _make_op_error()
+            return [{"ok": 1}]
+
+        monkeypatch.setattr(sql_client, "_execute_sql_sync", fake_execute)
+
+        with caplog.at_level(logging.WARNING, logger="slayer.sql.client"):
+            result = await _execute_with_retry_threaded(
+                sql=sql,
+                connection_string="sqlite:///:memory:",
+                db_type="sqlite",
+                initial_delay=0.0,
+                max_delay=0.0,
+            )
+
+        assert result == [{"ok": 1}]
+        assert calls["n"] == 2
+        assert any(
+            "Transient DB error" in rec.getMessage() and "<empty sql>" in rec.getMessage()
+            for rec in caplog.records
+        )
+
+    @pytest.mark.parametrize("sql", ["", "   \n  "])
+    def test_sync_empty_sql_logs_placeholder_and_retries(
+        self,
+        sql: str,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        calls = {"n": 0}
+
+        def fake_execute(*args: object, **kwargs: object) -> list:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _make_op_error()
+            return [{"ok": 1}]
+
+        monkeypatch.setattr(sql_client, "_execute_sql_sync", fake_execute)
+
+        with caplog.at_level(logging.WARNING, logger="slayer.sql.client"):
+            result = _execute_with_retry_sync(
+                sql=sql,
+                connection_string="sqlite:///:memory:",
+                db_type="sqlite",
+                initial_delay=0.0,
+                max_delay=0.0,
+            )
+
+        assert result == [{"ok": 1}]
+        assert calls["n"] == 2
+        assert any(
+            "Transient DB error" in rec.getMessage() and "<empty sql>" in rec.getMessage()
+            for rec in caplog.records
+        )


### PR DESCRIPTION
The "Transient DB error on attempt N, retrying" warning was emitted without the actual exception text or any hint about which query failed, making the warning useless for debugging. Bird-interact runs saw repeated occurrences of this on every slayer-leg task with no way to tell whether it was "database is locked" (concurrency) or a SQL construction bug — both share the OperationalError class.

Add `getattr(exc, "orig", exc)` (the driver's underlying exception, e.g. sqlite3.OperationalError("database is locked")) and a 120-char SQL excerpt to the warning. Applied to both the async and threaded-sync retry loops in `slayer/sql/client.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for transient database connection failures: warnings now include underlying driver error details and a concise SQL excerpt to aid troubleshooting.
* **Tests**
  * Expanded test coverage for retry behavior, including cases with empty or whitespace SQL to validate logging and retry semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->