### PR TITLE
Fix ClickHouse type ingestion mapping numerics to STRING (closes #62)

### DIFF
--- a/examples/clickhouse/verify.py
+++ b/examples/clickhouse/verify.py
@@ -24,31 +24,44 @@ if __name__ == "__main__":
     check("4 models (no rollup)", len(models) == 4)
     check_rollup(expect_rollup=False)
     # Regression for issue #62 — ClickHouse Int32 / Float64 / DateTime must
-    # round-trip as the right DataType, not as STRING.
-    check_column_types("orders", {
-        "id": "number",
-        "customer_id": "number",
-        "product_id": "number",
-        "quantity": "number",
-        "status": "string",
-        "created_at": "timestamp",
-    })
-    check_column_types("customers", {
-        "id": "number",
-        "name": "string",
-        "email": "string",
-        "region_id": "number",
-    })
-    check_column_types("products", {
-        "id": "number",
-        "name": "string",
-        "category": "string",
-        "price": "number",
-    })
-    check_column_types("regions", {
-        "id": "number",
-        "name": "string",
-    })
+    # round-trip as the right DataType, not as STRING. Note: DataType.TIMESTAMP
+    # serialises as the string "time" (see slayer/core/enums.py).
+    check_column_types(
+        model_name="orders",
+        expected_types={
+            "id": "number",
+            "customer_id": "number",
+            "product_id": "number",
+            "quantity": "number",
+            "status": "string",
+            "created_at": "time",
+        },
+    )
+    check_column_types(
+        model_name="customers",
+        expected_types={
+            "id": "number",
+            "name": "string",
+            "email": "string",
+            "region_id": "number",
+        },
+    )
+    check_column_types(
+        model_name="products",
+        expected_types={
+            "id": "number",
+            "name": "string",
+            "category": "string",
+            "price": "number",
+        },
+    )
+    check_column_types(
+        model_name="regions",
+        expected_types={
+            "id": "number",
+            "name": "string",
+        },
+    )
     # Exercises the parametric quantile(p)(x) syntax SLayer emits for ClickHouse.
     check_median_percentile()
     summary()

--- a/examples/clickhouse/verify.py
+++ b/examples/clickhouse/verify.py
@@ -15,6 +15,7 @@ from verify_common import (
     check_rollup,
     check_median_percentile,
     check,
+    check_column_types,
     summary,
 )
 
@@ -22,6 +23,32 @@ if __name__ == "__main__":
     models = run_common_checks()
     check("4 models (no rollup)", len(models) == 4)
     check_rollup(expect_rollup=False)
+    # Regression for issue #62 — ClickHouse Int32 / Float64 / DateTime must
+    # round-trip as the right DataType, not as STRING.
+    check_column_types("orders", {
+        "id": "number",
+        "customer_id": "number",
+        "product_id": "number",
+        "quantity": "number",
+        "status": "string",
+        "created_at": "timestamp",
+    })
+    check_column_types("customers", {
+        "id": "number",
+        "name": "string",
+        "email": "string",
+        "region_id": "number",
+    })
+    check_column_types("products", {
+        "id": "number",
+        "name": "string",
+        "category": "string",
+        "price": "number",
+    })
+    check_column_types("regions", {
+        "id": "number",
+        "name": "string",
+    })
     # Exercises the parametric quantile(p)(x) syntax SLayer emits for ClickHouse.
     check_median_percentile()
     summary()

--- a/examples/verify_common.py
+++ b/examples/verify_common.py
@@ -51,7 +51,7 @@ def check_column_types(model_name, expected_types):
     """Assert /models/{name} returns the expected DataType strings.
 
     expected_types: dict mapping column name to DataType .value string
-        (e.g. "number", "string", "timestamp", "date"). Columns absent
+        (e.g. "number", "string", "time", "date"). Columns absent
         from the dict are ignored — different dialects expose different
         column sets, and this helper is a positive-coverage check, not
         an exhaustive schema comparison.

--- a/examples/verify_common.py
+++ b/examples/verify_common.py
@@ -47,6 +47,29 @@ def check(name, condition):
         _failed += 1
 
 
+def check_column_types(model_name, expected_types):
+    """Assert /models/{name} returns the expected DataType strings.
+
+    expected_types: dict mapping column name to DataType .value string
+        (e.g. "number", "string", "timestamp", "date"). Columns absent
+        from the dict are ignored — different dialects expose different
+        column sets, and this helper is a positive-coverage check, not
+        an exhaustive schema comparison.
+    """
+    model = api("GET", f"/models/{model_name}")
+    columns_by_name = {c["name"]: c for c in model.get("columns", [])}
+    for col_name, expected_type in expected_types.items():
+        col = columns_by_name.get(col_name)
+        check(f"{model_name}.{col_name} exists", col is not None)
+        if col is None:
+            continue
+        actual = col.get("type")
+        check(
+            f"{model_name}.{col_name} type = {expected_type} (got {actual!r})",
+            actual == expected_type,
+        )
+
+
 def summary():
     """Print summary and exit with appropriate code."""
     print(f"\n{'=' * 40}")

--- a/slayer/engine/ingestion.py
+++ b/slayer/engine/ingestion.py
@@ -19,6 +19,10 @@ from slayer.core.models import Column, DatasourceConfig, ModelJoin, SlayerModel
 
 logger = logging.getLogger(__name__)
 
+# Module-level dedup set for unrecognized SA type warnings (see
+# _sa_type_to_data_type). Keyed by upper-cased class name.
+_logged_unmapped_sa_types: Set[str] = set()
+
 # Map SQLAlchemy types to SLayer DataTypes
 _SA_TYPE_MAP = {
     "INTEGER": DataType.NUMBER,
@@ -44,6 +48,23 @@ _SA_TYPE_MAP = {
     "TIME": DataType.TIMESTAMP,
     "SERIAL": DataType.NUMBER,
     "BIGSERIAL": DataType.NUMBER,
+    # ClickHouse adapter type names (clickhouse-sqlalchemy)
+    "INT8": DataType.NUMBER,
+    "INT16": DataType.NUMBER,
+    "INT32": DataType.NUMBER,
+    "INT64": DataType.NUMBER,
+    "INT128": DataType.NUMBER,
+    "INT256": DataType.NUMBER,
+    "UINT8": DataType.NUMBER,
+    "UINT16": DataType.NUMBER,
+    "UINT32": DataType.NUMBER,
+    "UINT64": DataType.NUMBER,
+    "UINT128": DataType.NUMBER,
+    "UINT256": DataType.NUMBER,
+    "FLOAT32": DataType.NUMBER,
+    "FLOAT64": DataType.NUMBER,
+    "DATETIME64": DataType.TIMESTAMP,
+    "DATE32": DataType.DATE,
 }
 
 _NUMERIC_TYPES = {DataType.NUMBER}
@@ -57,8 +78,16 @@ _FLOAT_LIKE_SA_TYPES = frozenset(
         "REAL",
         "DOUBLE",
         "DOUBLE_PRECISION",
+        # ClickHouse adapter (clickhouse-sqlalchemy)
+        "FLOAT32",
+        "FLOAT64",
     }
 )
+
+# ClickHouse SA wrapper class names — peeled before type lookup.
+# clickhouse-sqlalchemy exposes the inner type via .nested_type on both.
+_CLICKHOUSE_WRAPPER_NAMES = frozenset({"NULLABLE", "LOWCARDINALITY"})
+_CLICKHOUSE_WRAPPER_MAX_DEPTH = 8
 
 # NUMERIC/DECIMAL type names — float-like only when scale > 0
 _NUMERIC_DECIMAL_TYPES = frozenset({"NUMERIC", "DECIMAL"})
@@ -100,13 +129,41 @@ def _is_id_column(name: str) -> bool:
     return lower == "id" or lower.endswith(_ID_SUFFIXES)
 
 
+def _unwrap_clickhouse_wrappers(sa_type: sa.types.TypeEngine) -> sa.types.TypeEngine:
+    """Recursively peel ClickHouse Nullable(...) / LowCardinality(...) wrappers.
+
+    Returns the innermost non-wrapper type. Handles arbitrary nesting order
+    (e.g. LowCardinality(Nullable(String))). If the wrapper's `.nested_type`
+    attribute is missing (e.g. an upstream rename), returns the wrapper as-is
+    so the caller's normal fallback path runs.
+    """
+    current = sa_type
+    for _ in range(_CLICKHOUSE_WRAPPER_MAX_DEPTH):
+        if type(current).__name__.upper() not in _CLICKHOUSE_WRAPPER_NAMES:
+            return current
+        inner = getattr(current, "nested_type", None)
+        if inner is None:
+            return current
+        current = inner
+    return current
+
+
 def _sa_type_to_data_type(sa_type: sa.types.TypeEngine) -> DataType:
+    sa_type = _unwrap_clickhouse_wrappers(sa_type)
     type_name = type(sa_type).__name__.upper()
     if type_name in _SA_TYPE_MAP:
         return _SA_TYPE_MAP[type_name]
     type_str = str(sa_type).split("(")[0].upper().strip()
     if type_str in _SA_TYPE_MAP:
         return _SA_TYPE_MAP[type_str]
+    if type_name not in _logged_unmapped_sa_types:
+        _logged_unmapped_sa_types.add(type_name)
+        logger.warning(
+            "Unrecognized SQLAlchemy type %r (str=%r); falling back to "
+            "DataType.STRING. Consider adding to _SA_TYPE_MAP.",
+            type_name,
+            str(sa_type),
+        )
     return DataType.STRING
 
 
@@ -117,6 +174,7 @@ def _sa_type_is_float(sa_type: sa.types.TypeEngine) -> bool:
     only when their scale is > 0 (or unknown), so NUMERIC(10,0) is treated as
     integer-like.
     """
+    sa_type = _unwrap_clickhouse_wrappers(sa_type)
     type_name = type(sa_type).__name__.upper()
     if type_name in _FLOAT_LIKE_SA_TYPES:
         return True

--- a/tests/test_ingestion_clickhouse.py
+++ b/tests/test_ingestion_clickhouse.py
@@ -1,0 +1,204 @@
+"""ClickHouse-specific type-mapping tests for ingestion.
+
+Skipped when the `clickhouse` extra is not installed (clickhouse_sqlalchemy
+absent). Existing dialect-agnostic tests live in tests/test_ingestion.py and
+remain unconditional.
+"""
+
+import logging
+
+import pytest
+
+ch_types = pytest.importorskip("clickhouse_sqlalchemy.types")
+
+from slayer.core.enums import DataType
+from slayer.engine import ingestion
+from slayer.engine.ingestion import (
+    _sa_type_is_float,
+    _sa_type_to_data_type,
+    _unwrap_clickhouse_wrappers,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_warning_dedup():
+    """Ensure each test sees a clean warning dedup set."""
+    ingestion._logged_unmapped_sa_types.clear()
+    yield
+    ingestion._logged_unmapped_sa_types.clear()
+
+
+class TestClickHouseIntTypes:
+    @pytest.mark.parametrize(
+        "sa_type_cls",
+        [
+            ch_types.Int8,
+            ch_types.Int16,
+            ch_types.Int32,
+            ch_types.Int64,
+            ch_types.Int128,
+            ch_types.Int256,
+            ch_types.UInt8,
+            ch_types.UInt16,
+            ch_types.UInt32,
+            ch_types.UInt64,
+            ch_types.UInt128,
+            ch_types.UInt256,
+        ],
+    )
+    def test_int_maps_to_number_not_float(self, sa_type_cls):
+        sa_type = sa_type_cls()
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is False
+
+
+class TestClickHouseFloatTypes:
+    @pytest.mark.parametrize("sa_type_cls", [ch_types.Float32, ch_types.Float64])
+    def test_float_maps_to_number_and_is_float(self, sa_type_cls):
+        sa_type = sa_type_cls()
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is True
+
+
+class TestClickHouseDecimalScaleAware:
+    @pytest.mark.parametrize(
+        "scale,expect_float",
+        [
+            (2, True),
+            (0, False),
+        ],
+    )
+    def test_decimal_scale_decides_float(self, scale, expect_float):
+        sa_type = ch_types.Decimal(10, scale)
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is expect_float
+
+
+class TestClickHouseDateTimeTypes:
+    def test_datetime_maps_to_timestamp(self):
+        assert _sa_type_to_data_type(ch_types.DateTime()) is DataType.TIMESTAMP
+
+    def test_datetime64_maps_to_timestamp(self):
+        assert _sa_type_to_data_type(ch_types.DateTime64(3)) is DataType.TIMESTAMP
+
+    def test_date_maps_to_date(self):
+        assert _sa_type_to_data_type(ch_types.Date()) is DataType.DATE
+
+    def test_date32_maps_to_date(self):
+        assert _sa_type_to_data_type(ch_types.Date32()) is DataType.DATE
+
+
+class TestClickHouseNullableUnwrap:
+    def test_nullable_int(self):
+        sa_type = ch_types.Nullable(ch_types.Int32())
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is False
+
+    def test_nullable_float(self):
+        sa_type = ch_types.Nullable(ch_types.Float64())
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is True
+
+    def test_nullable_decimal_float(self):
+        sa_type = ch_types.Nullable(ch_types.Decimal(10, 2))
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is True
+
+    def test_nullable_decimal_integer(self):
+        sa_type = ch_types.Nullable(ch_types.Decimal(10, 0))
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is False
+
+
+class TestClickHouseLowCardinalityUnwrap:
+    def test_low_cardinality_string(self):
+        sa_type = ch_types.LowCardinality(ch_types.String())
+        assert _sa_type_to_data_type(sa_type) is DataType.STRING
+
+    def test_low_cardinality_int(self):
+        sa_type = ch_types.LowCardinality(ch_types.Int32())
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is False
+
+
+class TestClickHouseNestedWrappers:
+    def test_low_cardinality_nullable_string(self):
+        sa_type = ch_types.LowCardinality(ch_types.Nullable(ch_types.String()))
+        assert _sa_type_to_data_type(sa_type) is DataType.STRING
+
+    def test_nullable_low_cardinality_int(self):
+        sa_type = ch_types.Nullable(ch_types.LowCardinality(ch_types.Int32()))
+        assert _sa_type_to_data_type(sa_type) is DataType.NUMBER
+        assert _sa_type_is_float(sa_type) is False
+
+
+class TestUnwrapHelper:
+    def test_unwrap_nullable_returns_inner(self):
+        inner = ch_types.Int32()
+        unwrapped = _unwrap_clickhouse_wrappers(ch_types.Nullable(inner))
+        assert type(unwrapped).__name__ == "Int32"
+
+    def test_unwrap_low_cardinality_returns_inner(self):
+        inner = ch_types.Int32()
+        unwrapped = _unwrap_clickhouse_wrappers(ch_types.LowCardinality(inner))
+        assert type(unwrapped).__name__ == "Int32"
+
+    def test_unwrap_nested_returns_innermost(self):
+        unwrapped = _unwrap_clickhouse_wrappers(
+            ch_types.LowCardinality(ch_types.Nullable(ch_types.String()))
+        )
+        assert type(unwrapped).__name__ == "String"
+
+    def test_unwrap_non_wrapper_returns_self(self):
+        sa_type = ch_types.Int32()
+        assert _unwrap_clickhouse_wrappers(sa_type) is sa_type
+
+
+class _FakeUnknownType:
+    """Stand-in for an unrecognized SA type — bypasses MagicMock quirks
+    around overriding ``type(obj).__name__``.
+    """
+
+    def __str__(self) -> str:
+        return "FakeUnknownType()"
+
+
+class _AnotherUnknownType:
+    def __str__(self) -> str:
+        return "AnotherUnknownType(123)"
+
+
+class TestUnmappedTypeWarning:
+    def test_warning_fires_once_per_type_name(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
+            for _ in range(3):
+                result = _sa_type_to_data_type(_FakeUnknownType())  # type: ignore[arg-type]
+                assert result is DataType.STRING
+
+        relevant = [
+            r for r in caplog.records if "FAKEUNKNOWNTYPE" in r.getMessage().upper()
+        ]
+        assert len(relevant) == 1
+
+    def test_warning_message_contains_class_name_and_str(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
+            _sa_type_to_data_type(_AnotherUnknownType())  # type: ignore[arg-type]
+
+        relevant = [
+            r
+            for r in caplog.records
+            if "ANOTHERUNKNOWNTYPE" in r.getMessage().upper()
+        ]
+        assert len(relevant) == 1
+        msg = relevant[0].getMessage()
+        assert "ANOTHERUNKNOWNTYPE" in msg.upper()
+        assert "AnotherUnknownType(123)" in msg
+
+    def test_warning_dedup_isolated_between_distinct_types(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
+            _sa_type_to_data_type(_FakeUnknownType())  # type: ignore[arg-type]
+            _sa_type_to_data_type(_AnotherUnknownType())  # type: ignore[arg-type]
+
+        msgs = [r.getMessage().upper() for r in caplog.records]
+        assert any("FAKEUNKNOWNTYPE" in m for m in msgs)
+        assert any("ANOTHERUNKNOWNTYPE" in m for m in msgs)

--- a/tests/test_ingestion_clickhouse.py
+++ b/tests/test_ingestion_clickhouse.py
@@ -8,6 +8,7 @@ remain unconditional.
 import logging
 
 import pytest
+import sqlalchemy as sa
 
 ch_types = pytest.importorskip("clickhouse_sqlalchemy.types")
 
@@ -154,16 +155,17 @@ class TestUnwrapHelper:
         assert _unwrap_clickhouse_wrappers(sa_type) is sa_type
 
 
-class _FakeUnknownType:
-    """Stand-in for an unrecognized SA type — bypasses MagicMock quirks
-    around overriding ``type(obj).__name__``.
+class _FakeUnknownType(sa.types.TypeEngine):
+    """Stand-in for an unrecognized SA type. Inherits TypeEngine so the
+    function-signature contract is satisfied for static analysers without
+    needing per-call type: ignore.
     """
 
     def __str__(self) -> str:
         return "FakeUnknownType()"
 
 
-class _AnotherUnknownType:
+class _AnotherUnknownType(sa.types.TypeEngine):
     def __str__(self) -> str:
         return "AnotherUnknownType(123)"
 
@@ -172,7 +174,7 @@ class TestUnmappedTypeWarning:
     def test_warning_fires_once_per_type_name(self, caplog):
         with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
             for _ in range(3):
-                result = _sa_type_to_data_type(_FakeUnknownType())  # type: ignore[arg-type]
+                result = _sa_type_to_data_type(_FakeUnknownType())
                 assert result is DataType.STRING
 
         relevant = [
@@ -182,7 +184,7 @@ class TestUnmappedTypeWarning:
 
     def test_warning_message_contains_class_name_and_str(self, caplog):
         with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
-            _sa_type_to_data_type(_AnotherUnknownType())  # type: ignore[arg-type]
+            _sa_type_to_data_type(_AnotherUnknownType())
 
         relevant = [
             r
@@ -196,8 +198,8 @@ class TestUnmappedTypeWarning:
 
     def test_warning_dedup_isolated_between_distinct_types(self, caplog):
         with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
-            _sa_type_to_data_type(_FakeUnknownType())  # type: ignore[arg-type]
-            _sa_type_to_data_type(_AnotherUnknownType())  # type: ignore[arg-type]
+            _sa_type_to_data_type(_FakeUnknownType())
+            _sa_type_to_data_type(_AnotherUnknownType())
 
         msgs = [r.getMessage().upper() for r in caplog.records]
         assert any("FAKEUNKNOWNTYPE" in m for m in msgs)


### PR DESCRIPTION
## Summary

Issue [#62](https://github.com/MotleyAI/slayer/issues/62): every ClickHouse column was auto-ingested as `DataType.STRING` because `_SA_TYPE_MAP` (in `slayer/engine/ingestion.py:103`) only contained generic SQL names (`INTEGER`, `FLOAT`, …). The `clickhouse-sqlalchemy` adapter exposes `Int8`/.../`Int256`, `UInt8`/.../`UInt256`, `Float32`/`Float64`, `Date32`, `DateTime64`, `Nullable(T)`, `LowCardinality(T)` — none matched, so all numeric/date columns fell through to the silent `return DataType.STRING` fallback. The repro `quantity:median` failed with `"Aggregation 'median' is not applicable to string measure"`.

- Extend `_SA_TYPE_MAP` with all ClickHouse integer / float / extended date-time class names; extend `_FLOAT_LIKE_SA_TYPES` with `FLOAT32`/`FLOAT64`. (`Decimal` is already covered: `clickhouse-sqlalchemy` exports a single `Decimal` class whose name resolves via the existing `DECIMAL` entry, and the existing scale-aware logic handles it.)
- New `_unwrap_clickhouse_wrappers()` recursively peels `Nullable` and `LowCardinality` (any nesting order, depth-limited at 8) by reading `.nested_type`. Called as the first line of both `_sa_type_to_data_type` and `_sa_type_is_float`, so `Nullable(Decimal(10,2))` is correctly float-like.
- Replace the silent STRING fallback with a once-per-class-name `WARNING` log carrying both class name and `str(sa_type)`. Any future adapter mismatch is now visible.

## Tests

New file `tests/test_ingestion_clickhouse.py` (35 cases, module-level `pytest.importorskip("clickhouse_sqlalchemy")` so it skips on minimal installs):

- Parametrized round-trip across all `Int*`/`UInt*`/`Float32`/`Float64`.
- `Decimal(10, scale)` scale-aware classification (scale=2 → float, scale=0 → integer).
- `Date` / `Date32` / `DateTime` / `DateTime64` mapping.
- `Nullable` and `LowCardinality` unwrap, including nested in either order.
- `_unwrap_clickhouse_wrappers` direct unit coverage.
- Warning dedup (3 identical-type calls → 1 log) and content (class name + `str`).

`examples/verify_common.py` gains a reusable `check_column_types(model, dict)` helper; `examples/clickhouse/verify.py` uses it to assert correct types on `orders`/`customers`/`products`/`regions`, complementing the existing `check_median_percentile()` canary which now passes post-fix.

Out of scope: no mapping for `UUID`/`FixedString`/`Enum*`/`IPv*`/`Array`/`Map`/`Tuple` (they continue falling through to STRING with the dedup'd warning); no `TypeEngine.as_generic()` fallback layer (separate architectural change); no new live integration suite.

## Test plan

- [x] `poetry run ruff check slayer/ tests/` — clean.
- [x] `poetry run pytest tests/test_ingestion_clickhouse.py -v` — all 35 pass.
- [x] `poetry run pytest --ignore=tests/integration` — 1086 passed, 0 failed (no regressions).
- [ ] Manual against the Docker example (requires PR #60 merged for `start.sh` model persistence):
  - [ ] `cd examples/clickhouse && docker compose up -d --build`
  - [ ] `curl -s http://localhost:5143/models/orders | jq '.columns[] | {name, type}'` — `id`/`customer_id`/`product_id`/`quantity` show `number`, `created_at` shows `timestamp`.
  - [ ] `curl -X POST http://localhost:5143/query -H 'Content-Type: application/json' -d '{"source_model":"orders","measures":[{"formula":"quantity:median"}]}'` — numeric result, not the type-mismatch error.
  - [ ] `python examples/clickhouse/verify.py` — every check passes including the new `check_column_types(...)` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ClickHouse type handling: unwraps wrapped types (Nullable, LowCardinality), better numeric/timestamp mapping, and deduplicated unmapped-type warnings.

* **Tests**
  * Added comprehensive ClickHouse type-mapping tests covering integers, floats/decimals, dates/times, wrappers, and warning deduplication.

* **Examples**
  * Added verification checks to ensure ClickHouse column types round-trip to expected logical types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->