### PR TITLE
Speed up integration tests (~85s) via module-scope fixtures + cached Jaffle DB

### DIFF
--- a/tests/integration/test_ingestion_jaffle_shop.py
+++ b/tests/integration/test_ingestion_jaffle_shop.py
@@ -10,6 +10,7 @@ ingested models through YAMLStorage to confirm no v1 keys leak to disk.
 
 import asyncio
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Dict
@@ -38,11 +39,27 @@ from slayer.storage.yaml_storage import YAMLStorage
 
 pytestmark = pytest.mark.integration
 
+# Cached 3-year demo DB maintained by tests/integration/test_notebooks.py's
+# session-scoped _ensure_jaffle_db fixture. Reusing it avoids ~6s of
+# `jafgen` subprocess time per pytest invocation.
+_CACHED_JAFFLE_DB = (
+    Path(__file__).resolve().parent.parent.parent
+    / "docs" / "examples" / "jaffle_data" / "demo" / "jaffle_shop.duckdb"
+)
+
 
 @pytest.fixture(scope="module")
 def jaffle_duckdb_path(tmp_path_factory):
-    """Generate a small Jaffle Shop DuckDB file once for this module."""
+    """Path to a Jaffle Shop DuckDB file. Reuses the project-wide cached DB
+    at docs/examples/jaffle_data/demo/jaffle_shop.duckdb when present; falls
+    back to ``jafgen`` for fresh checkouts."""
     tmpdir = tmp_path_factory.mktemp("jaffle_ingest")
+    db_path = tmpdir / "jaffle_ingest.duckdb"
+
+    if _CACHED_JAFFLE_DB.exists():
+        shutil.copy(_CACHED_JAFFLE_DB, db_path)
+        return str(db_path)
+
     try:
         data_dir = generate_data(output_dir=str(tmpdir), years=1)
     except DemoDependencyError as exc:
@@ -50,7 +67,6 @@ def jaffle_duckdb_path(tmp_path_factory):
     except (FileNotFoundError, RuntimeError) as exc:
         pytest.skip(f"Jaffle shop prerequisite missing: {exc}")
 
-    db_path = tmpdir / "jaffle_ingest.duckdb"
     conn = duckdb.connect(str(db_path))
     try:
         create_schema(conn=conn)

--- a/tests/integration/test_integration_duckdb.py
+++ b/tests/integration/test_integration_duckdb.py
@@ -8,6 +8,7 @@ pytest.importorskip("duckdb")
 
 import duckdb
 
+from slayer.async_utils import run_sync
 from slayer.core.enums import DataType, TimeGranularity
 from slayer.core.models import Column, DatasourceConfig, ModelMeasure, SlayerModel
 from slayer.core.query import ColumnRef, OrderItem, SlayerQuery, TimeDimension
@@ -16,9 +17,13 @@ from slayer.engine.query_engine import SlayerQueryEngine
 from slayer.storage.yaml_storage import YAMLStorage
 
 
-@pytest.fixture
-async def duckdb_env(tmp_path):
-    """Set up a full SLayer environment against a temporary DuckDB database."""
+@pytest.fixture(scope="module")
+def _duckdb_env_storage(tmp_path_factory):
+    """Module-scoped: per-module DuckDB file with seeded customers/orders, plus
+    a YAMLStorage with the orders + customers models pre-saved. The per-test
+    ``duckdb_env`` fixture wraps a fresh engine around the returned storage
+    (engines bind to their event loop — see slayer/sql/client.py:144)."""
+    tmp_path = tmp_path_factory.mktemp("duckdb_env")
     db_path = tmp_path / "test.duckdb"
     conn = duckdb.connect(str(db_path))
 
@@ -56,14 +61,13 @@ async def duckdb_env(tmp_path):
     conn.close()
 
     # Set up SLayer storage
-    tmpdir = tempfile.mkdtemp()
-    storage = YAMLStorage(base_dir=tmpdir)
+    storage = YAMLStorage(base_dir=str(tmp_path / "storage"))
 
-    await storage.save_datasource(DatasourceConfig(
+    run_sync(storage.save_datasource(DatasourceConfig(
         name="testduckdb",
         type="duckdb",
         database=str(db_path),
-    ))
+    )))
 
     orders_model = SlayerModel(
         name="orders",
@@ -91,10 +95,18 @@ async def duckdb_env(tmp_path):
 
         ],
     )
-    await storage.save_model(orders_model)
-    await storage.save_model(customers_model)
+    run_sync(storage.save_model(orders_model))
+    run_sync(storage.save_model(customers_model))
 
-    return SlayerQueryEngine(storage=storage)
+    return storage
+
+
+@pytest.fixture
+def duckdb_env(_duckdb_env_storage):
+    """Per-test SlayerQueryEngine wrapping the module-scoped storage. The
+    engine is recreated per-test because its async SQLAlchemy engine binds to
+    the current event loop."""
+    return SlayerQueryEngine(storage=_duckdb_env_storage)
 
 
 @pytest.mark.integration
@@ -294,9 +306,15 @@ class TestDuckDBQueries:
         assert float(result.data[0]["orders.next"]) == pytest.approx(375.0)  # Mar
 
 
-@pytest.fixture
-def duckdb_ingest_env(tmp_path):
-    """Set up tables with FK relationships and ingest via rollup."""
+@pytest.fixture(scope="module")
+def duckdb_ingest_env(tmp_path_factory):
+    """Set up tables with FK relationships and ingest via rollup.
+
+    Module-scoped: tests destructure ``(models, ds)`` and build their own
+    ephemeral storage from the returned models — they never mutate the fixture
+    state. Saves the ~0.55s/call SQLAlchemy reflection across 6 tests.
+    """
+    tmp_path = tmp_path_factory.mktemp("duckdb_ingest")
     db_path = tmp_path / "ingest.duckdb"
     conn = duckdb.connect(str(db_path))
 

--- a/tests/integration/test_integration_postgres.py
+++ b/tests/integration/test_integration_postgres.py
@@ -1,11 +1,13 @@
 """Integration tests using a real PostgreSQL database via pytest-postgresql."""
 
 import tempfile
+import uuid
 
 import pytest
 
 pytest.importorskip("pytest_postgresql")
 
+import psycopg
 from pytest_postgresql import factories
 
 from slayer.core.enums import DataType, TimeGranularity
@@ -18,91 +20,143 @@ from slayer.async_utils import run_sync
 
 # Spawn a temporary Postgres process (random port)
 postgresql_proc = factories.postgresql_proc(port=None)
+# Function-scoped per-test connection — used by pg_cross_model_env, which has a
+# test that mutates storage (create_model_from_query) and so cannot share a
+# module-scoped DB safely.
 postgresql = factories.postgresql("postgresql_proc")
 
 
+def _create_module_db(postgresql_proc):
+    """Create a fresh database on the session-scoped Postgres for one
+    module-scoped fixture. Returns (open_connection, db_name). Caller is
+    responsible for closing the connection and calling _drop_module_db on
+    teardown."""
+    info = postgresql_proc
+    db_name = f"test_{uuid.uuid4().hex[:12]}"
+    admin = psycopg.connect(
+        host=info.host, port=info.port, user=info.user, dbname="postgres",
+    )
+    admin.autocommit = True
+    with admin.cursor() as cur:
+        cur.execute(f'CREATE DATABASE "{db_name}"')
+    admin.close()
+    conn = psycopg.connect(
+        host=info.host, port=info.port, user=info.user, dbname=db_name,
+    )
+    return conn, db_name
+
+
+def _drop_module_db(postgresql_proc, db_name):
+    info = postgresql_proc
+    admin = psycopg.connect(
+        host=info.host, port=info.port, user=info.user, dbname="postgres",
+    )
+    admin.autocommit = True
+    with admin.cursor() as cur:
+        # FORCE: terminate any lingering async-engine connection pools that
+        # haven't yet been GC'd. Requires Postgres 13+; pytest-postgresql ships
+        # with whatever the system pg_ctl is, so this is fine in practice.
+        cur.execute(f'DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)')
+    admin.close()
+
+
+@pytest.fixture(scope="module")
+def _pg_env_storage(postgresql_proc, tmp_path_factory):
+    """Module-scoped: per-module Postgres DB with seeded customers/orders, plus
+    a YAMLStorage with the orders + customers models pre-saved. Returns the
+    storage instance — the per-test ``pg_env`` fixture wraps a fresh engine
+    around it (engines bind to their event loop, see slayer/sql/client.py:144).
+    """
+    conn, db_name = _create_module_db(postgresql_proc)
+    try:
+        cur = conn.cursor()
+        cur.execute("""
+            CREATE TABLE customers (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                region TEXT NOT NULL
+            )
+        """)
+        cur.execute("""
+            CREATE TABLE orders (
+                id INTEGER PRIMARY KEY,
+                status TEXT NOT NULL,
+                amount NUMERIC(10,2) NOT NULL,
+                customer_id INTEGER REFERENCES customers(id),
+                created_at TIMESTAMP NOT NULL
+            )
+        """)
+        cur.executemany(
+            "INSERT INTO customers VALUES (%s, %s, %s)",
+            [(1, "Acme Corp", "US"), (2, "Globex", "EU"), (3, "Initech", "US")],
+        )
+        cur.executemany(
+            "INSERT INTO orders VALUES (%s, %s, %s, %s, %s)",
+            [
+                (1, "completed", 100, 1, "2024-01-15 10:00:00"),
+                (2, "completed", 200, 1, "2024-01-20 11:00:00"),
+                (3, "pending", 50, 2, "2024-02-10 09:00:00"),
+                (4, "completed", 150, 2, "2024-02-15 14:00:00"),
+                (5, "cancelled", 75, 3, "2024-03-01 08:00:00"),
+                (6, "pending", 300, 3, "2024-03-10 16:00:00"),
+            ],
+        )
+        conn.commit()
+
+        tmpdir = str(tmp_path_factory.mktemp("pg_env"))
+        storage = YAMLStorage(base_dir=tmpdir)
+
+        info = postgresql_proc
+        run_sync(storage.save_datasource(DatasourceConfig(
+            name="testpg",
+            type="postgres",
+            host=info.host,
+            port=info.port,
+            database=db_name,
+            username=info.user,
+            password="",
+        )))
+
+        orders_model = SlayerModel(
+            name="orders",
+            sql_table="orders",
+            data_source="testpg",
+            columns=[
+                Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
+                Column(name="status", sql="status", type=DataType.STRING),
+                Column(name="customer_id", sql="customer_id", type=DataType.NUMBER),
+                Column(name="created_at", sql="created_at", type=DataType.TIMESTAMP),
+
+                Column(name="total", sql="amount", type=DataType.NUMBER),
+                Column(name="avg_amount", sql="amount", type=DataType.NUMBER),
+            ],
+        )
+        customers_model = SlayerModel(
+            name="customers",
+            sql_table="customers",
+            data_source="testpg",
+            columns=[
+                Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
+                Column(name="name", sql="name", type=DataType.STRING),
+                Column(name="region", sql="region", type=DataType.STRING),
+
+            ],
+        )
+        run_sync(storage.save_model(orders_model))
+        run_sync(storage.save_model(customers_model))
+
+        yield storage
+    finally:
+        conn.close()
+        _drop_module_db(postgresql_proc, db_name)
+
+
 @pytest.fixture
-async def pg_env(postgresql):
-    """Set up a full SLayer environment against the temporary Postgres."""
-    # Create test tables
-    cur = postgresql.cursor()
-    cur.execute("""
-        CREATE TABLE customers (
-            id INTEGER PRIMARY KEY,
-            name TEXT NOT NULL,
-            region TEXT NOT NULL
-        )
-    """)
-    cur.execute("""
-        CREATE TABLE orders (
-            id INTEGER PRIMARY KEY,
-            status TEXT NOT NULL,
-            amount NUMERIC(10,2) NOT NULL,
-            customer_id INTEGER REFERENCES customers(id),
-            created_at TIMESTAMP NOT NULL
-        )
-    """)
-    cur.executemany(
-        "INSERT INTO customers VALUES (%s, %s, %s)",
-        [(1, "Acme Corp", "US"), (2, "Globex", "EU"), (3, "Initech", "US")],
-    )
-    cur.executemany(
-        "INSERT INTO orders VALUES (%s, %s, %s, %s, %s)",
-        [
-            (1, "completed", 100, 1, "2024-01-15 10:00:00"),
-            (2, "completed", 200, 1, "2024-01-20 11:00:00"),
-            (3, "pending", 50, 2, "2024-02-10 09:00:00"),
-            (4, "completed", 150, 2, "2024-02-15 14:00:00"),
-            (5, "cancelled", 75, 3, "2024-03-01 08:00:00"),
-            (6, "pending", 300, 3, "2024-03-10 16:00:00"),
-        ],
-    )
-    postgresql.commit()
-
-    # Set up SLayer storage
-    tmpdir = tempfile.mkdtemp()
-    storage = YAMLStorage(base_dir=tmpdir)
-
-    info = postgresql.info
-    await storage.save_datasource(DatasourceConfig(
-        name="testpg",
-        type="postgres",
-        host=info.host,
-        port=info.port,
-        database=info.dbname,
-        username=info.user,
-        password="",
-    ))
-
-    orders_model = SlayerModel(
-        name="orders",
-        sql_table="orders",
-        data_source="testpg",
-        columns=[
-            Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
-            Column(name="status", sql="status", type=DataType.STRING),
-            Column(name="customer_id", sql="customer_id", type=DataType.NUMBER),
-            Column(name="created_at", sql="created_at", type=DataType.TIMESTAMP),
-
-            Column(name="total", sql="amount", type=DataType.NUMBER),
-            Column(name="avg_amount", sql="amount", type=DataType.NUMBER),
-        ],
-    )
-    customers_model = SlayerModel(
-        name="customers",
-        sql_table="customers",
-        data_source="testpg",
-        columns=[
-            Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
-            Column(name="name", sql="name", type=DataType.STRING),
-            Column(name="region", sql="region", type=DataType.STRING),
-
-        ],
-    )
-    await storage.save_model(orders_model)
-    await storage.save_model(customers_model)
-
-    return SlayerQueryEngine(storage=storage)
+def pg_env(_pg_env_storage):
+    """Per-test SlayerQueryEngine wrapping the module-scoped storage. The
+    engine is recreated per-test because its async SQLAlchemy engine binds to
+    the current event loop."""
+    return SlayerQueryEngine(storage=_pg_env_storage)
 
 
 @pytest.mark.integration
@@ -468,54 +522,64 @@ class TestCrossModelAndMultistage:
         assert by_tier["low"] == 3
 
 
-@pytest.fixture
-def pg_ingest_env(postgresql):
-    """Set up tables with FK relationships and ingest via rollup."""
-    cur = postgresql.cursor()
-    cur.execute("""
-        CREATE TABLE regions (
-            id INTEGER PRIMARY KEY,
-            name TEXT NOT NULL
-        )
-    """)
-    cur.execute("""
-        CREATE TABLE customers (
-            id INTEGER PRIMARY KEY,
-            name TEXT NOT NULL,
-            region_id INTEGER REFERENCES regions(id)
-        )
-    """)
-    cur.execute("""
-        CREATE TABLE orders (
-            id INTEGER PRIMARY KEY,
-            amount NUMERIC(10,2) NOT NULL,
-            customer_id INTEGER REFERENCES customers(id)
-        )
-    """)
-    cur.executemany("INSERT INTO regions VALUES (%s, %s)", [(1, "US"), (2, "EU")])
-    cur.executemany(
-        "INSERT INTO customers VALUES (%s, %s, %s)",
-        [(1, "Acme", 1), (2, "Globex", 2), (3, "Initech", 1)],
-    )
-    cur.executemany(
-        "INSERT INTO orders VALUES (%s, %s, %s)",
-        [(1, 100, 1), (2, 200, 1), (3, 50, 2), (4, 150, 3)],
-    )
-    postgresql.commit()
+@pytest.fixture(scope="module")
+def pg_ingest_env(postgresql_proc):
+    """Set up tables with FK relationships and ingest via rollup.
 
-    info = postgresql.info
-    ds = DatasourceConfig(
-        name="testpg",
-        type="postgres",
-        host=info.host,
-        port=info.port,
-        database=info.dbname,
-        username=info.user,
-        password="",
-    )
+    Module-scoped: tests destructure ``(models, ds, _)`` and build their own
+    ephemeral storage from the returned models — they never mutate the fixture
+    state. Saves the ~0.32s/call SQLAlchemy reflection across 11 tests.
+    """
+    conn, db_name = _create_module_db(postgresql_proc)
+    try:
+        cur = conn.cursor()
+        cur.execute("""
+            CREATE TABLE regions (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )
+        """)
+        cur.execute("""
+            CREATE TABLE customers (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                region_id INTEGER REFERENCES regions(id)
+            )
+        """)
+        cur.execute("""
+            CREATE TABLE orders (
+                id INTEGER PRIMARY KEY,
+                amount NUMERIC(10,2) NOT NULL,
+                customer_id INTEGER REFERENCES customers(id)
+            )
+        """)
+        cur.executemany("INSERT INTO regions VALUES (%s, %s)", [(1, "US"), (2, "EU")])
+        cur.executemany(
+            "INSERT INTO customers VALUES (%s, %s, %s)",
+            [(1, "Acme", 1), (2, "Globex", 2), (3, "Initech", 1)],
+        )
+        cur.executemany(
+            "INSERT INTO orders VALUES (%s, %s, %s)",
+            [(1, 100, 1), (2, 200, 1), (3, 50, 2), (4, 150, 3)],
+        )
+        conn.commit()
 
-    models = ingest_datasource(datasource=ds, schema="public")
-    return models, ds, postgresql
+        info = postgresql_proc
+        ds = DatasourceConfig(
+            name="testpg",
+            type="postgres",
+            host=info.host,
+            port=info.port,
+            database=db_name,
+            username=info.user,
+            password="",
+        )
+
+        models = ingest_datasource(datasource=ds, schema="public")
+        yield models, ds, conn
+    finally:
+        conn.close()
+        _drop_module_db(postgresql_proc, db_name)
 
 
 @pytest.mark.integration

--- a/tests/integration/test_jaffle_shop_duckdb.py
+++ b/tests/integration/test_jaffle_shop_duckdb.py
@@ -1,5 +1,8 @@
 """Integration test for the Jaffle Shop DuckDB loader."""
 
+import shutil
+from pathlib import Path
+
 import pytest
 
 pytest.importorskip("duckdb")
@@ -15,18 +18,32 @@ from slayer.demo.jaffle_shop import (
     verify,
 )
 
+# Cached 3-year demo DB maintained by tests/integration/test_notebooks.py's
+# session-scoped _ensure_jaffle_db fixture. Reusing it avoids ~10s of
+# `jafgen` subprocess time per pytest invocation.
+_CACHED_JAFFLE_DB = (
+    Path(__file__).resolve().parent.parent.parent
+    / "docs" / "examples" / "jaffle_data" / "demo" / "jaffle_shop.duckdb"
+)
+
 
 @pytest.fixture(scope="module")
 def jaffle_db(tmp_path_factory):
-    """Generate 1 year of data and load into DuckDB. Shared across all tests in this module."""
+    """Module-scoped DuckDB connection with Jaffle Shop data. Reuses the
+    project-wide cached DB at docs/examples/jaffle_data/demo/jaffle_shop.duckdb
+    when present; falls back to ``jafgen`` for fresh checkouts where
+    _ensure_jaffle_db has never run."""
     tmpdir = tmp_path_factory.mktemp("jaffle")
-    data_dir = generate_data(output_dir=str(tmpdir), years=1)
-
     db_path = tmpdir / "test_jaffle.duckdb"
-    conn = duckdb.connect(str(db_path))
 
-    create_schema(conn=conn)
-    load_data(conn=conn, data_dir=data_dir)
+    if _CACHED_JAFFLE_DB.exists():
+        shutil.copy(_CACHED_JAFFLE_DB, db_path)
+        conn = duckdb.connect(str(db_path))
+    else:
+        data_dir = generate_data(output_dir=str(tmpdir), years=1)
+        conn = duckdb.connect(str(db_path))
+        create_schema(conn=conn)
+        load_data(conn=conn, data_dir=data_dir)
 
     yield conn
     conn.close()


### PR DESCRIPTION
## Summary

Three test-only commits that cut the warm-cache integration suite from ~195s to ~110s on the local machine. No production code changes.

- **c8b79d1** — module-scope `pg_env` (split into module-scoped `_pg_env_storage` + per-test engine wrapper, since SQLAlchemy async engines bind to the event loop they're created on per `slayer/sql/client.py:144`) and module-scope `pg_ingest_env`. Each fixture rolls its own per-module Postgres DB on the session-scoped `postgresql_proc` and drops it `WITH (FORCE)` on teardown. `pg_cross_model_env` left function-scoped because `test_create_model_from_query` mutates its storage. Wall time on this machine: 18.00s → 4.16s.
- **4d919ef** — module-scope `duckdb_env` (same split pattern as Stage 1) and module-scope `duckdb_ingest_env` (returns immutable `(models, ds)` — tests build their own ephemeral storage). Wall time: 11.06s → 1.46s.
- **5197c64** — `jaffle_db` and `jaffle_duckdb_path` now `shutil.copy` from the project-wide cached `docs/examples/jaffle_data/demo/jaffle_shop.duckdb` (already maintained by `_ensure_jaffle_db`) instead of re-running `jafgen` per fixture. Falls back to `jafgen` on fresh checkouts. Combined wall time: ~24s of setup → 1.77s.

Excluded from this PR (smaller wins or higher risk):
- sqlite `integration_env` promotion — six tests mutate the storage, requires PR #84's session-scope-with-per-test-YAML-reset pattern. Net saving ~1.5s after reset overhead, inside the suite's noise floor.
- Notebook kernel sharing — bigger win (~20s) but medium risk (notebooks may rely on fresh-kernel state). Warrants its own PR.

## Test plan
- [x] `poetry run pytest -m integration tests/integration/ -q` — 220/220 pass in 110.93s (down from ~195s baseline)
- [x] `poetry run pytest -q -m "not integration"` — 1542/1542 pass in 8.84s
- [x] `poetry run ruff check slayer/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test performance through database caching and reuse
  * Optimized fixture patterns to reduce redundant test setup overhead
  * Enhanced test isolation and stability across DuckDB and Postgres environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->