### PR TITLE
Fix stale models_summary docstring (DEV-1319 follow-up)

### DIFF
--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -934,12 +934,12 @@ def create_mcp_server(storage: StorageBackend):
     async def models_summary(datasource_name: str, format: str = "markdown") -> str:
         """Brief summary of all (non-hidden) models in a datasource.
 
-        For each model: name, description, a table of its dimensions
-        (just name + description), a table of its measures (just name
-        + description), and a comma-separated list of the model names it joins
-        to. No field types, no distinct values, no sample data, and no
-        expansion of joined models' fields — call inspect_model for any of
-        that.
+        For each model: name, description, a table of its columns (name +
+        type + description), a table of its named-formula measures (name
+        + formula + description), and a comma-separated list of the model
+        names it joins to. No distinct values, no sample data, and no
+        expansion of joined models' fields — call inspect_model for any
+        of that.
 
         Args:
             datasource_name: Name of the datasource (from list_datasources).


### PR DESCRIPTION
## Summary

`mcp.models_summary`'s function body correctly emits `## Columns` and `## Measures (formula)` sections in v3 shape, but the docstring still described the output as "a table of its **dimensions** ... a table of its **measures** (just name + description)" — pre-v2 wording that DEV-1319 didn't catch.

This PR updates the docstring to match what the function actually returns: a columns table (name + type + description) and a named-formula measures table (name + formula + description).

## Test plan

- [x] `poetry run pytest` — 1423 passed (38 Postgres integration errors are environmental, unrelated to this change)
- [x] Manually verified the diff is docstring-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the documentation for the models summary tool to accurately describe its output, including column specifications with types and descriptions, named formulas, and model relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->