### PR TITLE
Remove unnecessary slowness in unit tests (29x suite speedup)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3751,6 +3751,88 @@ markers = {main = "extra == \"docs\""}
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyinstrument"
+version = "5.1.2"
+description = "Call stack profiler for Python. Shows you why your code is slow!"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pyinstrument-5.1.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f224fe80ba288a00980af298d3808219f9d246fd95b4f91729c9c33a0dc54fe6"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7df09fc0d5b72daf48b73cdf07738761bff7f656c81aff686b3ccdd7d2abe236"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75a7e17377d4405666bbaf126b1fd7bbb7e206d7246e6db3d62864d3d4790ae3"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5381cc6583d26e04d9298acded4242f4fe71986f1472c8aee6992c6816f0cac5"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ec08a530bef8d3492d31d8b0b12d0cfde09539f2a1c4b9678662ebc3c843e478"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d671168508129b472be570bc9aee361190ba917b997c703bd134bb4de445ce7"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-win32.whl", hash = "sha256:5957a94f84564b374a7f856d1b322345d600964280b0d687b8ddcc483f21e576"},
+    {file = "pyinstrument-5.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:38a2180a7801c51610b50e5d423674b21872efd019ccf05a11b7f9016cb1dcfc"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3739a05583ea6312c385eb59fe985cd20d9048e95f9eeeb6a2f6c35202e2d36e"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c9ee05dc75ac5fb18498c311e624f77f7f321f7ff325b251aa09e52e46f1d6a"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a49a55ca5b75218767e29cacbe515d0b66fc18cb48a937bca0f77b8dafc7202"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c45c14974ff04b1bfdc6c2a448627c6da7409c7800d0eb7bd03fb435dcb41d7"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:22b9c04b3982c41c04b1c5ed05d1bc3a2ba26533450084058119f6dc160e70a3"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5c4995ee0774801790c138f0dfec17d4e7a7ef09a6d56d53cbcbf0578a711021"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-win32.whl", hash = "sha256:fe449e4a8ee60a2a27cf509350a584670f4c3704649601be7937598f09dbe7ca"},
+    {file = "pyinstrument-5.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:3fb839429671a42bf349335af4c1ce5cf83386ac11f04df0bc40720d4cb7d77d"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2519865d4bf58936f2506c1c46a82d29a20f3239aa50c941df1ca9618c7da5f0"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:059442106b8b5de29ae5ac1bdc20d044fed4da534b8caba434b6ffb119037bf5"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd51f2d54fc39a4cfd73ba6be27cd0187123132ce3f445b639bff5e1b23d7e26"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12af1e83795b6c640d657d339014dd1ff718b182dec736d7d1f1d8a97534eb53"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2565513658e742c5eb691a779cb29d19d01bc9ee951d0eb76482e9f343c38c2e"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5afd0ba788a1d112da49fb77966918e01df1f9e7d62e72894d82f7acb0996c2d"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-win32.whl", hash = "sha256:554077b031b278593cb2301f0057be771ea62a729878c69aaf29fcdfb7b71281"},
+    {file = "pyinstrument-5.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:55a905384ba43efc924b8863aa6cfd276f029e4aa70c4a0e3b7389e27b191e45"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7b8bab2334bf1d4c9e92d61db574300b914b594588a6b6dd67c45450152dfc29"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:13dcc138a61298ef4994b7aebff509d2c06db89dfd6e2021f0b9cd96aaa44ec3"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8abd4a7ffa2e7f9e00039a5e549e8eebc80d7ca8d43f0fb51a50ff2b117ce4a"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb3a05108edebc30f31e2c69c904576042f1158b2513ab80adc08f7848a7a8f0"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f70d588b53f3f35829d1d1ddfa05e07fcebf1434b3b1509d542ca317d8e9a2a5"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b007327e0d6a6a01d5064883dd27c19996f044ce7488d507826fee7884e6a32e"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-win32.whl", hash = "sha256:9ba0e6b17a7e86c3dc02d208e4c25506e8f914d9964ae89449f1f37f0b70abc0"},
+    {file = "pyinstrument-5.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:660d7fc486a839814db0b2f716bc13d8b99b9c780aaeb47f74a70a34adc02a7b"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0baed297beee2bb9897e737bbd89e3b9d45a2fbbea9f1ad4e809007d780a9b1e"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ebb910a32a45bde6c3fc30c578efc28a54517990e11e94b5e48a0d5479728568"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bad403c157f9c6dba7f731a6fca5bfcd8ca2701a39bcc717dcc6e0b10055ffc4"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f456cabdb95fd343c798a7f2a56688b028f981522e283c5f59bd59195b66df5"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4e9c4dcc1f2c4a0cd6b576e3604abc37496a7868243c9a1443ad3b9db69d590f"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:acf93b128328c6d80fdb85431068ac17508f0f7845e89505b0ea6130dead5ca6"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-win32.whl", hash = "sha256:9c7f0167903ecff8b1d744f7e37b2bd4918e05a69cca724cb112f5ed59d1e41b"},
+    {file = "pyinstrument-5.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:ce3f6b1f9a2b5d74819ecc07d631eadececf915f551474a75ad65ac580ec5a0e"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:af8651b239049accbeecd389d35823233f649446f76f47fd005316b05d08cef2"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c6082f1c3e43e1d22834e91ba8975f0080186df4018a04b4dd29f9623c59df1d"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c031eb066ddc16425e1e2f56aad5c1ce1e27b2432a70329e5385b85e812decee"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f447ec391cad30667ba412dce41607aaa20d4a2496a7ab867e0c199f0fe3ae3d"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50299bddfc1fe0039898f895b10ef12f9db08acffb4d85326fad589cda24d2ee"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a193ff08825ece115ececa136832acb14c491c77ab1e6b6a361905df8753d5c6"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-win32.whl", hash = "sha256:de887ba19e1057bd2d86e6584f17788516a890ae6fe1b7eed9927873f416b4d8"},
+    {file = "pyinstrument-5.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b6a71f5e7f53c86c9b476b30cf19509463a63581ef17ddbd8680fee37ae509db"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:47f14f248108f1202d48f34903bddc053a47c62ce46908aee848c1f667a1925b"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc3f2688981af764fa2c5f5a00d7040c0c12771ca5a026730f2d826f7a28d277"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7afb24d11d24fb1762059240ed97a1a4607779d5f221f91d62b67ae089bd506d"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d21221a29718d5dcdc1453dbbbdd100734525672ef1e34ff03d49bc5d688ca4"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3b68aa9f0d5217c67370762c99a80750ce56f66e5e9281c31b5baa3e4b88894d"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:755702f01800934c3bec3c0d30483f97b6ff1fc1d2afcf6d816584703c9f1235"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-win32.whl", hash = "sha256:2bacb980c95d4c9ea6a253e5ccf3e99993082de29ff7e7fc397e9484355577b1"},
+    {file = "pyinstrument-5.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:2588bc34c25d50f29d3a117c7dfac06513ee59c507b65081e66ca9569bcf45e0"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:bea0687665c181c6e62677fb560739a473c4286816582a43f8eb0aa6094ed529"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:64246d2bd475870b62ed5df4808bfb33328135e8dfbdff823f9cb7d1358eb40b"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff6fd3c7907e57f082cdd405bec1b34768c1810a165538299d259ee1bff5d7b6"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:af09af38ee8407ca273407e24a8e6470d2444561d01005ee6a8db5f2fd908c08"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1249d2799cdd57151b4444167e5c7736e2c9b5e79bd781b0779d631338509553"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2d653206f50260f20bc78339c3d7aa0f19f8cf9c9f71939fbf02e2ea30353487"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-win32.whl", hash = "sha256:d0b0c6e289725f14d0ff73f8190c953bdcb98f21c5c29c3eafb0dca8025583cb"},
+    {file = "pyinstrument-5.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:db8243e602aca43dc7ce8e40ed7d0ca4820d024c3c03824870c5a9e98f84e953"},
+    {file = "pyinstrument-5.1.2.tar.gz", hash = "sha256:af149d672da9493fa37334a1cc68f7b80c3e6cb9fd99b9e426c447db5c650bf0"},
+]
+
+[package.extras]
+bin = ["click", "nox"]
+docs = ["furo (==2024.7.18)", "myst-parser (==3.0.1)", "sphinx (==7.4.7)", "sphinx-autobuild (==2024.4.16)", "sphinxcontrib-programoutput (==0.17)"]
+examples = ["django", "litestar", "numpy"]
+test = ["cffi (>=1.17.0)", "flaky", "greenlet (>=3)", "ipython", "pytest", "pytest-asyncio (==0.23.8)", "trio"]
+types = ["typing_extensions"]
+
+[[package]]
 name = "pyjwt"
 version = "2.12.1"
 description = "JSON Web Token implementation in Python"
@@ -5378,4 +5460,4 @@ postgres = ["asyncpg", "psycopg2-binary"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "cfae0a74cdac0b168e26797b153ddf2d446a7cda600257a84f728f959d40be8c"
+content-hash = "5433c371791207173b36bf2bf57af2d4ac1d50e34b8de7358519d5eac96183d9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,11 @@ ipykernel = ">=6.0"
 pre-commit = "^4.5.1"
 notebook = "^7.5.5"
 pytest-asyncio = "^1.3.0"
+pyinstrument = "^5.1.2"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--ignore=tests/perf --cov=slayer --cov-report=term-missing --cov-report=html"
+addopts = "--ignore=tests/perf"
 markers = [
     "integration: marks tests as integration tests (require a real database)",
 ]

--- a/slayer/dbt/manifest.py
+++ b/slayer/dbt/manifest.py
@@ -11,6 +11,7 @@ The manifest is used to discover *regular* dbt models (``resource_type ==
 """
 
 import json
+import importlib.util
 import logging
 import os
 from typing import Any, Dict, List, Optional, Set
@@ -20,13 +21,13 @@ from slayer.dbt.models import DbtColumnMeta, DbtRegularModel
 logger = logging.getLogger(__name__)
 
 
-try:  # pragma: no cover - availability depends on the install-time extras
-    from dbt.cli.main import dbtRunner  # type: ignore[import-not-found]
-
-    DBT_AVAILABLE = True
-except Exception:  # ImportError or any dbt-core initialization error
-    dbtRunner = None  # type: ignore[assignment]
-    DBT_AVAILABLE = False
+# Cheap availability probe: ``find_spec`` checks the import system without
+# executing dbt's package init. Importing ``dbt.cli.main`` eagerly costs ~4s
+# (jsonschema, deepmerge, the whole rfc3987 stack) which previously hit every
+# `import slayer.dbt.parser` — including pytest collection of dbt tests. The
+# real ``dbtRunner`` import is deferred to ``_run_dbt_parse``.
+DBT_AVAILABLE: bool = importlib.util.find_spec("dbt") is not None
+dbtRunner: Any = None  # populated lazily on first use; tests may patch directly
 
 
 def _manifest_path(project_path: str) -> str:
@@ -44,8 +45,16 @@ def _load_manifest_file(path: str) -> Optional[dict]:
 
 def _run_dbt_parse(project_path: str) -> bool:
     """Invoke ``dbt parse`` programmatically. Returns True on success."""
-    if not DBT_AVAILABLE or dbtRunner is None:
+    global dbtRunner
+    if not DBT_AVAILABLE:
         return False
+    if dbtRunner is None:
+        try:
+            from dbt.cli.main import dbtRunner as _dbtRunner  # type: ignore[import-not-found]
+            dbtRunner = _dbtRunner
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("dbt-core import failed: %s", exc)
+            return False
     try:
         result = dbtRunner().invoke(["parse", "--project-dir", project_path])
     except Exception as exc:  # pragma: no cover - defensive

--- a/slayer/sql/client.py
+++ b/slayer/sql/client.py
@@ -470,6 +470,38 @@ _TRANSIENT_RETRY_LOG_FORMAT = (
     "Transient DB error on attempt %d, retrying in %.1fs: %s | sql: %s"
 )
 
+# Substrings (lower-cased match) on the underlying DBAPI message that indicate
+# a transient failure with some chance of succeeding on retry. Schema-level
+# errors (no such table, syntax error, permission denied, constraint violation)
+# are deterministic — sleeping changes nothing — so we re-raise them
+# immediately rather than burning 1s + 2s of backoff before the eventual fail.
+_TRANSIENT_DB_ERROR_SIGNALS = (
+    "database is locked",     # SQLite under contention
+    "deadlock",               # Postgres / MySQL deadlock_detected
+    "lost connection",        # MySQL "Lost connection to MySQL server"
+    "broken pipe",            # connection mid-query
+    "could not connect",      # libpq / psycopg
+    "server closed",          # Postgres "server closed the connection unexpectedly"
+    "connection refused",
+    "connection reset",
+    "connection was killed",  # MySQL admin kill
+)
+
+
+def _is_transient_db_error(exc: BaseException) -> bool:
+    """Return True only for DB errors that have a real chance of succeeding on retry.
+
+    `OperationalError` is too broad to retry blindly — it spans both schema
+    errors (no such table, syntax error) and genuinely transient conditions
+    (locking, deadlock, dropped connection). `DisconnectionError` is always
+    transient by definition. For everything else we look at the underlying
+    DBAPI message via ``exc.orig`` for known transient signals.
+    """
+    if isinstance(exc, sqlalchemy.exc.DisconnectionError):
+        return True
+    msg = str(getattr(exc, "orig", exc)).lower()
+    return any(sig in msg for sig in _TRANSIENT_DB_ERROR_SIGNALS)
+
 
 async def _retry_with_backoff(
     *,
@@ -493,7 +525,7 @@ async def _retry_with_backoff(
         try:
             return await do_call()
         except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
-            if attempt == max_attempts - 1:
+            if attempt == max_attempts - 1 or not _is_transient_db_error(exc):
                 raise
             sql_lines = (sql or "").strip().splitlines()
             sql_excerpt = sql_lines[0][:120] if sql_lines else _EMPTY_SQL_PLACEHOLDER
@@ -602,7 +634,7 @@ def _execute_with_retry_sync(
                 engine=engine,
             )
         except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.DisconnectionError) as exc:
-            if attempt == max_attempts - 1:
+            if attempt == max_attempts - 1 or not _is_transient_db_error(exc):
                 raise
             sql_lines = (sql or "").strip().splitlines()
             sql_excerpt = sql_lines[0][:120] if sql_lines else _EMPTY_SQL_PLACEHOLDER

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,5 +1,6 @@
 """Tests for the FastAPI server."""
 
+import os
 import tempfile
 
 import pytest
@@ -12,16 +13,40 @@ from slayer.core.query import SlayerQuery
 from slayer.storage.yaml_storage import YAMLStorage
 
 
-@pytest.fixture
-def storage() -> YAMLStorage:
+# `create_app` builds an MCP server (~2 s of FastMCP/pydantic schema gen)
+# plus a FastAPI app, and the app captures the storage instance. Sharing
+# both across the session and resetting the YAML files between tests
+# avoids paying that cost on every test in this file.
+@pytest.fixture(scope="session")
+def _shared_storage():
     with tempfile.TemporaryDirectory() as tmpdir:
         yield YAMLStorage(base_dir=tmpdir)
 
 
-@pytest.fixture
-def client(storage: YAMLStorage) -> TestClient:
-    app = create_app(storage=storage)
+@pytest.fixture(scope="session")
+def _shared_client(_shared_storage: YAMLStorage) -> TestClient:
+    app = create_app(storage=_shared_storage)
     return TestClient(app)
+
+
+def _reset_yaml_storage(storage: YAMLStorage) -> None:
+    for sub in ("models", "datasources"):
+        d = os.path.join(storage.base_dir, sub)
+        if os.path.isdir(d):
+            for f in os.listdir(d):
+                os.remove(os.path.join(d, f))
+
+
+@pytest.fixture
+def storage(_shared_storage: YAMLStorage) -> YAMLStorage:
+    _reset_yaml_storage(_shared_storage)
+    return _shared_storage
+
+
+@pytest.fixture
+def client(_shared_client: TestClient, storage: YAMLStorage) -> TestClient:
+    # Depending on `storage` ensures the per-test reset runs first.
+    return _shared_client
 
 
 class TestHealth:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -30,15 +30,44 @@ from slayer.mcp.server import (
 from slayer.storage.yaml_storage import YAMLStorage
 
 
-@pytest.fixture
-def storage() -> YAMLStorage:
+# `create_mcp_server` is expensive (~35 ms each, dominated by FastMCP tool
+# registration / pydantic schema gen). With ~160 tests in this file that
+# was ~5–6s of pure fixture overhead per run. The MCP server captures the
+# storage instance at construction time, so we share *both* across the
+# session and reset the underlying YAML files in a per-test fixture.
+@pytest.fixture(scope="session")
+def _shared_storage():
     with tempfile.TemporaryDirectory() as tmpdir:
         yield YAMLStorage(base_dir=tmpdir)
 
 
+@pytest.fixture(scope="session")
+def _shared_mcp_server(_shared_storage: YAMLStorage):
+    return create_mcp_server(storage=_shared_storage)
+
+
+def _reset_yaml_storage(storage: YAMLStorage) -> None:
+    """Wipe model + datasource files between tests so the session-scoped
+    storage looks fresh to every test."""
+    for sub in ("models", "datasources"):
+        d = os.path.join(storage.base_dir, sub)
+        if os.path.isdir(d):
+            for f in os.listdir(d):
+                os.remove(os.path.join(d, f))
+
+
 @pytest.fixture
-def mcp_server(storage: YAMLStorage):
-    return create_mcp_server(storage=storage)
+def storage(_shared_storage: YAMLStorage) -> YAMLStorage:
+    _reset_yaml_storage(_shared_storage)
+    return _shared_storage
+
+
+@pytest.fixture
+def mcp_server(_shared_mcp_server, storage: YAMLStorage):
+    # Depending on `storage` ensures the per-test reset runs before any
+    # test exercises the MCP server. `mcp_server` itself is the same
+    # session-scoped instance every call.
+    return _shared_mcp_server
 
 
 async def _call(mcp_server, *, name: str, arguments: Optional[dict[str, Any]] = None) -> str:

--- a/tests/test_sql_client.py
+++ b/tests/test_sql_client.py
@@ -1,6 +1,7 @@
 """Tests for SQL client helpers (type code mapping, retry-warning formatting)."""
 
 import logging
+import sqlite3
 
 import pytest
 import sqlalchemy.exc
@@ -99,9 +100,15 @@ class TestMapTypeCode:
 
 
 def _make_op_error(orig_message: str = "database is locked") -> sqlalchemy.exc.OperationalError:
-    """An OperationalError carrying a chosen DBAPI message in ``exc.orig``."""
+    """An OperationalError carrying a chosen DBAPI message in ``exc.orig``.
+
+    Uses ``sqlite3.OperationalError`` as the wrapped DBAPI exception — that's
+    the actual class SQLAlchemy puts in ``.orig`` when the SQLite driver
+    raises an OperationalError, so the fake mirrors production semantics
+    while satisfying Sonar's ``python:S112`` (no bare ``Exception``).
+    """
     return sqlalchemy.exc.OperationalError(
-        "SELECT 1", {}, Exception(orig_message),
+        "SELECT 1", {}, sqlite3.OperationalError(orig_message),
     )
 
 
@@ -160,7 +167,7 @@ class TestRetryFiltersDeterministicErrors:
     ) -> None:
         calls = {"n": 0}
 
-        async def fake_execute(**kwargs: object) -> list:
+        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(python:S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
             calls["n"] += 1
             raise _make_op_error("no such table: orders")
 
@@ -181,7 +188,7 @@ class TestRetryFiltersDeterministicErrors:
     ) -> None:
         calls = {"n": 0}
 
-        def fake_execute(*args: object, **kwargs: object) -> list:
+        def fake_execute(*_args: object, **_kwargs: object) -> list:
             calls["n"] += 1
             raise _make_op_error("no such table: orders")
 
@@ -202,7 +209,7 @@ class TestRetryFiltersDeterministicErrors:
     ) -> None:
         calls = {"n": 0}
 
-        def fake_execute(*args: object, **kwargs: object) -> list:
+        def fake_execute(*_args: object, **_kwargs: object) -> list:
             calls["n"] += 1
             raise _make_op_error("no such table: orders")
 
@@ -225,7 +232,7 @@ class TestRetryFiltersDeterministicErrors:
         production behaviour for genuine flakes is unchanged."""
         calls = {"n": 0}
 
-        async def fake_execute(**kwargs: object) -> list:
+        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(python:S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error("database is locked")
@@ -258,7 +265,7 @@ class TestRetryEmptySqlExcerpt:
     ) -> None:
         calls = {"n": 0}
 
-        async def fake_execute(**kwargs: object) -> list:
+        async def fake_execute(**_kwargs: object) -> list:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error()
@@ -291,7 +298,7 @@ class TestRetryEmptySqlExcerpt:
     ) -> None:
         calls = {"n": 0}
 
-        def fake_execute(*args: object, **kwargs: object) -> list:
+        def fake_execute(*_args: object, **_kwargs: object) -> list:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error()
@@ -324,7 +331,7 @@ class TestRetryEmptySqlExcerpt:
     ) -> None:
         calls = {"n": 0}
 
-        def fake_execute(*args: object, **kwargs: object) -> list:
+        def fake_execute(*_args: object, **_kwargs: object) -> list:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error()

--- a/tests/test_sql_client.py
+++ b/tests/test_sql_client.py
@@ -167,7 +167,7 @@ class TestRetryFiltersDeterministicErrors:
     ) -> None:
         calls = {"n": 0}
 
-        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(python:S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
+        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
             calls["n"] += 1
             raise _make_op_error("no such table: orders")
 
@@ -232,7 +232,7 @@ class TestRetryFiltersDeterministicErrors:
         production behaviour for genuine flakes is unchanged."""
         calls = {"n": 0}
 
-        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(python:S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
+        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error("database is locked")
@@ -265,7 +265,7 @@ class TestRetryEmptySqlExcerpt:
     ) -> None:
         calls = {"n": 0}
 
-        async def fake_execute(**_kwargs: object) -> list:
+        async def fake_execute(**_kwargs: object) -> list:  # NOSONAR(S7503) — must be async to replace _execute_sql_async (called via `await do_call()`)
             calls["n"] += 1
             if calls["n"] == 1:
                 raise _make_op_error()

--- a/tests/test_sql_client.py
+++ b/tests/test_sql_client.py
@@ -10,6 +10,7 @@ from slayer.sql.client import (
     _execute_with_retry_async,
     _execute_with_retry_sync,
     _execute_with_retry_threaded,
+    _is_transient_db_error,
     _map_type_code,
 )
 
@@ -97,11 +98,148 @@ class TestMapTypeCode:
         assert _map_type_code(0, db_type="mysql") == "number"
 
 
-def _make_op_error() -> sqlalchemy.exc.OperationalError:
-    """A minimal OperationalError that mimics a transient driver failure."""
+def _make_op_error(orig_message: str = "database is locked") -> sqlalchemy.exc.OperationalError:
+    """An OperationalError carrying a chosen DBAPI message in ``exc.orig``."""
     return sqlalchemy.exc.OperationalError(
-        "SELECT 1", {}, Exception("database is locked"),
+        "SELECT 1", {}, Exception(orig_message),
     )
+
+
+class TestIsTransientDbError:
+    """``_is_transient_db_error`` separates retry-worthy from deterministic errors.
+
+    Schema-level OperationalErrors (no such table, syntax error) used to
+    burn 1s + 2s of retry sleep for nothing — a real UX hit on inspect_model
+    and (massively) on the unit suite, where ~75 tests intentionally query
+    a non-existent in-memory table.
+    """
+
+    @pytest.mark.parametrize("orig_message", [
+        "database is locked",
+        "deadlock detected",
+        "lost connection to MySQL server during query",
+        "BrokenPipeError: Broken pipe",
+        "could not connect to server: Connection refused",
+        "server closed the connection unexpectedly",
+        "Connection refused",
+        "Connection reset by peer",
+        "Connection was killed",
+        # Case-insensitive: upper-cased input still matches.
+        "DATABASE IS LOCKED",
+    ])
+    def test_transient_messages_are_retried(self, orig_message: str) -> None:
+        assert _is_transient_db_error(_make_op_error(orig_message)) is True
+
+    @pytest.mark.parametrize("orig_message", [
+        "no such table: orders",
+        "no such column: revenue",
+        "syntax error at or near \"FROM\"",
+        "permission denied for table orders",
+        "duplicate key value violates unique constraint",
+        "relation \"orders\" does not exist",
+    ])
+    def test_deterministic_messages_are_not_retried(self, orig_message: str) -> None:
+        assert _is_transient_db_error(_make_op_error(orig_message)) is False
+
+    def test_disconnection_error_always_transient(self) -> None:
+        """``DisconnectionError`` is by definition a connection drop — retry."""
+        exc = sqlalchemy.exc.DisconnectionError("connection went away")
+        assert _is_transient_db_error(exc) is True
+
+
+class TestRetryFiltersDeterministicErrors:
+    """Retry helpers must re-raise deterministic errors immediately.
+
+    Before this filter was added, all three retry paths slept 1s+2s before
+    finally raising — turning ~75 unit tests that intentionally hit a
+    non-existent ``:memory:`` table into 3-15 s timeouts each.
+    """
+
+    async def test_async_no_such_table_raises_immediately(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = {"n": 0}
+
+        async def fake_execute(**kwargs: object) -> list:
+            calls["n"] += 1
+            raise _make_op_error("no such table: orders")
+
+        monkeypatch.setattr(sql_client, "_execute_sql_async", fake_execute)
+
+        with pytest.raises(sqlalchemy.exc.OperationalError, match="no such table"):
+            await _execute_with_retry_async(
+                sql="SELECT 1", engine=None, db_type="postgres",
+                # Non-zero delays prove we don't sleep — if the filter regressed,
+                # the test would still pass but get noticeably slower.
+                initial_delay=10.0, max_delay=10.0,
+            )
+
+        assert calls["n"] == 1, "deterministic error must not retry"
+
+    async def test_threaded_no_such_table_raises_immediately(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = {"n": 0}
+
+        def fake_execute(*args: object, **kwargs: object) -> list:
+            calls["n"] += 1
+            raise _make_op_error("no such table: orders")
+
+        monkeypatch.setattr(sql_client, "_execute_sql_sync", fake_execute)
+
+        with pytest.raises(sqlalchemy.exc.OperationalError, match="no such table"):
+            await _execute_with_retry_threaded(
+                sql="SELECT 1",
+                connection_string="sqlite:///:memory:",
+                db_type="sqlite",
+                initial_delay=10.0, max_delay=10.0,
+            )
+
+        assert calls["n"] == 1
+
+    def test_sync_no_such_table_raises_immediately(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls = {"n": 0}
+
+        def fake_execute(*args: object, **kwargs: object) -> list:
+            calls["n"] += 1
+            raise _make_op_error("no such table: orders")
+
+        monkeypatch.setattr(sql_client, "_execute_sql_sync", fake_execute)
+
+        with pytest.raises(sqlalchemy.exc.OperationalError, match="no such table"):
+            _execute_with_retry_sync(
+                sql="SELECT 1",
+                connection_string="sqlite:///:memory:",
+                db_type="sqlite",
+                initial_delay=10.0, max_delay=10.0,
+            )
+
+        assert calls["n"] == 1
+
+    async def test_async_transient_still_retries(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Locking errors should still go through the retry path so the
+        production behaviour for genuine flakes is unchanged."""
+        calls = {"n": 0}
+
+        async def fake_execute(**kwargs: object) -> list:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _make_op_error("database is locked")
+            return [{"ok": 1}]
+
+        monkeypatch.setattr(sql_client, "_execute_sql_async", fake_execute)
+
+        result = await _execute_with_retry_async(
+            sql="SELECT 1", engine=None, db_type="postgres",
+            initial_delay=0.0, max_delay=0.0,
+        )
+
+        assert result == [{"ok": 1}]
+        assert calls["n"] == 2
 
 
 class TestRetryEmptySqlExcerpt:


### PR DESCRIPTION
## Summary

- `_retry_with_backoff` was retrying every `OperationalError` indiscriminately — including deterministic ones (no such table, syntax error, permission denied). Each retry sleeps 1s + 2s = 3s, so any caller hitting such an error waited ~3s before the eventual fail.
- `inspect_model` issues up to 5 DB calls (row_count, dim profile, measure profile, column-types probe, sample-data execute), turning a missing/renamed backing table into a 9–15s wait for the user.
- In the unit suite this dominated wall time — 75+ tests intentionally query a `:memory:` SQLite without real tables, so the suite spent ~228s of 243s in `asyncio.sleep`.
- New `_is_transient_db_error(exc)` retries only on `DisconnectionError` or known transient DBAPI signals (database is locked, deadlock, lost connection, broken pipe, could not connect, server closed, connection refused/reset, killed). Applied to both the async `_retry_with_backoff` and `_execute_with_retry_sync`.
- Also drops `--cov` from pytest `addopts` (locally + CI inherit) so default `pytest` runs are no longer slowed by coverage instrumentation. Coverage stays opt-in: `pytest --cov=slayer --cov-report=term-missing`.

## Impact

| | Before | After |
|---|---|---|
| Unit suite wall time | **243 s** | **15 s** (~16×) |
| Slowest unit test | 15.08 s (`test_mcp_server.py`) | 0.38 s (a fixture setup) |
| Wasted asyncio.sleep | ~228 s | ~0 |
| `inspect_model` against missing table (UX) | 9–15 s sleep, then error | immediate error |

Pyinstrument trace before: 222.3 s of 231.4 s in `epoll.poll` for `tests/test_mcp_server.py` (CPU time only 9.2 s).

## Test plan

- [x] `poetry run pytest tests/test_sql_client.py -v` — 49 passed (21 new + 28 existing)
- [x] `poetry run pytest -m "not integration" --ignore=tests/integration tests/` — **1542 passed in 15.35 s**
- [x] `poetry run ruff check slayer/ tests/` — clean
- [x] New tests cover both directions: deterministic errors raise immediately without retry; "database is locked" / `DisconnectionError` still retry as before
- [ ] CI matrix run (3.11, 3.14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retry logic now only retries transient DB failures (locks, disconnects); deterministic errors fail immediately.

* **Refactor**
  * DBT integration detection and runner initialization now occur lazily at runtime.

* **Chores**
  * Added a development profiler dependency and simplified pytest CLI options (coverage flags removed).

* **Tests**
  * Expanded transient-vs-deterministic DB error tests and consolidated test server/storage fixtures to session scope with per-test resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->