### PR TITLE
S4: align auto-ingestion + dbt converter with v2 schema

### DIFF
--- a/docs/dbt/dbt_import.md
+++ b/docs/dbt/dbt_import.md
@@ -50,72 +50,103 @@ joins:
     join_pairs: [["customer_id", "id"]]
 ```
 
-### Measures — Aggregation at Query Time
+### Measures — Column + ModelMeasure Split
 
-dbt bakes aggregation into each measure (`agg: sum`). SLayer separates them — measures are row-level expressions, aggregation is specified at query time.
+dbt bakes aggregation into each measure (`agg: sum`). SLayer separates them — a row-level expression lives on a `Column`, and the aggregation is named on a `ModelMeasure` formula.
 
-The converter stores the dbt aggregation in `allowed_aggregations`:
+Each unique SQL expression among the dbt measures of a semantic model becomes one SLayer `Column`; each dbt measure becomes one `ModelMeasure` whose formula references that column with the colon aggregation:
 
 ```yaml
 # dbt: {name: revenue, agg: sum, expr: amount}
-# SLayer: {name: revenue, sql: amount, allowed_aggregations: [sum]}
+# SLayer:
+columns:
+  - name: amount
+    type: number
+    format: {type: float}
+measures:
+  - name: revenue
+    formula: amount:sum
 ```
 
-Use `--no-strict-aggregations` to allow all aggregation types on imported measures.
+When the dbt expression is a SQL fragment rather than a bare identifier (e.g. `amount * quantity`), the Column is named `<first_dbt_measure_name>_col`:
+
+```yaml
+# dbt: {name: line_total, agg: sum, expr: amount * quantity}
+columns:
+  - name: line_total_col
+    sql: amount * quantity
+    type: number
+    format: {type: float}
+measures:
+  - name: line_total
+    formula: line_total_col:sum
+```
+
+If the natural Column name would collide with a `ModelMeasure` name on the same model, the Column is suffixed with `_col`. The dbt measure's `label` and `description` are written verbatim onto the `ModelMeasure` only — never onto the underlying `Column`.
 
 ### Measure Consolidation
 
-When multiple dbt measures share the same SQL expression but differ only in aggregation type, they are consolidated into a single SLayer measure with multiple `allowed_aggregations`. The original name:aggregation pairs are listed in the description:
+When multiple dbt measures share the same SQL expression but differ in aggregation, they collapse into a single SLayer Column; each dbt measure still becomes its own ModelMeasure:
 
 ```yaml
 # dbt: {name: revenue_sum, agg: sum, expr: amount} + {name: revenue_avg, agg: average, expr: amount}
-# SLayer:
-- name: amount
-  sql: amount
-  allowed_aggregations: [sum, avg]
-  description: "dbt measures: revenue_sum (sum), revenue_avg (average)"
+columns:
+  - name: amount
+    type: number
+    format: {type: float}
+measures:
+  - name: revenue_sum
+    formula: amount:sum
+  - name: revenue_avg
+    formula: amount:avg
 ```
 
 ### Metrics
 
-dbt metrics are handled differently depending on their type:
+dbt metrics fold into `ModelMeasure` formulas on their source semantic model. No separate query file is produced.
 
 #### Simple metrics (with filter)
 
-Converted to a **filtered measure** on the base model. The dbt Jinja filter syntax is converted to a SLayer filter string:
+Converted to a `Column` carrying the filter (with no `allowed_aggregations` whitelist) plus a `ModelMeasure` referencing it:
 
 ```yaml
 # dbt metric: loss_payment_amount (filter: has_loss_payment = 1)
-# SLayer measure added to the claim_amount model:
-- name: loss_payment_amount
-  sql: claim_amount
-  filter: "has_loss_payment = 1"
-  allowed_aggregations: [sum]
+columns:
+  - name: loss_payment_amount_col
+    sql: claim_amount
+    type: number
+    format: {type: float}
+    filter: "has_loss_payment = 1"
+measures:
+  - name: loss_payment_amount
+    formula: loss_payment_amount_col:sum
 ```
 
-At query time, `loss_payment_amount:sum` generates:
+At query time, `loss_payment_amount` generates:
+
 ```sql
 SUM(CASE WHEN has_loss_payment = 1 THEN claim_amount END)
 ```
 
 #### Simple metrics (without filter)
 
-Nothing to add — the underlying measure is already directly queryable in SLayer.
+Nothing to add — the underlying measure is already directly queryable.
 
-#### Derived, ratio, and cumulative metrics → `queries.yaml`
+#### Derived / ratio / cumulative metrics → `ModelMeasure`
 
-These don't map to model-level constructs. They are converted to SlayerQuery definitions and written to a separate `queries.yaml` file:
+All three fold into a `ModelMeasure` on the source semantic model. Inputs are referenced by **bare ModelMeasure name**, so the formula parser resolves them locally:
 
-- **Derived**: `{"formula": "metric_a:sum + metric_b:sum", "name": "combined"}`
-- **Ratio**: `{"formula": "numerator:sum / denominator:sum", "name": "ratio"}`
-- **Cumulative (unbounded)**: `{"formula": "cumsum(measure:agg)", "name": "running_total"}`
+- **Derived**: `formula: "metric_a + metric_b"`
+- **Ratio**: `formula: "numerator / denominator"`
+- **Cumulative (unbounded)**: `formula: "cumsum(measure_name)"`
 
-These can be executed via the SLayer API/MCP or used as templates for building queries.
+#### Unconverted metrics
 
-#### Unsupported metric types
+Some dbt metrics cannot be expressed as a `ModelMeasure`. They are reported in `ConversionResult.unconverted_metrics` and printed with an `UNCONVERTED` tag. Categories:
 
-- **Cumulative with window or grain_to_date**: warning emitted (SLayer's `cumsum` is unbounded)
-- **Conversion metrics**: warning emitted (entity-based sequential event tracking not supported)
+- **Cumulative with window or grain_to_date**: SLayer's `cumsum` is unbounded.
+- **Conversion metrics**: entity-based sequential event tracking is not supported.
+- **Transform-name shadowing**: a dbt measure or metric named after a SLayer transform (`cumsum`, `lag`, `lead`, `change`, `change_pct`, `time_shift`, `rank`, `first`, `last`) is rejected — using it bare in a formula would shadow the transform.
 
 ## Filter Syntax Conversion
 
@@ -133,12 +164,11 @@ The converter resolves these to plain SLayer filter strings:
 - `TimeDimension('name', 'grain')` → `name` (granularity is query-time in SLayer)
 - `Entity('name')` → the entity's SQL expression column name
 
-## Output Files
+## Output
 
 The converter produces:
-1. **Model YAML files** in `models/` — one per dbt semantic model
-2. **`queries.yaml`** — SlayerQuery definitions for derived/ratio/cumulative metrics (if any)
-3. **Console report** — summary of models imported, queries generated, and warnings
+1. **Model YAML files** (or rows in SQLite storage) — one per dbt semantic model. Every metric folds into a `ModelMeasure` on its source model.
+2. **Console report** — summary of models imported, unconverted metrics, and warnings.
 
 ## Regular dbt Models (Hidden Import)
 
@@ -217,8 +247,11 @@ Arguments:
 Options:
   --datasource NAME         SLayer datasource name for imported models (required)
   --storage PATH            Storage directory for output (default: ./slayer_data)
-  --no-strict-aggregations  Allow all aggregation types (don't restrict to dbt's defined agg)
   --include-hidden-models   Also import regular dbt models (not wrapped by a
                             semantic_model) as hidden SLayer models via SQL
                             introspection. Requires the `dbt` extra.
 ```
+
+## Hard Failures
+
+The converter raises `DbtConversionError` (and aborts) when a dbt semantic model defines both a dimension and a measure with the same name. SLayer columns and named measures share a single namespace per model, so the names must be disjoint — rename one side in the dbt project.

--- a/docs/interfaces/cli.md
+++ b/docs/interfaces/cli.md
@@ -114,7 +114,6 @@ slayer import-dbt ./my_dbt_project --datasource my_postgres --include-hidden-mod
 |------|----------|-------------|
 | `dbt_project_path` | Yes | Path to the dbt project root (or a models directory) |
 | `--datasource` | Yes | SLayer datasource name for the imported models |
-| `--no-strict-aggregations` | No | Don't restrict measures to their dbt-defined aggregation types |
 | `--include-hidden-models` | No | Also import regular dbt models (those not wrapped by a `semantic_model`) as hidden SLayer models via SQL introspection. Requires the `dbt` extra. |
 | `--storage` | No | Storage path |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -117,7 +117,6 @@ slayer import-dbt ./my_dbt_project --datasource my_postgres --include-hidden-mod
 |------|----------|-------------|
 | `dbt_project_path` | Yes | Path to the dbt project root (or a models directory) |
 | `--datasource` | Yes | SLayer datasource name for the imported models |
-| `--no-strict-aggregations` | No | Don't restrict measures to their dbt-defined aggregation types |
 | `--include-hidden-models` | No | Also import regular dbt models (those not wrapped by a `semantic_model`) as hidden SLayer models via SQL introspection. Requires the `dbt` extra (`pip install 'motley-slayer[dbt]'`). See [dbt Import](../dbt/dbt_import.md#regular-dbt-models-hidden-import). |
 | `--storage` | No | Storage path |
 

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -727,6 +727,33 @@ def _confirm(prompt: str, *, assume_yes: bool) -> bool:
     return answer in ("y", "yes")
 
 
+def _persist_ingested_models(models, storage, *, assume_yes: bool, pre_save=None) -> None:
+    """Persist freshly-ingested models, after a collision-confirmation prompt.
+
+    Used by both ``datasources create`` (with ``--ingest``) and
+    ``datasources create demo --ingest``. ``pre_save`` is an optional hook
+    called once per model just before saving — the demo path uses it to
+    apply ``default_time_dimension`` overrides.
+    """
+    if not models:
+        print("No models were generated.")
+        return
+
+    colliding = [m.name for m in models if run_sync(storage.get_model(m.name)) is not None]
+    if colliding and not _confirm(
+        f"Models already exist and will be overwritten: {', '.join(colliding)}. Continue?",
+        assume_yes=assume_yes,
+    ):
+        print("Aborted before writing models.")
+        sys.exit(1)
+
+    for model in models:
+        if pre_save is not None:
+            pre_save(model)
+        run_sync(storage.save_model(model))
+        print(f"Ingested: {model.name} ({len(model.columns)} columns, {len(model.measures)} measures)")
+
+
 def _run_datasources_create(args, storage):
     if (args.connection_string or "").strip().lower() == "demo":
         _run_datasources_create_demo(args, storage)
@@ -779,21 +806,7 @@ def _run_datasources_create(args, storage):
         print(f"Ingestion failed: {e}")
         sys.exit(1)
 
-    if not models:
-        print("No models were generated.")
-        return
-
-    colliding = [m.name for m in models if run_sync(storage.get_model(m.name)) is not None]
-    if colliding and not _confirm(
-        f"Models already exist and will be overwritten: {', '.join(colliding)}. Continue?",
-        assume_yes=args.yes,
-    ):
-        print("Aborted before writing models.")
-        sys.exit(1)
-
-    for model in models:
-        run_sync(storage.save_model(model))
-        print(f"Ingested: {model.name} ({len(model.columns)} columns, {len(model.measures)} measures)")
+    _persist_ingested_models(models, storage, assume_yes=args.yes)
 
 
 def _run_datasources_create_demo(args, storage):
@@ -856,23 +869,13 @@ def _run_datasources_create_demo(args, storage):
         print(f"Ingestion failed: {e}")
         sys.exit(1)
 
-    if not models:
-        print("No models were generated.")
-        return
-
-    colliding = [m.name for m in models if run_sync(storage.get_model(m.name)) is not None]
-    if colliding and not _confirm(
-        f"Models already exist and will be overwritten: {', '.join(colliding)}. Continue?",
-        assume_yes=args.yes,
-    ):
-        print("Aborted before writing models.")
-        sys.exit(1)
-
-    for model in models:
+    def _apply_demo_time_dim(model):
         if model.name in DEFAULT_TIME_DIMENSIONS:
             model.default_time_dimension = DEFAULT_TIME_DIMENSIONS[model.name]
-        run_sync(storage.save_model(model))
-        print(f"Ingested: {model.name} ({len(model.columns)} columns, {len(model.measures)} measures)")
+
+    _persist_ingested_models(
+        models, storage, assume_yes=args.yes, pre_save=_apply_demo_time_dim
+    )
 
 
 if __name__ == "__main__":

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from slayer.async_utils import run_sync
-from slayer.storage.base import default_storage_path, storage_base_dir
+from slayer.storage.base import default_storage_path
 
 _STORAGE_DEFAULT = default_storage_path()
 _STORAGE_HELP = (
@@ -30,11 +30,6 @@ def _resolve_storage(args):
 
     path = args.storage or args.models_dir or _STORAGE_DEFAULT
     return resolve_storage(path)
-
-
-def _queries_dir_for_storage(storage_path: str) -> str:
-    """Return the directory where queries.yaml should be written."""
-    return storage_base_dir(storage_path)
 
 
 def main():
@@ -188,11 +183,6 @@ examples:
     )
     import_dbt_parser.add_argument("dbt_project_path", help="Path to dbt project root or models directory")
     import_dbt_parser.add_argument("--datasource", required=True, help="SLayer datasource name for the imported models")
-    import_dbt_parser.add_argument(
-        "--no-strict-aggregations",
-        action="store_true",
-        help="Don't restrict measures to their dbt-defined aggregation types",
-    )
     import_dbt_parser.add_argument(
         "--include-hidden-models",
         action="store_true",
@@ -503,7 +493,6 @@ def _run_ingest(args):
 
 def _run_import_dbt(args):
     import sqlalchemy as sa
-    import yaml as _yaml
 
     from slayer.dbt.converter import DbtToSlayerConverter
     from slayer.dbt.parser import parse_dbt_project
@@ -535,7 +524,6 @@ def _run_import_dbt(args):
         converter = DbtToSlayerConverter(
             project=project,
             data_source=args.datasource,
-            strict_aggregations=not args.no_strict_aggregations,
             sa_engine=sa_engine,
             include_hidden_models=include_hidden,
         )
@@ -544,7 +532,6 @@ def _run_import_dbt(args):
         if sa_engine is not None:
             sa_engine.dispose()
 
-    # Save models
     hidden_count = 0
     for model in result.models:
         run_sync(storage.save_model(model))
@@ -556,17 +543,10 @@ def _run_import_dbt(args):
             f"({len(model.columns)} columns, {len(model.measures)} measures)"
         )
 
-    # Save queries to queries.yaml if any
-    if result.queries:
-        storage_path = args.storage or args.models_dir or _STORAGE_DEFAULT
-        queries_dir = _queries_dir_for_storage(storage_path)
-        os.makedirs(queries_dir, exist_ok=True)
-        queries_path = os.path.join(queries_dir, "queries.yaml")
-        with open(queries_path, "w", encoding="utf-8") as f:
-            _yaml.dump(result.queries, f, sort_keys=False, default_flow_style=False)
-        print(f"Generated {len(result.queries)} metric queries → {queries_path}")
+    for u in result.unconverted_metrics:
+        context = u.model_name or u.metric_name or "general"
+        print(f"  UNCONVERTED [{context}]: {u.message}")
 
-    # Print warnings
     for w in result.warnings:
         context = w.model_name or w.metric_name or "general"
         print(f"  WARNING [{context}]: {w.message}")
@@ -574,7 +554,8 @@ def _run_import_dbt(args):
     visible_count = len(result.models) - hidden_count
     print(
         f"\nDone: {visible_count} models, {hidden_count} hidden, "
-        f"{len(result.queries)} queries, {len(result.warnings)} warnings"
+        f"{len(result.unconverted_metrics)} unconverted metrics, "
+        f"{len(result.warnings)} warnings"
     )
 
 

--- a/slayer/dbt/converter.py
+++ b/slayer/dbt/converter.py
@@ -30,6 +30,7 @@ from slayer.dbt.models import (
     DbtDimension,
     DbtMeasure,
     DbtMetric,
+    DbtMetricTypeParams,
     DbtProject,
     DbtRegularModel,
     DbtSemanticModel,
@@ -753,77 +754,83 @@ class DbtToSlayerConverter:
     def _find_metric_source_model(self, metric: DbtMetric) -> Optional[str]:
         """Determine the source model for a metric.
 
-        Walks ``measure``, then ``metrics``, then ``numerator``/``denominator``
-        to support all metric shapes that reference an underlying measure.
+        Walks ``measure``, ``metrics``, and ``numerator``/``denominator`` and
+        returns the unique source semantic-model name. When the metric's
+        inputs span multiple semantic models, returns ``None`` so the caller
+        routes the metric to ``unconverted_metrics`` rather than silently
+        anchoring it to whichever model is discovered first.
         """
         if metric.type_params is None:
             return None
+        sources = self._collect_metric_sources_from_params(metric.type_params)
+        return next(iter(sources)) if len(sources) == 1 else None
 
-        if metric.type_params.measure:
-            sm = self._find_measure_model(metric.type_params.measure)
-            if sm:
-                return sm.name
+    def _collect_metric_sources(self, metric_name: str, _seen: Optional[set] = None) -> set:
+        """Collect every distinct semantic-model name a metric ultimately resolves to.
 
-        if metric.type_params.metrics:
-            for m_input in metric.type_params.metrics:
-                source = self._resolve_metric_source(m_input.name)
-                if source:
-                    return source
-
-        # Q-E: ratio metrics carry numerator/denominator, not metrics=[…].
-        for side in (metric.type_params.numerator, metric.type_params.denominator):
-            if side is None:
-                continue
-            source = self._resolve_metric_source(side.name)
-            if source:
-                return source
-
-        return None
-
-    def _resolve_metric_source(self, metric_name: str) -> Optional[str]:
-        """Recursively resolve a metric name to its source model.
-
-        First tries the metric's own ``measure`` (simple), then descends into
-        ``numerator``/``denominator`` (ratio), then ``metrics`` (derived).
-        Falls back to looking up ``metric_name`` as a dbt measure directly.
+        Recurses through derived (``metrics``) and ratio
+        (``numerator``/``denominator``) inputs. Falls back to looking
+        ``metric_name`` up as a dbt measure when no metric of that name
+        exists. ``_seen`` guards against pathological metric cycles.
         """
+        seen = _seen if _seen is not None else set()
+        if metric_name in seen:
+            return set()
+        seen = seen | {metric_name}
+
         for m in self.project.metrics:
             if m.name != metric_name:
                 continue
             if m.type_params is None:
-                return None
-            if m.type_params.measure:
-                sm = self._find_measure_model(m.type_params.measure)
-                if sm:
-                    return sm.name
-            for side in (m.type_params.numerator, m.type_params.denominator):
-                if side is None:
-                    continue
-                source = self._resolve_metric_source(side.name)
-                if source:
-                    return source
-            if m.type_params.metrics:
-                for m_input in m.type_params.metrics:
-                    source = self._resolve_metric_source(m_input.name)
-                    if source:
-                        return source
-            return None
-        # ``metric_name`` may be a bare dbt measure name rather than a metric.
+                return set()
+            return self._collect_metric_sources_from_params(m.type_params, seen=seen)
+
         sm = self._find_measure_model(metric_name)
-        return sm.name if sm else None
+        return {sm.name} if sm else set()
+
+    def _collect_metric_sources_from_params(
+        self, type_params: DbtMetricTypeParams, *, seen: Optional[set] = None
+    ) -> set:
+        """Shared shape-walker used by both entry points above."""
+        sources: set = set()
+        if type_params.measure:
+            sm = self._find_measure_model(type_params.measure)
+            if sm:
+                sources.add(sm.name)
+        if type_params.metrics:
+            for m_input in type_params.metrics:
+                sources |= self._collect_metric_sources(m_input.name, _seen=seen)
+        for side in (type_params.numerator, type_params.denominator):
+            if side is None:
+                continue
+            sources |= self._collect_metric_sources(side.name, _seen=seen)
+        return sources
 
     def _resolve_metric_to_name(self, metric_name: str) -> Optional[str]:
         """Resolve a metric name to a formula reference.
 
         Returns the bare ``ModelMeasure`` name when the metric was lowered
-        into a ``ModelMeasure`` (simple, derived, ratio, cumulative). Falls
-        back to the ``column:agg`` colon form when ``metric_name`` is a dbt
-        measure rather than a metric.
+        into a ``ModelMeasure`` (filtered simple, derived, ratio, cumulative).
+        For an *unfiltered* simple metric — which ``_convert_simple_metric``
+        deliberately does not materialize — resolves to the backing dbt
+        measure name instead, since that is what's actually addressable on
+        the model. Falls back to ``_resolve_measure_to_name`` when
+        ``metric_name`` is a dbt measure rather than a metric.
         """
         for m in self.project.metrics:
-            if m.name == metric_name:
-                # All metric kinds are stored as ModelMeasures named after the metric.
-                return metric_name
+            if m.name != metric_name:
+                continue
+            if (
+                m.type
+                and m.type.lower() == "simple"
+                and not m.filter
+                and m.type_params is not None
+                and m.type_params.measure
+            ):
+                # Unfiltered simple metric was not materialized — point at
+                # the backing measure's ModelMeasure on its own model.
+                return self._resolve_measure_to_name(m.type_params.measure)
+            return metric_name
         return self._resolve_measure_to_name(metric_name)
 
     def _resolve_measure_to_name(self, measure_name: str) -> Optional[str]:

--- a/slayer/dbt/converter.py
+++ b/slayer/dbt/converter.py
@@ -1,19 +1,29 @@
-"""Convert a parsed DbtProject into SLayer models and query definitions.
+"""Convert a parsed DbtProject into SLayer models.
 
-Orchestrates the full pipeline: entity resolution, dimension/measure conversion,
-measure consolidation, metric-to-measure and metric-to-query generation.
+Orchestrates the full pipeline: entity resolution, dimension/measure
+conversion, measure consolidation (one ``Column`` per unique expr +
+one ``ModelMeasure`` per dbt measure), and folding of metric definitions
+(simple-with-filter / derived / ratio / cumulative) into ``ModelMeasure``
+entries on the source semantic model.
+
+The converter never emits ``SlayerQuery`` definitions: every dbt artefact
+that produces a query-shaped result is expressed as a named formula on a
+model. Metrics that cannot be expressed that way (e.g. transform-name
+collisions, conversion metrics) are returned in
+``ConversionResult.unconverted_metrics``.
 """
 
 import logging
 import re
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import sqlalchemy as sa
 from pydantic import BaseModel, Field
 
 from slayer.core.enums import DataType, JoinType
-from slayer.core.models import Column, ModelJoin, SlayerModel
+from slayer.core.format import NumberFormat, NumberFormatType
+from slayer.core.models import Column, ModelJoin, ModelMeasure, SlayerModel
 from slayer.dbt.entities import EntityRegistry
 from slayer.dbt.filters import convert_dbt_filter
 from slayer.dbt.models import (
@@ -43,6 +53,17 @@ _AGG_MAP: Dict[str, str] = {
     "sum_boolean": "sum",
 }
 
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_FLOAT_FORMAT = NumberFormat(type=NumberFormatType.FLOAT)
+
+
+class DbtConversionError(Exception):
+    """Raised when a dbt project cannot be converted to SLayer shape.
+
+    The message includes the offending semantic-model name and the
+    colliding identifiers so the user can fix the dbt definitions.
+    """
+
 
 class ConversionWarning(BaseModel):
     """A warning or info message from the conversion process."""
@@ -54,7 +75,7 @@ class ConversionWarning(BaseModel):
 class ConversionResult(BaseModel):
     """Result of converting a DbtProject to SLayer representations."""
     models: List[SlayerModel] = Field(default_factory=list)
-    queries: List[dict] = Field(default_factory=list)  # SlayerQuery dicts for metrics
+    unconverted_metrics: List[ConversionWarning] = Field(default_factory=list)
     warnings: List[ConversionWarning] = Field(default_factory=list)
 
 
@@ -65,6 +86,11 @@ def _map_agg(dbt_agg: str) -> str:
         logger.warning("Unknown dbt aggregation '%s', passing through as-is", dbt_agg)
         return dbt_agg.lower()
     return mapped
+
+
+def _is_simple_identifier(s: str) -> bool:
+    """A bare SQL column reference (no operators, calls, or dots)."""
+    return bool(_IDENTIFIER_RE.match(s))
 
 
 def _convert_dimension(dim: DbtDimension) -> Column:
@@ -87,98 +113,102 @@ def _convert_dimension(dim: DbtDimension) -> Column:
 
 def _convert_measures(
     dbt_measures: List[DbtMeasure],
-    strict_aggregations: bool,
-) -> List[Column]:
-    """Convert dbt measures to SLayer columns with consolidation.
+    *,
+    sm_name: str,
+    existing_column_names: set,
+    unconverted: List[ConversionWarning],
+) -> Tuple[List[Column], List[ModelMeasure]]:
+    """Convert dbt measures into a (Columns, ModelMeasures) pair.
 
-    Measures with the same expr are consolidated into one SLayer column
-    with multiple allowed_aggregations. Original name:agg pairs are listed
-    in the description. dbt measures imply numeric data, so the resulting
-    columns get DataType.NUMBER.
+    Each unique measure expression yields a single ``Column`` whose name is
+    either the bare expression (when it is a SQL identifier) or
+    ``<first_dbt_measure_name>_col`` (when the expression is a SQL fragment
+    like ``amount * quantity``). Each dbt measure yields one ``ModelMeasure``
+    whose formula is ``<col_name>:<agg>``. label and description live on the
+    ``ModelMeasure`` only — they belong to the named formula, not the raw
+    column.
+
+    Column-name collisions with already-emitted dimensions/entities or with
+    any of the about-to-be-emitted ``ModelMeasure`` names are resolved by
+    suffixing the Column with ``_col`` (Q-2 / Q-I in the S4 spec).
+
+    A ``ModelMeasure`` whose name shadows a built-in transform (e.g.
+    ``cumsum``) is rejected by the Pydantic validator; the dbt measure is
+    routed to ``unconverted`` and skipped.
     """
-    # Group by effective expr (expr or name if expr is None)
     groups: Dict[str, List[DbtMeasure]] = defaultdict(list)
     for m in dbt_measures:
         key = m.expr or m.name
         groups[key].append(m)
 
-    result: List[Column] = []
-    for expr_key, measures_in_group in groups.items():
-        if len(measures_in_group) == 1:
-            m = measures_in_group[0]
-            mapped_agg = _map_agg(m.agg)
-            sql = m.expr if m.expr and m.expr != m.name else None
-            allowed = [mapped_agg] if strict_aggregations else None
+    # All dbt-measure names, taken to be the eventual ``ModelMeasure`` names.
+    measure_names = {m.name for m in dbt_measures}
 
-            desc = m.description or ""
-            if desc and not desc.endswith("."):
-                desc += "."
-            desc = f"{desc} Default aggregation: {m.agg}".strip()
+    columns: List[Column] = []
+    measures: List[ModelMeasure] = []
+    used_column_names = set(existing_column_names)
 
-            result.append(Column(
-                name=m.name,
-                sql=sql,
-                type=DataType.NUMBER,
-                description=desc,
-                label=m.label,
-                allowed_aggregations=allowed,
-            ))
+    for expr_key, group in groups.items():
+        if _is_simple_identifier(expr_key):
+            base_name = expr_key
         else:
-            # Consolidate: multiple dbt measures → one SLayer column
-            aggs = []
-            name_agg_pairs = []
-            labels = []
-            descriptions = []
+            base_name = f"{group[0].name}_col"
 
-            for m in measures_in_group:
-                mapped = _map_agg(m.agg)
-                if mapped not in aggs:
-                    aggs.append(mapped)
-                name_agg_pairs.append(f"{m.name} ({m.agg})")
-                if m.label:
-                    labels.append(m.label)
-                if m.description:
-                    descriptions.append(m.description)
+        col_name = base_name
+        # Q-2: avoid collision with any ModelMeasure name in this model.
+        # Q-I: also avoid collision with the dimensions/entities already on
+        # the model, by suffixing ``_col`` until unique.
+        while col_name in measure_names or col_name in used_column_names:
+            col_name = f"{col_name}_col"
+        used_column_names.add(col_name)
 
-            # Use the first dbt measure's name; fall back to expr_key. Keep the
-            # SQL expression whenever it differs from the chosen name.
-            measure_name = measures_in_group[0].name or expr_key
-            sql = expr_key if expr_key != measure_name else None
+        sql = expr_key if expr_key != col_name else None
+        columns.append(Column(
+            name=col_name,
+            sql=sql,
+            type=DataType.NUMBER,
+            format=_FLOAT_FORMAT,
+        ))
 
-            desc = f"dbt measures: {', '.join(name_agg_pairs)}"
-            if descriptions:
-                desc = f"{descriptions[0]}. {desc}"
+        for m in group:
+            mapped_agg = _map_agg(m.agg)
+            try:
+                measures.append(ModelMeasure(
+                    name=m.name,
+                    formula=f"{col_name}:{mapped_agg}",
+                    label=m.label,
+                    description=m.description,
+                ))
+            except ValueError as exc:
+                unconverted.append(ConversionWarning(
+                    model_name=sm_name,
+                    metric_name=m.name,
+                    message=(
+                        f"dbt measure '{m.name}' could not be converted to a "
+                        f"ModelMeasure: {exc}"
+                    ),
+                ))
 
-            result.append(Column(
-                name=measure_name,
-                sql=sql,
-                type=DataType.NUMBER,
-                description=desc,
-                label=labels[0] if labels else None,
-                allowed_aggregations=aggs if strict_aggregations else None,
-            ))
-
-    return result
+    return columns, measures
 
 
 class DbtToSlayerConverter:
-    """Convert a DbtProject into SLayer models and query definitions."""
+    """Convert a DbtProject into SLayer models."""
 
     def __init__(
         self,
         project: DbtProject,
         data_source: str,
-        strict_aggregations: bool = True,
         sa_engine: Optional[sa.Engine] = None,
         include_hidden_models: bool = False,
     ) -> None:
         self.project = project
         self.data_source = data_source
-        self.strict_aggregations = strict_aggregations
         self.sa_engine = sa_engine
         self.include_hidden_models = include_hidden_models
         self.entity_registry = EntityRegistry()
         self._warnings: List[ConversionWarning] = []
+        self._unconverted: List[ConversionWarning] = []
         # {model_name: SlayerModel} for metric resolution
         self._models_by_name: Dict[str, SlayerModel] = {}
         # {model_name: DbtSemanticModel} for looking up entities
@@ -193,37 +223,28 @@ class DbtToSlayerConverter:
 
     def convert(self) -> ConversionResult:
         """Full conversion pipeline."""
-        # 1. Build entity registry
         self.entity_registry.build(self.project.semantic_models)
 
-        # 2. Index dbt models
         for sm in self.project.semantic_models:
             self._dbt_models_by_name[sm.name] = sm
 
-        # 3. Convert semantic models
         models: List[SlayerModel] = []
         for sm in self.project.semantic_models:
             model = self._convert_semantic_model(sm)
             models.append(model)
             self._models_by_name[model.name] = model
 
-        # 4. Convert metrics
-        queries: List[dict] = []
         for metric in self.project.metrics:
-            query = self._convert_metric(metric)
-            if query is not None:
-                queries.append(query)
+            self._convert_metric(metric)
 
-        # 5. Mirror inner joins: if A→B is inner, ensure B→A is inner too
         self._mirror_inner_joins()
 
-        # 6. Convert orphan regular dbt models into hidden SLayer models
         if self.include_hidden_models and self.project.regular_models:
             models.extend(self._convert_regular_models(existing_names={m.name for m in models}))
 
         return ConversionResult(
             models=models,
-            queries=queries,
+            unconverted_metrics=self._unconverted,
             warnings=self._warnings,
         )
 
@@ -249,11 +270,7 @@ class DbtToSlayerConverter:
                     ))
 
     def _convert_regular_models(self, existing_names: set) -> List[SlayerModel]:
-        """Convert orphan dbt models (not wrapped by semantic_models) to hidden SLayer models.
-
-        Requires a live SQLAlchemy engine for SQL introspection. If no engine was
-        provided, logs one warning and returns [].
-        """
+        """Convert orphan dbt models (not wrapped by semantic_models) to hidden SLayer models."""
         if self.sa_engine is None:
             self._warnings.append(ConversionWarning(
                 message=(
@@ -268,8 +285,6 @@ class DbtToSlayerConverter:
         results: List[SlayerModel] = []
         for rm in self.project.regular_models:
             if rm.name in existing_names:
-                # A semantic_model with the same name already produced a visible
-                # SLayer model; don't shadow it with a hidden import.
                 continue
             converted = self._convert_regular_model(rm=rm, sa_engine=engine, inspector=inspector)
             if converted is not None:
@@ -308,7 +323,6 @@ class DbtToSlayerConverter:
         if rm.description:
             model.description = rm.description
 
-        # Overlay column-level descriptions from dbt manifest onto columns.
         col_descriptions = {c.name: c.description for c in rm.columns if c.description}
         if col_descriptions:
             for c in model.columns:
@@ -321,12 +335,21 @@ class DbtToSlayerConverter:
     def _convert_semantic_model(self, sm: DbtSemanticModel) -> SlayerModel:
         """Convert a single dbt semantic model to a SlayerModel.
 
-        If the referenced dbt model is a regular model with a ``.sql`` body
-        on disk (i.e. a query, not a physical source table), inline the
-        resolved SQL into ``SlayerModel.sql`` so SLayer can query it directly
-        without requiring ``dbt run`` to have materialised it. Otherwise the
-        ref name is used as ``sql_table``.
+        Hard-fails (DbtConversionError) when the same name appears as both a
+        dimension and a measure on this semantic model — ambiguous, since v2
+        SLayer columns and measures share a namespace per model.
         """
+        # Q-G: hard-fail on dim/measure name collisions before doing any work.
+        dim_names = {d.name for d in sm.dimensions}
+        measure_names = {m.name for m in sm.measures}
+        collisions = sorted(dim_names & measure_names)
+        if collisions:
+            raise DbtConversionError(
+                f"Semantic model '{sm.name}': dimension and measure share name(s) "
+                f"{collisions}. SLayer columns and measures occupy a single "
+                f"namespace per model — rename one side in the dbt project."
+            )
+
         ref_name = sm.model or sm.name
 
         sql_source: Optional[str] = None
@@ -345,15 +368,13 @@ class DbtToSlayerConverter:
         else:
             sql_table = ref_name
 
-        # Default time dimension
         default_time_dim = None
         if sm.defaults and sm.defaults.agg_time_dimension:
             default_time_dim = sm.defaults.agg_time_dimension
 
-        # Convert dimensions to columns
         cols: List[Column] = [_convert_dimension(d) for d in sm.dimensions]
 
-        # Add primary key column for primary/unique entities
+        # Add primary key column for primary/unique entities.
         entity_col_names = {c.name for c in cols}
         for entity in sm.entities:
             if entity.type in ("primary", "unique"):
@@ -371,7 +392,6 @@ class DbtToSlayerConverter:
                         if c.name == col_name:
                             c.primary_key = True
 
-        # Also handle primary_entity shorthand
         if sm.primary_entity:
             pe_name = sm.primary_entity
             pe_expr = pe_name
@@ -387,19 +407,14 @@ class DbtToSlayerConverter:
                 ))
                 entity_col_names.add(pe_expr)
 
-        # Append converted measures (consolidated). Avoid name collisions with
-        # already-added entity/dimension columns by skipping duplicates.
-        existing_names = {c.name for c in cols}
-        for m_col in _convert_measures(
+        measure_cols, measures = _convert_measures(
             dbt_measures=sm.measures,
-            strict_aggregations=self.strict_aggregations,
-        ):
-            if m_col.name in existing_names:
-                continue
-            cols.append(m_col)
-            existing_names.add(m_col.name)
+            sm_name=sm.name,
+            existing_column_names={c.name for c in cols},
+            unconverted=self._unconverted,
+        )
+        cols.extend(measure_cols)
 
-        # Resolve joins from foreign entities
         joins = self.entity_registry.resolve_joins_for_model(sm)
 
         return SlayerModel(
@@ -410,72 +425,114 @@ class DbtToSlayerConverter:
             description=sm.description,
             default_time_dimension=default_time_dim,
             columns=cols,
+            measures=measures,
             joins=joins,
         )
 
-    def _convert_metric(self, metric: DbtMetric) -> Optional[dict]:
-        """Convert a dbt metric. Returns a query dict, or None if handled as a measure."""
+    # ── Metric conversion ─────────────────────────────────────────────
+
+    def _convert_metric(self, metric: DbtMetric) -> None:
+        """Route a dbt metric to the appropriate handler.
+
+        All handlers fold their output into a ``ModelMeasure`` on the source
+        semantic model (or report ``unconverted_metrics`` on failure). No
+        ``SlayerQuery`` is produced.
+        """
         metric_type = metric.type.lower()
 
         if metric_type == "simple":
-            return self._convert_simple_metric(metric)
+            self._convert_simple_metric(metric)
         elif metric_type == "derived":
-            return self._convert_derived_metric(metric)
+            self._convert_derived_metric(metric)
         elif metric_type == "ratio":
-            return self._convert_ratio_metric(metric)
+            self._convert_ratio_metric(metric)
         elif metric_type == "cumulative":
-            return self._convert_cumulative_metric(metric)
+            self._convert_cumulative_metric(metric)
         elif metric_type == "conversion":
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message="Conversion metrics are not supported in SLayer. Skipped.",
             ))
-            return None
         else:
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message=f"Unknown metric type '{metric.type}'. Skipped.",
             ))
-            return None
 
-    def _convert_simple_metric(self, metric: DbtMetric) -> Optional[dict]:
-        """Convert a simple metric to a filtered measure on the base model."""
-        if not metric.type_params or not metric.type_params.measure:
+    def _add_model_measure(
+        self,
+        *,
+        slayer_model: SlayerModel,
+        metric: DbtMetric,
+        formula: str,
+    ) -> None:
+        """Append a ``ModelMeasure`` to ``slayer_model``.
+
+        Routes transform-name collisions (Q-F) to ``unconverted_metrics``
+        instead of raising. Skips silently with a warning if the name
+        collides with an existing column or measure on the model.
+        """
+        existing_names = {c.name for c in slayer_model.columns}
+        existing_names.update(m.name for m in slayer_model.measures if m.name is not None)
+        if metric.name in existing_names:
             self._warnings.append(ConversionWarning(
+                model_name=slayer_model.name,
+                metric_name=metric.name,
+                message=(
+                    f"Metric '{metric.name}' collides with an existing column or "
+                    f"measure on model '{slayer_model.name}'. Skipped."
+                ),
+            ))
+            return
+        try:
+            slayer_model.measures.append(ModelMeasure(
+                name=metric.name,
+                formula=formula,
+                label=metric.label,
+                description=metric.description,
+            ))
+        except ValueError as exc:
+            self._unconverted.append(ConversionWarning(
+                model_name=slayer_model.name,
+                metric_name=metric.name,
+                message=(
+                    f"Metric '{metric.name}' could not be converted to a "
+                    f"ModelMeasure: {exc}"
+                ),
+            ))
+
+    def _convert_simple_metric(self, metric: DbtMetric) -> None:
+        """A simple metric is a (filtered) re-aggregation of a single measure.
+
+        Without a filter: nothing to do — the underlying measure is already
+        addressable as a ModelMeasure. With a filter: emit a Column carrying
+        the CASE-WHEN ``filter`` and a ModelMeasure pointing at it.
+        """
+        if not metric.type_params or not metric.type_params.measure:
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message="Simple metric has no measure reference. Skipped.",
             ))
-            return None
+            return
 
         measure_name = metric.type_params.measure
 
         if not metric.filter:
-            # No filter — the measure is already queryable. Nothing to add.
-            return None
+            return
 
-        # Find which semantic model owns this measure
         source_sm = self._find_measure_model(measure_name)
         if source_sm is None:
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message=f"Cannot find measure '{measure_name}' in any semantic model. Skipped.",
             ))
-            return None
+            return
 
-        # Find the dbt measure to get the expr and agg
-        dbt_measure = None
-        for m in source_sm.measures:
-            if m.name == measure_name:
-                dbt_measure = m
-                break
-
+        dbt_measure = next((m for m in source_sm.measures if m.name == measure_name), None)
         if dbt_measure is None:
-            return None
+            return
 
-        # Build entity names dict for filter resolution
         model_entities = {e.name: e.type for e in source_sm.entities}
-
-        # Convert the filter
         sm_by_name = {sm.name: sm for sm in self.project.semantic_models}
         slayer_filter = convert_dbt_filter(
             filter_str=metric.filter,
@@ -485,133 +542,205 @@ class DbtToSlayerConverter:
             all_semantic_models=sm_by_name,
         )
 
-        # Create a filtered measure and add to the SLayer model
         mapped_agg = _map_agg(dbt_measure.agg)
         slayer_model = self._models_by_name.get(source_sm.name)
         if slayer_model is None:
-            return None
+            return
 
-        sql = dbt_measure.expr if dbt_measure.expr and dbt_measure.expr != dbt_measure.name else None
-
-        filtered_column = Column(
-            name=metric.name,
-            sql=sql or dbt_measure.name,
-            type=DataType.NUMBER,
-            description=metric.description or f"Filtered metric: {metric.name}",
-            label=metric.label,
-            allowed_aggregations=[mapped_agg] if self.strict_aggregations else None,
-            filter=slayer_filter,
-        )
-        if any(c.name == filtered_column.name for c in slayer_model.columns):
+        # Q-3: filtered simple metrics get a Column carrying the filter, with
+        # NO allowed_aggregations. The metric becomes a ModelMeasure that
+        # references that Column with the dbt-defined aggregation.
+        existing_names = {c.name for c in slayer_model.columns}
+        existing_names.update(m.name for m in slayer_model.measures if m.name is not None)
+        if metric.name in existing_names:
             self._warnings.append(ConversionWarning(
                 model_name=slayer_model.name,
                 metric_name=metric.name,
                 message=(
                     f"Filtered metric '{metric.name}' collides with an existing column "
-                    f"on model '{slayer_model.name}'. Skipped."
+                    f"or measure on model '{slayer_model.name}'. Skipped."
                 ),
             ))
-            return None
-        slayer_model.columns.append(filtered_column)
-        return None  # Handled as a column, no query needed
+            return
 
-    def _convert_derived_metric(self, metric: DbtMetric) -> Optional[dict]:
-        """Convert a derived metric to a SlayerQuery dict."""
+        col_name = f"{metric.name}_col"
+        while col_name in existing_names:
+            col_name = f"{col_name}_col"
+
+        underlying_sql = (
+            dbt_measure.expr
+            if dbt_measure.expr and dbt_measure.expr != dbt_measure.name
+            else dbt_measure.name
+        )
+        slayer_model.columns.append(Column(
+            name=col_name,
+            sql=underlying_sql,
+            type=DataType.NUMBER,
+            format=_FLOAT_FORMAT,
+            filter=slayer_filter,
+        ))
+        try:
+            slayer_model.measures.append(ModelMeasure(
+                name=metric.name,
+                formula=f"{col_name}:{mapped_agg}",
+                label=metric.label,
+                description=metric.description or f"Filtered metric: {metric.name}",
+            ))
+        except ValueError as exc:
+            # Roll back the column we just appended so the model stays consistent.
+            slayer_model.columns.pop()
+            self._unconverted.append(ConversionWarning(
+                model_name=slayer_model.name,
+                metric_name=metric.name,
+                message=(
+                    f"Filtered metric '{metric.name}' could not be converted: {exc}"
+                ),
+            ))
+
+    def _convert_derived_metric(self, metric: DbtMetric) -> None:
+        """A derived metric expresses a formula over other metrics/measures.
+
+        The ``ModelMeasure.formula`` references inputs by **bare name** —
+        either another ``ModelMeasure`` on the same model (which the formula
+        parser resolves) or a column-with-aggregation when bare names cannot
+        be located locally.
+        """
         if not metric.type_params:
-            return None
+            return
 
         expr = metric.type_params.expr
         if not expr:
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message="Derived metric has no expr. Skipped.",
             ))
-            return None
+            return
 
-        # Build the formula: replace metric names with SLayer colon syntax.
-        # Use word-boundary regex so a ref like "total" doesn't mutate
-        # `subtotal` or `total_orders` elsewhere in the expression.
         formula = expr
         if metric.type_params.metrics:
             for m_input in metric.type_params.metrics:
                 ref_name = m_input.alias or m_input.name
-                resolved = self._resolve_metric_to_formula(m_input.name)
-                if resolved:
+                resolved = self._resolve_metric_to_name(m_input.name)
+                if resolved and resolved != ref_name:
                     formula = re.sub(
                         rf"\b{re.escape(ref_name)}\b",
-                        # Escape backreference syntax in the replacement so
-                        # any literal \1 / \g<...> in the resolved colon
-                        # expression is treated as text, not a backref.
                         resolved.replace("\\", r"\\"),
                         formula,
                     )
 
-        # Find a source model for this query
-        source_model = self._find_metric_source_model(metric)
+        source_model_name = self._find_metric_source_model(metric)
+        if source_model_name is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=f"Could not determine source model for derived metric '{metric.name}'. Skipped.",
+            ))
+            return
 
-        query = {
-            "name": metric.name,
-            "description": metric.description or f"Derived metric: {metric.name}",
-            "measures": [{"formula": formula, "name": metric.name}],
-        }
-        if source_model:
-            query["source_model"] = source_model
+        slayer_model = self._models_by_name.get(source_model_name)
+        if slayer_model is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=(
+                    f"Source model '{source_model_name}' for derived metric "
+                    f"'{metric.name}' was not converted. Skipped."
+                ),
+            ))
+            return
 
-        return query
+        self._add_model_measure(
+            slayer_model=slayer_model,
+            metric=metric,
+            formula=formula,
+        )
 
-    def _convert_ratio_metric(self, metric: DbtMetric) -> Optional[dict]:
-        """Convert a ratio metric to a SlayerQuery dict."""
+    def _convert_ratio_metric(self, metric: DbtMetric) -> None:
+        """A ratio metric is numerator / denominator over two measures/metrics."""
         if not metric.type_params:
-            return None
+            return
 
         num = metric.type_params.numerator
         den = metric.type_params.denominator
         if not num or not den:
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message="Ratio metric missing numerator or denominator. Skipped.",
             ))
-            return None
+            return
 
-        num_formula = self._resolve_metric_to_formula(num.name) or num.name
-        den_formula = self._resolve_metric_to_formula(den.name) or den.name
+        num_formula = self._resolve_metric_to_name(num.name) or num.name
+        den_formula = self._resolve_metric_to_name(den.name) or den.name
 
-        source_model = self._find_metric_source_model(metric)
+        source_model_name = self._find_metric_source_model(metric)
+        if source_model_name is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=f"Could not determine source model for ratio metric '{metric.name}'. Skipped.",
+            ))
+            return
 
-        query = {
-            "name": metric.name,
-            "description": metric.description or f"Ratio metric: {metric.name}",
-            "measures": [{"formula": f"{num_formula} / {den_formula}", "name": metric.name}],
-        }
-        if source_model:
-            query["source_model"] = source_model
+        slayer_model = self._models_by_name.get(source_model_name)
+        if slayer_model is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=(
+                    f"Source model '{source_model_name}' for ratio metric "
+                    f"'{metric.name}' was not converted. Skipped."
+                ),
+            ))
+            return
 
-        return query
+        self._add_model_measure(
+            slayer_model=slayer_model,
+            metric=metric,
+            formula=f"{num_formula} / {den_formula}",
+        )
 
-    def _convert_cumulative_metric(self, metric: DbtMetric) -> Optional[dict]:
-        """Convert a cumulative metric to a SlayerQuery dict."""
+    def _convert_cumulative_metric(self, metric: DbtMetric) -> None:
+        """A cumulative metric is a running total of one underlying measure."""
         if not metric.type_params or not metric.type_params.measure:
-            self._warnings.append(ConversionWarning(
+            self._unconverted.append(ConversionWarning(
                 metric_name=metric.name,
                 message="Cumulative metric has no measure reference. Skipped.",
             ))
-            return None
+            return
 
-        measure_ref = self._resolve_measure_to_formula(metric.type_params.measure)
+        measure_ref = self._resolve_measure_to_name(metric.type_params.measure)
         if not measure_ref:
-            return None
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=(
+                    f"Cumulative metric '{metric.name}' references unknown "
+                    f"measure '{metric.type_params.measure}'. Skipped."
+                ),
+            ))
+            return
 
-        source_model = self._find_metric_source_model(metric)
+        source_model_name = self._find_metric_source_model(metric)
+        if source_model_name is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=f"Could not determine source model for cumulative metric '{metric.name}'. Skipped.",
+            ))
+            return
 
-        query = {
-            "name": metric.name,
-            "description": metric.description or f"Cumulative metric: {metric.name}",
-            "measures": [{"formula": f"cumsum({measure_ref})", "name": metric.name}],
-        }
-        if source_model:
-            query["source_model"] = source_model
+        slayer_model = self._models_by_name.get(source_model_name)
+        if slayer_model is None:
+            self._unconverted.append(ConversionWarning(
+                metric_name=metric.name,
+                message=(
+                    f"Source model '{source_model_name}' for cumulative metric "
+                    f"'{metric.name}' was not converted. Skipped."
+                ),
+            ))
+            return
 
-        return query
+        self._add_model_measure(
+            slayer_model=slayer_model,
+            metric=metric,
+            formula=f"cumsum({measure_ref})",
+        )
+
+    # ── Resolution helpers ────────────────────────────────────────────
 
     def _find_measure_model(self, measure_name: str) -> Optional[DbtSemanticModel]:
         """Find which dbt semantic model contains a given measure."""
@@ -622,57 +751,98 @@ class DbtToSlayerConverter:
         return None
 
     def _find_metric_source_model(self, metric: DbtMetric) -> Optional[str]:
-        """Determine the source model for a metric query."""
-        if metric.type_params and metric.type_params.measure:
+        """Determine the source model for a metric.
+
+        Walks ``measure``, then ``metrics``, then ``numerator``/``denominator``
+        to support all metric shapes that reference an underlying measure.
+        """
+        if metric.type_params is None:
+            return None
+
+        if metric.type_params.measure:
             sm = self._find_measure_model(metric.type_params.measure)
             if sm:
                 return sm.name
-        # For derived metrics, try to find source through input metrics
-        if metric.type_params and metric.type_params.metrics:
+
+        if metric.type_params.metrics:
             for m_input in metric.type_params.metrics:
                 source = self._resolve_metric_source(m_input.name)
                 if source:
                     return source
+
+        # Q-E: ratio metrics carry numerator/denominator, not metrics=[…].
+        for side in (metric.type_params.numerator, metric.type_params.denominator):
+            if side is None:
+                continue
+            source = self._resolve_metric_source(side.name)
+            if source:
+                return source
+
         return None
 
     def _resolve_metric_source(self, metric_name: str) -> Optional[str]:
-        """Recursively resolve a metric name to its source model."""
+        """Recursively resolve a metric name to its source model.
+
+        First tries the metric's own ``measure`` (simple), then descends into
+        ``numerator``/``denominator`` (ratio), then ``metrics`` (derived).
+        Falls back to looking up ``metric_name`` as a dbt measure directly.
+        """
+        for m in self.project.metrics:
+            if m.name != metric_name:
+                continue
+            if m.type_params is None:
+                return None
+            if m.type_params.measure:
+                sm = self._find_measure_model(m.type_params.measure)
+                if sm:
+                    return sm.name
+            for side in (m.type_params.numerator, m.type_params.denominator):
+                if side is None:
+                    continue
+                source = self._resolve_metric_source(side.name)
+                if source:
+                    return source
+            if m.type_params.metrics:
+                for m_input in m.type_params.metrics:
+                    source = self._resolve_metric_source(m_input.name)
+                    if source:
+                        return source
+            return None
+        # ``metric_name`` may be a bare dbt measure name rather than a metric.
+        sm = self._find_measure_model(metric_name)
+        return sm.name if sm else None
+
+    def _resolve_metric_to_name(self, metric_name: str) -> Optional[str]:
+        """Resolve a metric name to a formula reference.
+
+        Returns the bare ``ModelMeasure`` name when the metric was lowered
+        into a ``ModelMeasure`` (simple, derived, ratio, cumulative). Falls
+        back to the ``column:agg`` colon form when ``metric_name`` is a dbt
+        measure rather than a metric.
+        """
         for m in self.project.metrics:
             if m.name == metric_name:
-                if m.type_params and m.type_params.measure:
-                    sm = self._find_measure_model(m.type_params.measure)
-                    return sm.name if sm else None
-        return None
+                # All metric kinds are stored as ModelMeasures named after the metric.
+                return metric_name
+        return self._resolve_measure_to_name(metric_name)
 
-    def _resolve_metric_to_formula(self, metric_name: str) -> Optional[str]:
-        """Resolve a metric name to a SLayer field formula (measure:agg)."""
-        for m in self.project.metrics:
-            if m.name == metric_name:
-                return self._resolve_measure_to_formula_from_metric(m)
-        # Might be a direct measure name
-        return self._resolve_measure_to_formula(metric_name)
+    def _resolve_measure_to_name(self, measure_name: str) -> Optional[str]:
+        """Resolve a dbt measure name to a formula reference.
 
-    def _resolve_measure_to_formula_from_metric(self, metric: DbtMetric) -> Optional[str]:
-        """Resolve a metric to its underlying measure:agg formula."""
-        if metric.type_params and metric.type_params.measure:
-            return self._resolve_measure_to_formula(metric.type_params.measure)
-        return f"{metric.name}:sum"  # Fallback
-
-    def _resolve_measure_to_formula(self, measure_name: str) -> Optional[str]:
-        """Resolve a dbt measure name to SLayer colon syntax (measure:agg)."""
-        for sm in self.project.semantic_models:
-            for m in sm.measures:
-                if m.name == measure_name:
-                    mapped_agg = _map_agg(m.agg)
-                    # After consolidation, the SLayer column might have a
-                    # different name (expr-based). Check if it was consolidated.
-                    slayer_model = self._models_by_name.get(sm.name)
-                    if slayer_model:
-                        for slayer_c in slayer_model.columns:
-                            if slayer_c.name == measure_name:
-                                return f"{measure_name}:{mapped_agg}"
-                            # Check if consolidated under expr name
-                            if slayer_c.sql == (m.expr or m.name) and slayer_c.name != measure_name:
-                                return f"{slayer_c.name}:{mapped_agg}"
-                    return f"{measure_name}:{mapped_agg}"
+        After ``_convert_measures`` has run, the dbt measure name is the
+        ``ModelMeasure`` name on its semantic model. Reference it by bare
+        name (Q-5) so the formula parser can resolve it relative to the
+        current model.
+        """
+        sm = self._find_measure_model(measure_name)
+        if sm is None:
+            return None
+        slayer_model = self._models_by_name.get(sm.name)
+        if slayer_model is None:
+            return None
+        for m in slayer_model.measures:
+            if m.name == measure_name:
+                return measure_name
+        # Fallback: shouldn't happen for converted measures, but if the
+        # measure was routed to unconverted_metrics we have nothing to point at.
         return None

--- a/slayer/engine/ingestion.py
+++ b/slayer/engine/ingestion.py
@@ -4,7 +4,7 @@ Flow:
 1. Get table names, build FK graph, check for cycles
 2. For each table, build rollup SQL (with LEFT JOINs for referenced tables)
 3. Introspect the rollup query's result columns for types
-4. Generate dimensions and measures from those columns
+4. Generate one Column per non-joined column (v2 unified-columns shape)
 """
 
 import logging
@@ -49,7 +49,7 @@ _SA_TYPE_MAP = {
 _NUMERIC_TYPES = {DataType.NUMBER}
 _ID_SUFFIXES = ("_id", "_key", "_pk", "_fk")
 
-# Float-like SA type names — these columns get measures only, no dimensions.
+# Float-like SA type names — these columns get a FLOAT NumberFormat on the emitted Column.
 # NUMERIC/DECIMAL are handled separately via scale inspection in _sa_type_is_float.
 _FLOAT_LIKE_SA_TYPES = frozenset(
     {

--- a/slayer/storage/base.py
+++ b/slayer/storage/base.py
@@ -13,8 +13,7 @@ def storage_base_dir(path: str) -> str:
 
     For a SQLite file (``foo.db``/``.sqlite``/``.sqlite3``), returns its parent
     directory; otherwise the path is itself a directory. Used by callers that
-    need to colocate auxiliary files (queries.yaml, demo databases, etc.) next
-    to the storage.
+    need to colocate auxiliary files (demo databases, etc.) next to the storage.
     """
     if path.endswith((".db", ".sqlite", ".sqlite3")):
         return os.path.dirname(path) or "."

--- a/tests/integration/test_ingestion_jaffle_shop.py
+++ b/tests/integration/test_ingestion_jaffle_shop.py
@@ -1,0 +1,219 @@
+"""End-to-end auto-ingestion test against the Jaffle Shop DuckDB.
+
+This is the integration test called out in S4 (issue #48): generate the
+Jaffle Shop demo into a temp DuckDB, call ``ingest_datasource``, and assert
+the resulting models conform to the v2 unified-columns shape (one ``Column``
+list per model, ``measures`` library left empty by ingestion, no dotted
+column names, joins resolved to direct FK pairs only). Also round-trips the
+ingested models through YAMLStorage to confirm no v1 keys leak to disk.
+"""
+
+import os
+import tempfile
+from typing import Dict
+
+import pytest
+import yaml
+
+pytest.importorskip("duckdb")
+pytest.importorskip("jafgen")
+
+import duckdb
+
+from slayer.core.enums import DataType
+from slayer.core.format import NumberFormatType
+from slayer.core.models import DatasourceConfig, SlayerModel
+from slayer.demo.jaffle_shop import (
+    DemoDependencyError,
+    create_schema,
+    generate_data,
+    load_data,
+)
+from slayer.engine.ingestion import ingest_datasource
+from slayer.storage.yaml_storage import YAMLStorage
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def jaffle_duckdb_path(tmp_path_factory):
+    """Generate a small Jaffle Shop DuckDB file once for this module."""
+    tmpdir = tmp_path_factory.mktemp("jaffle_ingest")
+    try:
+        data_dir = generate_data(output_dir=str(tmpdir), years=1)
+    except DemoDependencyError as exc:
+        pytest.skip(f"Jaffle shop prerequisite missing: {exc}")
+    except (FileNotFoundError, RuntimeError) as exc:
+        pytest.skip(f"Jaffle shop prerequisite missing: {exc}")
+
+    db_path = tmpdir / "jaffle_ingest.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        create_schema(conn=conn)
+        load_data(conn=conn, data_dir=data_dir)
+    finally:
+        conn.close()
+    return str(db_path)
+
+
+@pytest.fixture(scope="module")
+def jaffle_models(jaffle_duckdb_path):
+    """Ingest the Jaffle Shop DuckDB and return models keyed by name."""
+    ds = DatasourceConfig(
+        name="jaffle_test",
+        type="duckdb",
+        database=jaffle_duckdb_path,
+    )
+    models = ingest_datasource(datasource=ds)
+    return {m.name: m for m in models}
+
+
+# Expected non-joined columns per ingested model. The values are dicts of
+# ``column_name -> (DataType, primary_key, format_type_or_None)``. Columns
+# whose source name contained a dot (joined columns) are excluded by
+# ``_columns_to_model`` and so are not listed here.
+_EXPECTED_COLUMNS: Dict[str, Dict[str, tuple]] = {
+    "customers": {
+        "id": (DataType.STRING, True, None),
+        "name": (DataType.STRING, False, None),
+    },
+    "stores": {
+        "id": (DataType.STRING, True, None),
+        "name": (DataType.STRING, False, None),
+        "opened_at": (DataType.DATE, False, None),
+        "tax_rate": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+    },
+    "products": {
+        "sku": (DataType.STRING, True, None),
+        "name": (DataType.STRING, False, None),
+        "type": (DataType.STRING, False, None),
+        "price": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+        "description": (DataType.STRING, False, None),
+    },
+    "orders": {
+        "id": (DataType.STRING, True, None),
+        "customer_id": (DataType.STRING, False, None),
+        "ordered_at": (DataType.DATE, False, None),
+        "store_id": (DataType.STRING, False, None),
+        "subtotal": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+        "tax_paid": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+        "order_total": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+    },
+    "order_items": {
+        "id": (DataType.STRING, True, None),
+        "order_id": (DataType.STRING, False, None),
+        "sku": (DataType.STRING, False, None),
+        "quantity": (DataType.NUMBER, False, NumberFormatType.INTEGER),
+    },
+    "supplies": {
+        "id": (DataType.STRING, True, None),
+        "name": (DataType.STRING, False, None),
+        "cost": (DataType.NUMBER, False, NumberFormatType.FLOAT),
+        "perishable": (DataType.STRING, False, None),
+        "sku": (DataType.STRING, True, None),
+    },
+    "tweets": {
+        "id": (DataType.STRING, True, None),
+        "user_id": (DataType.STRING, False, None),
+        "tweeted_at": (DataType.DATE, False, None),
+        "content": (DataType.STRING, False, None),
+    },
+}
+
+
+# Expected direct joins per model. Values are sets of (target_model, src_col, tgt_col).
+_EXPECTED_JOINS: Dict[str, set] = {
+    "customers": set(),
+    "stores": set(),
+    "products": set(),
+    "orders": {
+        ("customers", "customer_id", "id"),
+        ("stores", "store_id", "id"),
+    },
+    "order_items": {
+        ("orders", "order_id", "id"),
+        ("products", "sku", "sku"),
+    },
+    "supplies": {
+        ("products", "sku", "sku"),
+    },
+    "tweets": {
+        ("customers", "user_id", "id"),
+    },
+}
+
+
+def test_all_jaffle_models_produced(jaffle_models):
+    assert set(jaffle_models.keys()) == set(_EXPECTED_COLUMNS.keys())
+
+
+@pytest.mark.parametrize("model_name", sorted(_EXPECTED_COLUMNS.keys()))
+def test_jaffle_model_columns_v2_shape(jaffle_models, model_name):
+    model: SlayerModel = jaffle_models[model_name]
+    expected = _EXPECTED_COLUMNS[model_name]
+
+    by_name = {c.name: c for c in model.columns}
+    assert set(by_name.keys()) == set(expected.keys())
+
+    for col_name, (data_type, is_pk, fmt_type) in expected.items():
+        col = by_name[col_name]
+        assert col.type == data_type, f"{model_name}.{col_name}: type"
+        assert col.primary_key == is_pk, f"{model_name}.{col_name}: primary_key"
+        if fmt_type is None:
+            assert col.format is None, f"{model_name}.{col_name}: format should be None"
+        else:
+            assert col.format is not None, f"{model_name}.{col_name}: format should be set"
+            assert col.format.type == fmt_type, f"{model_name}.{col_name}: format.type"
+
+
+def test_jaffle_models_have_empty_measures_library(jaffle_models):
+    """Auto-ingestion never populates the named-measures formula library."""
+    for name, model in jaffle_models.items():
+        assert model.measures == [], f"{name} should have measures == []"
+
+
+def test_jaffle_no_dotted_column_names(jaffle_models):
+    """Joined columns live on the target model and must not leak into the source."""
+    for name, model in jaffle_models.items():
+        for col in model.columns:
+            assert "." not in col.name, (
+                f"{name}.{col.name}: ingestion should never emit dotted column names"
+            )
+
+
+@pytest.mark.parametrize("model_name", sorted(_EXPECTED_JOINS.keys()))
+def test_jaffle_model_joins(jaffle_models, model_name):
+    model = jaffle_models[model_name]
+    expected = _EXPECTED_JOINS[model_name]
+
+    actual: set = set()
+    for j in model.joins:
+        # Each join in auto-ingestion has exactly one column pair (direct FKs only).
+        assert len(j.join_pairs) == 1, f"{model_name} → {j.target_model}: expected one pair"
+        src_col, tgt_col = j.join_pairs[0]
+        actual.add((j.target_model, src_col, tgt_col))
+
+    assert actual == expected
+
+
+async def test_jaffle_yaml_round_trip_omits_v1_keys(jaffle_models):
+    """Saving an ingested model to YAML must produce v2 shape with no v1 keys."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = YAMLStorage(base_dir=tmpdir)
+        for model in jaffle_models.values():
+            await storage.save_model(model)
+
+        for model_name in jaffle_models:
+            path = os.path.join(storage.models_dir, f"{model_name}.yaml")
+            with open(path) as f:
+                on_disk = yaml.safe_load(f)
+            assert on_disk["version"] == 2, model_name
+            assert "columns" in on_disk, model_name
+            assert "dimensions" not in on_disk, (
+                f"{model_name}: v1 'dimensions' key should not be on disk"
+            )
+            # ``measures`` MAY appear (as []) in the v2 ModelMeasure library;
+            # if present, it must not contain v1 measure shape (sql + agg etc).
+            for entry in on_disk.get("measures") or []:
+                assert "formula" in entry, f"{model_name}: v2 measure entry must carry 'formula'"

--- a/tests/integration/test_ingestion_jaffle_shop.py
+++ b/tests/integration/test_ingestion_jaffle_shop.py
@@ -8,8 +8,10 @@ column names, joins resolved to direct FK pairs only). Also round-trips the
 ingested models through YAMLStorage to confirm no v1 keys leak to disk.
 """
 
+import asyncio
 import os
 import tempfile
+from pathlib import Path
 from typing import Dict
 
 import pytest
@@ -206,8 +208,8 @@ async def test_jaffle_yaml_round_trip_omits_v1_keys(jaffle_models):
 
         for model_name in jaffle_models:
             path = os.path.join(storage.models_dir, f"{model_name}.yaml")
-            with open(path) as f:
-                on_disk = yaml.safe_load(f)
+            raw = await asyncio.to_thread(Path(path).read_text)
+            on_disk = yaml.safe_load(raw)
             assert on_disk["version"] == 2, model_name
             assert "columns" in on_disk, model_name
             assert "dimensions" not in on_disk, (

--- a/tests/test_dbt_converter.py
+++ b/tests/test_dbt_converter.py
@@ -28,6 +28,40 @@ from slayer.dbt.models import (
 from slayer.dbt.parser import parse_dbt_project
 
 
+@pytest.fixture
+def aov_ratio_project() -> DbtProject:
+    """Minimal dbt project: an ``orders`` semantic model with two measures
+    and a single ratio metric ``aov = total_amount / order_count``.
+
+    Shared between the ratio-becomes-ModelMeasure and the
+    _find_metric_source_model regression tests, which previously copy-pasted
+    this same project literal.
+    """
+    return DbtProject(
+        semantic_models=[
+            DbtSemanticModel(
+                name="orders",
+                model="orders",
+                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                measures=[
+                    DbtMeasure(name="total_amount", agg="sum", expr="amount"),
+                    DbtMeasure(name="order_count", agg="count", expr="id"),
+                ],
+            ),
+        ],
+        metrics=[
+            DbtMetric(
+                name="aov",
+                type="ratio",
+                type_params=DbtMetricTypeParams(
+                    numerator=DbtMetricInput(name="total_amount"),
+                    denominator=DbtMetricInput(name="order_count"),
+                ),
+            ),
+        ],
+    )
+
+
 def _make_simple_project():
     """Create a minimal dbt project for testing."""
     return DbtProject(
@@ -535,10 +569,13 @@ class TestDerivedMetricConversion:
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
         # Derived metric folded into a ModelMeasure on the source model — no
-        # SlayerQuery dicts are produced.
+        # SlayerQuery dicts are produced. The two referenced metrics are
+        # *unfiltered* simple metrics so they were never materialized as
+        # ModelMeasures; the formula must point at the backing dbt measures
+        # (which are the actual ModelMeasure names on the model).
         orders = next(m for m in result.models if m.name == "orders")
         m = next(mm for mm in orders.measures if mm.name == "avg_order_value")
-        assert m.formula == "total_amount_metric / order_count_metric"
+        assert m.formula == "total_amount / order_count"
         assert m.description == "Average order value"
 
 
@@ -1144,31 +1181,8 @@ class TestColumnNamingS4:
 class TestDbtMeasureToModelMeasure:
     """Step 7 (Q-1, Q-5, Q-6): metrics fold into ModelMeasures, not SlayerQuery dicts."""
 
-    def test_ratio_metric_becomes_model_measure(self) -> None:
-        project = DbtProject(
-            semantic_models=[
-                DbtSemanticModel(
-                    name="orders",
-                    model="orders",
-                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
-                    measures=[
-                        DbtMeasure(name="total_amount", agg="sum", expr="amount"),
-                        DbtMeasure(name="order_count", agg="count", expr="id"),
-                    ],
-                ),
-            ],
-            metrics=[
-                DbtMetric(
-                    name="aov",
-                    type="ratio",
-                    type_params=DbtMetricTypeParams(
-                        numerator=DbtMetricInput(name="total_amount"),
-                        denominator=DbtMetricInput(name="order_count"),
-                    ),
-                ),
-            ],
-        )
-        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+    def test_ratio_metric_becomes_model_measure(self, aov_ratio_project) -> None:
+        result = DbtToSlayerConverter(project=aov_ratio_project, data_source="test").convert()
         orders = next(m for m in result.models if m.name == "orders")
 
         aov = next(m for m in orders.measures if m.name == "aov")
@@ -1204,9 +1218,160 @@ class TestDbtMeasureToModelMeasure:
 class TestFindMetricSourceModelRatio:
     """Q-E regression: _find_metric_source_model must walk numerator/denominator."""
 
-    def test_find_metric_source_model_resolves_ratio_numerator_denominator(self) -> None:
+    def test_find_metric_source_model_resolves_ratio_numerator_denominator(
+        self, aov_ratio_project
+    ) -> None:
         """A ratio metric whose source is reachable only through its
         numerator (or denominator) must still resolve."""
+        result = DbtToSlayerConverter(project=aov_ratio_project, data_source="test").convert()
+        # Source resolution worked — the ModelMeasure ended up on orders.
+        orders = next(m for m in result.models if m.name == "orders")
+        assert any(m.name == "aov" for m in orders.measures), (
+            "Ratio metric source model not resolved via numerator/denominator"
+        )
+
+
+class TestMultiSourceMetricRouting:
+    """Metrics whose inputs span multiple semantic models must be routed to
+    ``unconverted_metrics`` rather than silently anchored to whichever model
+    happens to be discovered first (CodeRabbit 1a)."""
+
+    def test_derived_metric_spanning_two_models_is_unconverted(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[DbtMeasure(name="total_amount", agg="sum", expr="amount")],
+                ),
+                DbtSemanticModel(
+                    name="customers",
+                    model="customers",
+                    entities=[DbtEntity(name="customer_id", type="primary", expr="id")],
+                    measures=[DbtMeasure(name="customer_count", agg="count", expr="id")],
+                ),
+            ],
+            metrics=[
+                # Derived metric whose two referenced measures live on
+                # different semantic models.
+                DbtMetric(
+                    name="amount_per_customer",
+                    type="derived",
+                    type_params=DbtMetricTypeParams(
+                        expr="total_amount / customer_count",
+                        metrics=[
+                            DbtMetricInput(name="total_amount"),
+                            DbtMetricInput(name="customer_count"),
+                        ],
+                    ),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+
+        orders = next(m for m in result.models if m.name == "orders")
+        customers = next(m for m in result.models if m.name == "customers")
+        assert not any(m.name == "amount_per_customer" for m in orders.measures), (
+            "Cross-model derived metric should not be anchored to 'orders'"
+        )
+        assert not any(m.name == "amount_per_customer" for m in customers.measures), (
+            "Cross-model derived metric should not be anchored to 'customers'"
+        )
+        assert any(
+            u.metric_name == "amount_per_customer" for u in result.unconverted_metrics
+        ), "Cross-model derived metric should be routed to unconverted_metrics"
+
+    def test_ratio_metric_spanning_two_models_is_unconverted(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[DbtMeasure(name="total_amount", agg="sum", expr="amount")],
+                ),
+                DbtSemanticModel(
+                    name="customers",
+                    model="customers",
+                    entities=[DbtEntity(name="customer_id", type="primary", expr="id")],
+                    measures=[DbtMeasure(name="customer_count", agg="count", expr="id")],
+                ),
+            ],
+            metrics=[
+                DbtMetric(
+                    name="amount_per_customer_ratio",
+                    type="ratio",
+                    type_params=DbtMetricTypeParams(
+                        numerator=DbtMetricInput(name="total_amount"),
+                        denominator=DbtMetricInput(name="customer_count"),
+                    ),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+
+        orders = next(m for m in result.models if m.name == "orders")
+        customers = next(m for m in result.models if m.name == "customers")
+        assert not any(m.name == "amount_per_customer_ratio" for m in orders.measures)
+        assert not any(m.name == "amount_per_customer_ratio" for m in customers.measures)
+        assert any(
+            u.metric_name == "amount_per_customer_ratio"
+            for u in result.unconverted_metrics
+        )
+
+
+class TestUnfilteredSimpleMetricResolution:
+    """An unfiltered simple metric is not materialized as a ModelMeasure; any
+    derived/ratio formula that references it must resolve to the backing
+    measure's name instead of the (non-existent) metric name (CodeRabbit 1b).
+    """
+
+    def test_derived_metric_referencing_unfiltered_simple_metric_uses_backing_measure(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[DbtMeasure(name="total_amount", agg="sum", expr="amount")],
+                ),
+            ],
+            metrics=[
+                # Simple unfiltered metric — _convert_simple_metric returns
+                # without creating a ModelMeasure for this one.
+                DbtMetric(
+                    name="amount_metric",
+                    type="simple",
+                    type_params=DbtMetricTypeParams(measure="total_amount"),
+                ),
+                # Derived metric referencing the simple metric by name.
+                DbtMetric(
+                    name="double_amount",
+                    type="derived",
+                    type_params=DbtMetricTypeParams(
+                        expr="amount_metric * 2",
+                        metrics=[DbtMetricInput(name="amount_metric")],
+                    ),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = next(m for m in result.models if m.name == "orders")
+
+        measure_names = {m.name for m in orders.measures}
+        assert "amount_metric" not in measure_names, (
+            "Unfiltered simple metric should not be materialized as a ModelMeasure"
+        )
+        double = next(m for m in orders.measures if m.name == "double_amount")
+        assert "amount_metric" not in double.formula, (
+            f"Derived formula must not reference unmaterialized metric name; got {double.formula!r}"
+        )
+        assert "total_amount" in double.formula, (
+            f"Derived formula should reference backing measure 'total_amount'; got {double.formula!r}"
+        )
+
+    def test_ratio_metric_referencing_unfiltered_simple_metric_uses_backing_measure(self) -> None:
         project = DbtProject(
             semantic_models=[
                 DbtSemanticModel(
@@ -1220,23 +1385,31 @@ class TestFindMetricSourceModelRatio:
                 ),
             ],
             metrics=[
-                # Ratio metric — only reachable via numerator/denominator names,
-                # NOT via type_params.measure or type_params.metrics.
                 DbtMetric(
-                    name="aov",
+                    name="amount_metric",
+                    type="simple",
+                    type_params=DbtMetricTypeParams(measure="total_amount"),
+                ),
+                DbtMetric(
+                    name="count_metric",
+                    type="simple",
+                    type_params=DbtMetricTypeParams(measure="order_count"),
+                ),
+                DbtMetric(
+                    name="aov_via_metrics",
                     type="ratio",
                     type_params=DbtMetricTypeParams(
-                        numerator=DbtMetricInput(name="total_amount"),
-                        denominator=DbtMetricInput(name="order_count"),
+                        numerator=DbtMetricInput(name="amount_metric"),
+                        denominator=DbtMetricInput(name="count_metric"),
                     ),
                 ),
             ],
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
-        # Source resolution worked — the ModelMeasure ended up on orders.
         orders = next(m for m in result.models if m.name == "orders")
-        assert any(m.name == "aov" for m in orders.measures), (
-            "Ratio metric source model not resolved via numerator/denominator"
+        aov = next(m for m in orders.measures if m.name == "aov_via_metrics")
+        assert aov.formula == "total_amount / order_count", (
+            f"Ratio formula should reference backing measures, got {aov.formula!r}"
         )
 
 

--- a/tests/test_dbt_converter.py
+++ b/tests/test_dbt_converter.py
@@ -3,13 +3,15 @@
 import textwrap
 from unittest.mock import MagicMock, patch
 
+import pytest
 import sqlalchemy as sa
 from sqlalchemy.exc import SQLAlchemyError
 
 from slayer.core.enums import DataType
+from slayer.core.format import NumberFormatType
 from slayer.core.models import Column, SlayerModel
 from slayer.dbt import converter as converter_module
-from slayer.dbt.converter import DbtToSlayerConverter
+from slayer.dbt.converter import DbtConversionError, DbtToSlayerConverter
 from slayer.dbt.models import (
     DbtColumnMeta,
     DbtDefaults,
@@ -99,16 +101,32 @@ class TestBasicConversion:
         assert order_date.type == DataType.TIMESTAMP
 
     def test_measures(self) -> None:
-        """v2 dbt converter emits all dim/measure/entity columns into ``columns``."""
+        """v2 dbt converter splits dbt measures: a Column per unique expr,
+        a ModelMeasure per dbt measure carrying the agg as colon syntax.
+        """
         project = _make_simple_project()
         result = DbtToSlayerConverter(project=project, data_source="test_db").convert()
         orders = next(m for m in result.models if m.name == "orders")
-        # dbt measures appear as Columns with allowed_aggregations + numeric type.
-        amount = next(c for c in orders.columns if c.name == "total_amount")
-        assert amount.sql == "amount"
-        assert amount.allowed_aggregations == ["sum"]
-        order_count = next(c for c in orders.columns if c.name == "order_count")
-        assert order_count.allowed_aggregations == ["count"]
+
+        col_names = {c.name for c in orders.columns}
+        # Bare-identifier exprs become Column names directly (Q-1 / Q-I).
+        assert "amount" in col_names
+        # ``order_count`` had ``expr=id`` but ``id`` is the entity PK already on the
+        # model, so the measure-derived Column gets a ``_col`` suffix (Q-2 / Q-I).
+        assert "id_col" in col_names
+
+        amount = next(c for c in orders.columns if c.name == "amount")
+        assert amount.allowed_aggregations is None
+        assert amount.format is not None
+        assert amount.format.type == NumberFormatType.FLOAT
+        assert amount.hidden is False  # Q-A
+
+        # ModelMeasures carry the agg + the dbt name.
+        measures_by_name = {m.name: m for m in orders.measures}
+        assert "total_amount" in measures_by_name
+        assert measures_by_name["total_amount"].formula == "amount:sum"
+        assert "order_count" in measures_by_name
+        assert measures_by_name["order_count"].formula == "id_col:count"
 
     def test_primary_key_dimension(self) -> None:
         project = _make_simple_project()
@@ -241,7 +259,7 @@ DbtMeasure(name="number_of_policies", agg="sum", expr="1")
 
 class TestMeasureConsolidation:
     def test_same_expr_consolidated(self) -> None:
-        """Measures with same expr but different aggs become one SLayer column."""
+        """Measures with same expr collapse into one SLayer column; one ModelMeasure per dbt measure."""
         project = DbtProject(semantic_models=[
             DbtSemanticModel(
                 name="orders",
@@ -255,12 +273,17 @@ class TestMeasureConsolidation:
         ])
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
         orders = result.models[0]
-        m = next(c for c in orders.columns if c.name == "revenue_sum")
-        assert m.sql == "amount"
-        assert "sum" in (m.allowed_aggregations or [])
-        assert "avg" in (m.allowed_aggregations or [])
-        assert "revenue_sum" in (m.description or "")
-        assert "revenue_avg" in (m.description or "")
+
+        # One Column for the shared expr; consolidation description (Q-C) dropped.
+        amount_cols = [c for c in orders.columns if c.name == "amount"]
+        assert len(amount_cols) == 1
+        assert amount_cols[0].description in (None, "")
+        assert amount_cols[0].allowed_aggregations is None
+
+        # One ModelMeasure per dbt measure, formula carries the agg.
+        by_name = {m.name: m for m in orders.measures}
+        assert by_name["revenue_sum"].formula == "amount:sum"
+        assert by_name["revenue_avg"].formula == "amount:avg"
 
     def test_different_expr_not_consolidated(self) -> None:
         """Measures with different exprs stay separate columns."""
@@ -277,28 +300,14 @@ class TestMeasureConsolidation:
         ])
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
         orders = result.models[0]
-        # Both measure columns plus the entity PK column.
-        names = {c.name for c in orders.columns}
-        assert "revenue" in names
-        assert "quantity" in names
+        col_names = {c.name for c in orders.columns}
+        # Bare-identifier exprs become the Column names.
+        assert "amount" in col_names
+        assert "qty" in col_names
 
-    def test_no_strict_aggregations(self) -> None:
-        project = DbtProject(semantic_models=[
-            DbtSemanticModel(
-                name="orders",
-                model="orders",
-                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
-                measures=[
-DbtMeasure(name="revenue", agg="sum", expr="amount")
-                ,
-                ],
-            ),
-        ])
-        result = DbtToSlayerConverter(
-            project=project, data_source="test", strict_aggregations=False,
-        ).convert()
-        m = next(c for c in result.models[0].columns if c.name == "revenue")
-        assert m.allowed_aggregations is None
+        measures_by_name = {m.name: m for m in orders.measures}
+        assert measures_by_name["revenue"].formula == "amount:sum"
+        assert measures_by_name["quantity"].formula == "qty:sum"
 
     def test_primary_entity_does_not_duplicate_pk_column(self) -> None:
         """When primary_entity resolves to the same column the entity loop already
@@ -346,12 +355,17 @@ DbtMeasure(name="total_amount", agg="sum", expr="amount")
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
         orders = result.models[0]
-        # Should have the original measure plus the filtered one
-        filtered = [m for m in orders.columns if m.name == "completed_amount"]
-        assert len(filtered) == 1
-        assert filtered[0].filter is not None
-        assert "completed" in filtered[0].filter
-        assert filtered[0].label == "Completed Amount"
+        # Filtered simple metric: a Column carries the WHERE filter (no
+        # allowed_aggregations whitelist), and a ModelMeasure points at it
+        # using the dbt measure's aggregation.
+        filtered_cols = [c for c in orders.columns if c.filter is not None and "completed" in c.filter]
+        assert len(filtered_cols) == 1
+        assert filtered_cols[0].allowed_aggregations is None
+
+        completed = next(m for m in orders.measures if m.name == "completed_amount")
+        assert completed.label == "Completed Amount"
+        # Formula references the filter-bearing column with the dbt agg.
+        assert completed.formula == f"{filtered_cols[0].name}:sum"
 
     def test_filtered_metric_collision_with_existing_column_skipped(self) -> None:
         """Filtered metric whose name collides with an existing column on the model
@@ -385,14 +399,16 @@ DbtMeasure(name="total_amount", agg="sum", expr="amount")
         orders = next(m for m in result.models if m.name == "orders")
         # Exactly one column named "status" — no duplicate appended.
         assert [c.name for c in orders.columns].count("status") == 1
-        # And a warning was emitted explaining why.
+        # No ModelMeasure with the colliding name was added either.
+        assert not any(m.name == "status" for m in orders.measures)
         warning_msgs = [w.message for w in result.warnings]
         assert any("status" in m and "collide" in m.lower() for m in warning_msgs), (
             f"Expected collision warning, got: {warning_msgs}"
         )
 
     def test_unfiltered_simple_metric_no_extra_measure(self) -> None:
-        """Simple metric without filter doesn't add anything."""
+        """Simple metric without filter doesn't add anything — the underlying
+        ModelMeasure is already addressable on its own model."""
         project = DbtProject(
             semantic_models=[
                 DbtSemanticModel(
@@ -415,11 +431,11 @@ DbtMeasure(name="total_amount", agg="sum", expr="amount")
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
         orders = result.models[0]
-        # The metric matches an existing measure name → no duplicate column.
-        # v2: the entity 'order_id' is also added as a PK column, so we just
-        # check that no extra "total_amount" column was added.
-        names = [c.name for c in orders.columns]
-        assert names.count("total_amount") == 1
+        # No extra Column added — only the original "amount" expr column.
+        amount_cols = [c for c in orders.columns if c.name == "amount"]
+        assert len(amount_cols) == 1
+        # Exactly one ModelMeasure named total_amount.
+        assert [m.name for m in orders.measures].count("total_amount") == 1
 
 
 class TestDerivedMetricConversion:
@@ -464,22 +480,21 @@ class TestDerivedMetricConversion:
             ],
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
-        q = next(qq for qq in result.queries if qq["name"] == "weird_ratio")
-        formula = q["measures"][0]["formula"]
-        # `total:sum`, `subtotal:sum`, and `total_orders:count` should all appear,
-        # each as a complete token. The bug would have produced something like
-        # `subtotal:sum + total:sum) / total:sum_orders` because plain replace
-        # rewrites the "total" substring inside "subtotal" and "total_orders".
-        assert "total:sum" in formula
-        assert "subtotal:sum" in formula
-        assert "total_orders:count" in formula
-        # Bug check: the "total" inside "subtotal" was NOT mangled into "total:sum"
-        assert "subtotal:sum" in formula
-        assert "subtotal:sum:sum" not in formula
-        # Bug check: the "total" inside "total_orders" was NOT mangled
+        # Derived metric is a ModelMeasure on the orders model; bare-name refs
+        # (Q-5) — the formula references each input metric by its name, no
+        # colon-aggregation suffix.
+        orders = next(m for m in result.models if m.name == "orders")
+        weird = next(m for m in orders.measures if m.name == "weird_ratio")
+        formula = weird.formula
+        # All three input names appear as complete tokens.
+        assert "total" in formula
+        assert "subtotal" in formula
+        assert "total_orders" in formula
+        # Token-aware substitution didn't mangle "subtotal" or "total_orders".
+        assert "subtotal:sum" not in formula
         assert "total:sum_orders" not in formula
 
-    def test_derived_metric_generates_query(self) -> None:
+    def test_derived_metric_becomes_model_measure(self) -> None:
         project = DbtProject(
             semantic_models=[
                 DbtSemanticModel(
@@ -519,15 +534,16 @@ class TestDerivedMetricConversion:
             ],
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
-        assert len(result.queries) == 1
-        q = result.queries[0]
-        assert q["name"] == "avg_order_value"
-        assert "source_model" in q
-        assert len(q["measures"]) == 1
+        # Derived metric folded into a ModelMeasure on the source model — no
+        # SlayerQuery dicts are produced.
+        orders = next(m for m in result.models if m.name == "orders")
+        m = next(mm for mm in orders.measures if mm.name == "avg_order_value")
+        assert m.formula == "total_amount_metric / order_count_metric"
+        assert m.description == "Average order value"
 
 
 class TestConversionWarnings:
-    def test_conversion_metric_warning(self) -> None:
+    def test_conversion_metric_routed_to_unconverted(self) -> None:
         project = DbtProject(
             semantic_models=[],
             metrics=[
@@ -535,10 +551,10 @@ class TestConversionWarnings:
             ],
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
-        assert len(result.warnings) == 1
-        assert "not supported" in result.warnings[0].message.lower()
+        assert len(result.unconverted_metrics) == 1
+        assert "not supported" in result.unconverted_metrics[0].message.lower()
 
-    def test_unknown_metric_type_warning(self) -> None:
+    def test_unknown_metric_type_routed_to_unconverted(self) -> None:
         project = DbtProject(
             semantic_models=[],
             metrics=[
@@ -546,35 +562,7 @@ class TestConversionWarnings:
             ],
         )
         result = DbtToSlayerConverter(project=project, data_source="test").convert()
-        assert len(result.warnings) == 1
-
-
-class TestQueriesDirForStorage:
-    """Regression tests for CodeRabbit #1 — _queries_dir_for_storage helper.
-
-    `slayer import-dbt --storage slayer.db` must write queries.yaml beside the
-    SQLite file, not inside `slayer.db/queries.yaml` (which would fail because
-    the .db file is not a directory).
-    """
-
-    def test_directory_storage_path_returned_as_is(self) -> None:
-        from slayer.cli import _queries_dir_for_storage
-
-        assert _queries_dir_for_storage("./slayer_data") == "./slayer_data"
-        assert _queries_dir_for_storage("/tmp/models") == "/tmp/models"
-
-    def test_sqlite_db_uses_parent_directory(self) -> None:
-        from slayer.cli import _queries_dir_for_storage
-
-        assert _queries_dir_for_storage("/tmp/slayer.db") == "/tmp"
-        assert _queries_dir_for_storage("./data/slayer.sqlite") == "./data"
-        assert _queries_dir_for_storage("project.sqlite3") == "."
-
-    def test_bare_sqlite_filename_in_cwd(self) -> None:
-        """A bare 'slayer.db' (no directory) should write to the current dir."""
-        from slayer.cli import _queries_dir_for_storage
-
-        assert _queries_dir_for_storage("slayer.db") == "."
+        assert len(result.unconverted_metrics) == 1
 
 
 class TestImportDbtCli:
@@ -623,7 +611,6 @@ class TestImportDbtCli:
             datasource="test_db",
             storage=str(storage_dir),
             models_dir=None,
-            no_strict_aggregations=False,
             include_hidden_models=False,
         )
 
@@ -638,7 +625,8 @@ class TestImportDbtCli:
             "was likely discarded without run_sync"
         )
         assert persisted.name == "orders"
-        assert any(m.name == "total" for m in persisted.columns)
+        # The dbt measure 'total' becomes a ModelMeasure (not a Column) under v2.
+        assert any(m.name == "total" for m in persisted.measures)
 
 
 class TestParserRoundTrip:
@@ -683,13 +671,16 @@ class TestParserRoundTrip:
         assert m.data_source == "mydb"
         assert m.default_time_dimension == "order_date"
 
-        # Labels preserved
+        # Dimension labels preserved on Columns.
         status_dim = next(d for d in m.columns if d.name == "status")
         assert status_dim.label == "Order Status"
 
-        rev_measure = next(me for me in m.columns if me.name == "revenue")
+        # Measure labels live on the ModelMeasure (Q-D); the dbt measure
+        # 'revenue' has expr=amount so it lowers into a Column 'amount' and
+        # a ModelMeasure 'revenue' carrying the agg + label.
+        rev_measure = next(me for me in m.measures if me.name == "revenue")
         assert rev_measure.label == "Revenue"
-        assert rev_measure.allowed_aggregations == ["sum"]
+        assert rev_measure.formula == "amount:sum"
 
 
 def _sample_slayer_model(name: str = "raw_events") -> SlayerModel:
@@ -932,14 +923,20 @@ DbtMeasure(name="total_claim_amount", agg="sum", expr="claim_amount")
                 ),
             ],
         )
-        result = DbtToSlayerConverter(project=project, data_source="test", strict_aggregations=True).convert()
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
         ca = next(m for m in result.models if m.name == "claim_amount")
-        filtered_measure = next((m for m in ca.columns if m.name == "loss_payment_amount"), None)
-        assert filtered_measure is not None, "Filtered measure not created"
-        # The filter must be qualified with the peer model name
-        assert "loss_payment.has_loss_payment" in filtered_measure.filter, (
-            f"Filter not qualified: {filtered_measure.filter!r}"
+        # The filtered metric becomes a (Column with .filter) + (ModelMeasure
+        # pointing at it). Find the Column carrying the filter.
+        filtered_cols = [c for c in ca.columns if c.filter is not None]
+        assert len(filtered_cols) == 1, "Filtered Column not created"
+        actual_filter = filtered_cols[0].filter or ""
+        assert "loss_payment.has_loss_payment" in actual_filter, (
+            f"Filter not qualified: {actual_filter!r}"
         )
+        # And the ModelMeasure references that column.
+        loss_metric = next(m for m in ca.measures if m.name == "loss_payment_amount")
+        assert loss_metric.label == "Loss Payment Amount"
+        assert loss_metric.formula == f"{filtered_cols[0].name}:sum"
 
     def test_filter_dim_on_source_model_stays_bare(self) -> None:
         """Dimension('orders__status') where status exists on orders → bare 'status'."""
@@ -967,11 +964,15 @@ DbtMeasure(name="revenue", agg="sum", expr="amount")
                 ),
             ],
         )
-        result = DbtToSlayerConverter(project=project, data_source="test", strict_aggregations=True).convert()
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
         orders = next(m for m in result.models if m.name == "orders")
-        filtered_measure = next((m for m in orders.columns if m.name == "active_revenue"), None)
-        assert filtered_measure is not None
-        assert filtered_measure.filter == "status = 'active'", f"Got: {filtered_measure.filter!r}"
+        filtered_cols = [c for c in orders.columns if c.filter is not None]
+        assert len(filtered_cols) == 1
+        assert filtered_cols[0].filter == "status = 'active'", (
+            f"Got: {filtered_cols[0].filter!r}"
+        )
+        active_rev = next(m for m in orders.measures if m.name == "active_revenue")
+        assert active_rev.label == "Active Revenue"
         assert not result.models[0].hidden
 
 
@@ -1043,3 +1044,251 @@ class TestJoinTypeFromDbt:
         assert reverse is not None, f"Missing reverse join. Policy joins: {[j.target_model for j in policy.joins]}"
         assert str(reverse.join_type) == "inner"
         assert reverse.join_pairs == [["id", "policy_id"]]
+
+
+class TestColumnNamingS4:
+    """S4 specifics: Column-name resolution rules in _convert_measures."""
+
+    def test_non_identifier_expr_uses_first_name_col_suffix(self) -> None:
+        """Q-I: a SQL fragment expr (not a bare identifier) gets the first
+        dbt measure's name + ``_col`` as the SLayer Column name.
+        """
+        project = DbtProject(semantic_models=[
+            DbtSemanticModel(
+                name="orders",
+                model="orders",
+                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                measures=[
+                    DbtMeasure(name="line_total", agg="sum", expr="amount * quantity"),
+                    DbtMeasure(name="line_max", agg="max", expr="amount * quantity"),
+                ],
+            ),
+        ])
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = result.models[0]
+
+        # One Column for the SQL fragment, named after the first dbt measure.
+        col_names = {c.name for c in orders.columns}
+        assert "line_total_col" in col_names
+        line_col = next(c for c in orders.columns if c.name == "line_total_col")
+        assert line_col.sql == "amount * quantity"
+        assert line_col.allowed_aggregations is None
+        assert line_col.format is not None
+        assert line_col.format.type == NumberFormatType.FLOAT
+
+        # ModelMeasures point at that column with their respective aggs.
+        by_name = {m.name: m for m in orders.measures}
+        assert by_name["line_total"].formula == "line_total_col:sum"
+        assert by_name["line_max"].formula == "line_total_col:max"
+
+    def test_column_name_collision_with_measure_name_suffixed_with_col(self) -> None:
+        """Q-2: when the natural Column name (= the bare expr) would collide
+        with a ModelMeasure name, suffix the Column with ``_col``.
+        """
+        project = DbtProject(semantic_models=[
+            DbtSemanticModel(
+                name="orders",
+                model="orders",
+                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                measures=[
+                    # expr == name → Column would naturally be named "revenue",
+                    # but the ModelMeasure for this same dbt measure is also
+                    # named "revenue". Suffix the Column to break the tie.
+                    DbtMeasure(name="revenue", agg="sum", expr="revenue"),
+                ],
+            ),
+        ])
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = result.models[0]
+
+        col_names = {c.name for c in orders.columns}
+        assert "revenue_col" in col_names
+        # Bare "revenue" must NOT also be a Column — it's the ModelMeasure name.
+        assert "revenue" not in col_names
+
+        rev_meas = next(m for m in orders.measures if m.name == "revenue")
+        assert rev_meas.formula == "revenue_col:sum"
+
+    def test_label_and_description_on_model_measure_only(self) -> None:
+        """Q-D: label/description live on the ModelMeasure verbatim — no
+        ``Default aggregation: …`` tail, and the Column itself has neither.
+        """
+        project = DbtProject(semantic_models=[
+            DbtSemanticModel(
+                name="orders",
+                model="orders",
+                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                measures=[
+                    DbtMeasure(
+                        name="revenue",
+                        agg="sum",
+                        expr="amount",
+                        label="Revenue",
+                        description="Total revenue",
+                    ),
+                ],
+            ),
+        ])
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = result.models[0]
+
+        amount_col = next(c for c in orders.columns if c.name == "amount")
+        assert amount_col.label is None
+        assert amount_col.description is None
+
+        rev = next(m for m in orders.measures if m.name == "revenue")
+        assert rev.label == "Revenue"
+        assert rev.description == "Total revenue"
+
+
+class TestDbtMeasureToModelMeasure:
+    """Step 7 (Q-1, Q-5, Q-6): metrics fold into ModelMeasures, not SlayerQuery dicts."""
+
+    def test_ratio_metric_becomes_model_measure(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[
+                        DbtMeasure(name="total_amount", agg="sum", expr="amount"),
+                        DbtMeasure(name="order_count", agg="count", expr="id"),
+                    ],
+                ),
+            ],
+            metrics=[
+                DbtMetric(
+                    name="aov",
+                    type="ratio",
+                    type_params=DbtMetricTypeParams(
+                        numerator=DbtMetricInput(name="total_amount"),
+                        denominator=DbtMetricInput(name="order_count"),
+                    ),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = next(m for m in result.models if m.name == "orders")
+
+        aov = next(m for m in orders.measures if m.name == "aov")
+        # Q-5: bare ModelMeasure names — formula refs total_amount / order_count
+        assert aov.formula == "total_amount / order_count"
+
+    def test_cumulative_metric_becomes_model_measure(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[
+                        DbtMeasure(name="revenue", agg="sum", expr="amount"),
+                    ],
+                ),
+            ],
+            metrics=[
+                DbtMetric(
+                    name="cumulative_revenue",
+                    type="cumulative",
+                    type_params=DbtMetricTypeParams(measure="revenue"),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        orders = next(m for m in result.models if m.name == "orders")
+        cum = next(m for m in orders.measures if m.name == "cumulative_revenue")
+        assert cum.formula == "cumsum(revenue)"
+
+
+class TestFindMetricSourceModelRatio:
+    """Q-E regression: _find_metric_source_model must walk numerator/denominator."""
+
+    def test_find_metric_source_model_resolves_ratio_numerator_denominator(self) -> None:
+        """A ratio metric whose source is reachable only through its
+        numerator (or denominator) must still resolve."""
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[
+                        DbtMeasure(name="total_amount", agg="sum", expr="amount"),
+                        DbtMeasure(name="order_count", agg="count", expr="id"),
+                    ],
+                ),
+            ],
+            metrics=[
+                # Ratio metric — only reachable via numerator/denominator names,
+                # NOT via type_params.measure or type_params.metrics.
+                DbtMetric(
+                    name="aov",
+                    type="ratio",
+                    type_params=DbtMetricTypeParams(
+                        numerator=DbtMetricInput(name="total_amount"),
+                        denominator=DbtMetricInput(name="order_count"),
+                    ),
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+        # Source resolution worked — the ModelMeasure ended up on orders.
+        orders = next(m for m in result.models if m.name == "orders")
+        assert any(m.name == "aov" for m in orders.measures), (
+            "Ratio metric source model not resolved via numerator/denominator"
+        )
+
+
+class TestDbtConversionErrorOnDimMeasureCollision:
+    """Q-G: a semantic model whose dim and measure share a name must hard-fail."""
+
+    def test_dim_measure_name_collision_raises_dbt_conversion_error(self) -> None:
+        project = DbtProject(semantic_models=[
+            DbtSemanticModel(
+                name="orders",
+                model="orders",
+                entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                dimensions=[DbtDimension(name="amount", type="categorical")],
+                measures=[DbtMeasure(name="amount", agg="sum", expr="amount")],
+            ),
+        ])
+        with pytest.raises(DbtConversionError) as exc_info:
+            DbtToSlayerConverter(project=project, data_source="test").convert()
+        msg = str(exc_info.value)
+        assert "orders" in msg
+        assert "amount" in msg
+
+
+class TestUnconvertedTransformShadowing:
+    """Q-F: a dbt measure or metric named after a SLayer transform is routed
+    to ``unconverted_metrics`` rather than crashing."""
+
+    def test_unconverted_metrics_for_transform_shadowing_name(self) -> None:
+        project = DbtProject(
+            semantic_models=[
+                DbtSemanticModel(
+                    name="orders",
+                    model="orders",
+                    entities=[DbtEntity(name="order_id", type="primary", expr="id")],
+                    measures=[
+                        # Valid measure to anchor the model (so we can test
+                        # the metric-side transform shadowing path).
+                        DbtMeasure(name="total", agg="sum", expr="amount"),
+                        # ``cumsum`` is a SLayer transform — ModelMeasure
+                        # construction must reject it and route to unconverted.
+                        DbtMeasure(name="cumsum", agg="sum", expr="amount"),
+                    ],
+                ),
+            ],
+        )
+        result = DbtToSlayerConverter(project=project, data_source="test").convert()
+
+        # The good measure converted normally.
+        orders = next(m for m in result.models if m.name == "orders")
+        assert any(m.name == "total" for m in orders.measures)
+        # The shadowing measure was routed to unconverted_metrics.
+        assert any(
+            u.metric_name == "cumsum"
+            for u in result.unconverted_metrics
+        )


### PR DESCRIPTION
Closes #48.

## Context

S3 / S3a landed the v2 schema migration: `SlayerModel.columns` (a single unified list replacing v1's `dimensions` + `measures`) and `SlayerModel.measures` (a library of named `ModelMeasure` formulas). S4 brings auto-ingestion and the dbt converter into that shape.

## Part A — auto-ingestion

Mostly already correct after S3a (`_columns_to_model` already emits one `Column` per non-joined column with `name`/`sql`/`type`/`primary_key`/numeric `format`, and leaves `SlayerModel.measures` empty). This PR adds:

- Light comment cleanup in `slayer/engine/ingestion.py` to drop v1-flavoured language.
- `tests/integration/test_ingestion_jaffle_shop.py` — 18 parametrized integration tests against the bundled Jaffle Shop DuckDB asserting:
  - exact column counts/types/PKs per ingested model;
  - direct-FK joins only (multi-hop is query-time);
  - `model.measures == []` for every ingested model;
  - no dotted column names leak from joined tables;
  - YAML round-trip writes v2 shape with no v1 keys on disk.

## Part B — dbt converter rewrite (`slayer/dbt/converter.py`)

The converter previously baked the dbt aggregation into `Column.allowed_aggregations` and emitted derived/ratio/cumulative metrics as `SlayerQuery` dicts written to `queries.yaml`. After this PR every dbt artefact lowers into a `Column` + `ModelMeasure` pair on the source semantic model.

**Measures (`_convert_measures`)** — returns `(List[Column], List[ModelMeasure])`:
- One `Column` per **unique expr** (consolidation preserved); the Column carries the bare expression in `sql`, `type=DataType.NUMBER`, `format=NumberFormat(type=FLOAT)`, no `allowed_aggregations` whitelist.
- Column naming:
  - bare-identifier expr → use as the Column name;
  - non-identifier SQL fragment → `<first_dbt_measure_name>_col`;
  - collision with a `ModelMeasure` name on the same model → suffix `_col`.
- One `ModelMeasure` per dbt measure with `formula=\"<col_name>:<agg>\"`. `label`/`description` go on the `ModelMeasure` only — verbatim from dbt, no synthesised `Default aggregation: …` tail and no consolidation description on the underlying Column.

**Metrics** — fold into `ModelMeasure` formulas on the source semantic model:
- **Simple (with filter)**: emit a `Column` carrying the WHERE filter (no `allowed_aggregations`) plus a `ModelMeasure` referencing it.
- **Simple (no filter)**: nothing new — the underlying measure is already addressable.
- **Derived**: `formula=\"a + b\"` (bare ModelMeasure-name refs, Q-5).
- **Ratio**: `formula=\"a / b\"`.
- **Cumulative**: `formula=\"cumsum(measure_name)\"`.

**Removed surface**:
- `DbtToSlayerConverter(strict_aggregations=…)` parameter and `--no-strict-aggregations` CLI flag.
- `ConversionResult.queries` field, `queries.yaml` write block in `_run_import_dbt`, `_queries_dir_for_storage` helper.

**New surface**:
- `ConversionResult.unconverted_metrics: List[ConversionWarning]` — metrics that cannot be expressed as a `ModelMeasure` (conversion metrics, unknown types, transform-name shadowing). Printed by the CLI with an `UNCONVERTED [<context>]` tag.
- `DbtConversionError` — raised when a semantic model has the same name as both a dimension and a measure (SLayer columns and measures share a single namespace per model — must hard-fail rather than silently lose data). Includes the offending `(model, names)` in the message.
- `_find_metric_source_model` and `_resolve_metric_source` now walk `numerator`/`denominator` for ratio metrics whose source is reachable only through one of those sides (regression fix Q-E).
- `ModelMeasure(...)` construction at all four sites (per-measure + 3 metric helpers) is wrapped in `try/except ValueError` so transform-name shadowing (`cumsum`, `lag`, `lead`, `change`, `change_pct`, `time_shift`, `rank`, `first`, `last`) routes to `unconverted_metrics` (Q-F).

## CLI / Docs

- `slayer/cli.py`: removed `--no-strict-aggregations` and `_queries_dir_for_storage`; added `unconverted_metrics` print path; final summary now reports `K unconverted metrics, W warnings`.
- `slayer/storage/base.py`: dropped a stale `queries.yaml` mention from a docstring.
- `docs/dbt/dbt_import.md`, `docs/reference/cli.md`, `docs/interfaces/cli.md`: reshaped the Measures and Metrics sections to describe the Column + ModelMeasure split, bare-name metric refs, `unconverted_metrics`, and the dim/measure collision hard-fail; removed `--no-strict-aggregations` from CLI flag tables.

## Tests

`tests/test_dbt_converter.py`:
- Existing tests updated for the new shape (`allowed_aggregations` → ModelMeasure, `result.queries` → `m.measures`, kwargs cleanup).
- Deleted `TestQueriesDirForStorage` and `test_no_strict_aggregations`.
- New: `TestColumnNamingS4` (Q-2 / Q-I / Q-D), `TestDbtMeasureToModelMeasure` (Q-1 / Q-5 / Q-6), `TestFindMetricSourceModelRatio` (Q-E), `TestDbtConversionErrorOnDimMeasureCollision` (Q-G), `TestUnconvertedTransformShadowing` (Q-F).

## Test plan

- [x] \`poetry run pytest -m \"not integration\"\` — 1055 passed.
- [x] \`poetry run pytest tests/integration/test_ingestion_jaffle_shop.py -m integration\` — 18 passed.
- [x] \`poetry run ruff check slayer/ tests/\` — clean.
- [ ] Existing SQLite / Postgres / DuckDB integration suites still pass (please run in CI).
- [ ] Sanity-check \`slayer import-dbt\` against a small dbt project: every dbt measure name appears as a ModelMeasure on its semantic model with formula \`\"<col>:<agg>\"\`; every dbt metric (simple-with-filter, derived, ratio, cumulative) appears as a ModelMeasure; no \`queries.yaml\` is written; final summary includes \`unconverted metrics\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised dbt import docs: measures/metrics now described as per new v2 conversion and clearer unconverted-metrics reporting
  * Updated CLI reference to remove the deprecated flag

* **Breaking Changes**
  * Removed documented CLI flag for import
  * Import no longer writes generated metric queries to a queries.yaml artifact

* **Validation**
  * Import now hard-fails when a model defines a dimension and measure with the same name

* **Tests**
  * Added integration and converter tests validating the new v2 import behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->