### PR TITLE
Add meta field to ModelMeasure and Aggregation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.4.1"
+version = "0.4.2"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -147,6 +147,7 @@ class ModelMeasure(BaseModel):
     name: Optional[str] = None
     label: Optional[str] = None
     description: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
 
     @field_validator("name")
     @classmethod
@@ -193,6 +194,7 @@ class Aggregation(BaseModel):
     formula: Optional[str] = None  # SQL template; None = use built-in formula
     params: List[AggregationParam] = Field(default_factory=list)
     description: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
 
     @model_validator(mode="after")
     def _require_formula_for_custom(self) -> "Aggregation":

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -1560,8 +1560,11 @@ def create_mcp_server(storage: StorageBackend):
                 ``allowed_aggregations`` (whitelist), ``filter`` (CASE WHEN inside aggregation),
                 ``label``, ``description``, ``hidden``, ``meta``.
             measures: List of named formula definitions on the model. Each:
-                {"name": "aov", "formula": "revenue:sum / *:count", "label": "..."}.
+                {"name": "aov", "formula": "revenue:sum / *:count", "label": "...",
+                 "description": "...", "meta": {...}}.
                 Queries can reference these by bare name (e.g. ``{"formula": "aov"}``).
+                ``meta`` is an optional opaque dict for caller bookkeeping
+                (e.g. linking the formula back to a source identifier).
             query: A SLayer query dict (or list of stage dicts for a multi-stage backing
                 query). When provided, the query is saved as the model's ``source_queries``
                 and the model becomes query-backed. Mutually exclusive with sql_table, sql,
@@ -1707,11 +1710,15 @@ def create_mcp_server(storage: StorageBackend):
                 If a column with this name exists, only the provided fields are updated.
                 Types: string, number, time, date, boolean.
             measures: Named formula measures to create or update (upsert by name). Each dict:
-                {"name": "aov", "formula": "revenue:sum / *:count", "label": "...", "description": "..."}.
+                {"name": "aov", "formula": "revenue:sum / *:count", "label": "...",
+                 "description": "...", "meta": {...}}.
                 Queries can reference these by bare name (e.g. ``{"formula": "aov"}``).
+                ``meta`` is an optional opaque dict for caller bookkeeping.
             aggregations: Aggregations to create or update (upsert by name). Each dict:
                 {"name": "weighted_avg", "formula": "SUM({value} * {weight}) / NULLIF(SUM({weight}), 0)",
-                 "params": [{"name": "weight", "sql": "quantity"}], "description": "..."}.
+                 "params": [{"name": "weight", "sql": "quantity"}], "description": "...",
+                 "meta": {...}}.
+                ``meta`` is an optional opaque dict for caller bookkeeping.
             joins: Joins to create or update (upsert by target_model). Each dict:
                 {"target_model": "customers", "join_pairs": [["customer_id", "id"]]}.
             add_filters: SQL filter strings to add (e.g. ["deleted_at IS NULL"]). Duplicates ignored.

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -1533,7 +1533,7 @@ def create_mcp_server(storage: StorageBackend):
         data_source: Optional[str] = None,
         description: Optional[str] = None,
         columns: Optional[List[Dict[str, Any]]] = None,
-        measures: Optional[List[Dict[str, str]]] = None,
+        measures: Optional[List[Dict[str, Any]]] = None,
         query: Optional[Any] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> str:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1470,6 +1470,27 @@ class TestCreateModel:
         model = await storage.get_model("orders")
         assert model.columns[0].allowed_aggregations == ["sum", "avg"]
 
+    async def test_create_with_measure_meta_dict(self, mcp_server, storage: YAMLStorage) -> None:
+        # Pins create_model.measures' parameter type at List[Dict[str, Any]] —
+        # FastMCP introspects the annotation to build its tool schema, so a
+        # narrower Dict[str, str] would reject this dict-typed `meta` value at
+        # call time before the function body ever runs.
+        result = await _call(mcp_server, name="create_model", arguments={
+            "name": "orders",
+            "sql_table": "public.orders",
+            "data_source": "test_ds",
+            "columns": [
+                {"name": "revenue", "sql": "amount", "type": "number"},
+            ],
+            "measures": [
+                {"name": "aov", "formula": "revenue:sum / *:count",
+                 "meta": {"kb_id": "abc-123", "tags": ["finance", "kpi"]}},
+            ],
+        })
+        assert "created" in result
+        model = await storage.get_model("orders")
+        assert model.measures[0].meta == {"kb_id": "abc-123", "tags": ["finance", "kpi"]}
+
     async def test_create_reports_replaced(self, mcp_server, storage: YAMLStorage) -> None:
         await storage.save_model(SlayerModel(name="orders", sql_table="t", data_source="test"))
         result = await _call(mcp_server, name="create_model", arguments={"name": "orders", "sql_table": "t2", "data_source": "test"})


### PR DESCRIPTION
## Summary

`Column` and `SlayerModel` already carry `meta: Optional[Dict[str, Any]]` for caller bookkeeping (linking entities back to their source, owner tags, etc). `ModelMeasure` and `Aggregation` did not, which means a downstream caller (e.g. the bird-interact-agents translate-kb skill) that wants to stamp every encoded entity uniformly with a source identifier couldn't.

This PR adds the same field to both classes:

```python
meta: Optional[Dict[str, Any]] = None
```

Default `None` preserves backward compat — existing YAML loads unchanged. The MCP `create_model` / `edit_model` docstrings are updated to mention the new optional `meta` key on `measures` / `aggregations` dicts.

Concrete motivation: the BIRD-Interact translation skill (DEV-1318) stamps `meta={"kb_id": <id>}` on every entity it creates from a KB entry, so a downstream verifier can confirm every KB id is accounted for and a HARD-8 task-time preprocessor can mask entities by `kb_id`. Without this field, KB entries that produce a ModelMeasure (R-MEASURE recipe) or a custom Aggregation (R-AGG recipe) have no place to carry the link.

## Test plan

- [x] `poetry run pytest` — 1696 passed (45 Postgres integration errors are environmental, unrelated)
- [x] No existing tests construct ModelMeasure/Aggregation in a way that would care about the new optional field

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Measures and aggregations now support optional metadata fields for attaching custom bookkeeping/context to model definitions.

* **Documentation**
  * Model creation and editing tool docs updated to describe usage of the new optional metadata fields.

* **Tests**
  * Added a test to verify metadata passed with measures is persisted unchanged.

* **Chores**
  * Package version bumped to 0.4.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->