### PR TITLE
Preserve json_extract() on SQLite to avoid lossy -> rewrite (DEV-1331)

### DIFF
--- a/.claude/skills/slayer-models.md
+++ b/.claude/skills/slayer-models.md
@@ -88,6 +88,7 @@ You **cannot** supply `columns` or `backing_query_sql` when saving a query-backe
 
 - Use **bare column names** (e.g., `"amount"`) in dimension/measure SQL — SLayer qualifies them automatically
 - For complex expressions, use the model name as table prefix (e.g., `"orders.amount * orders.quantity"`)
+- **SQLite**: `json_extract(col, '$.path')` is preserved as the function-call form (not rewritten to `col -> '$.path'`, which would return the JSON-quoted form and silently break `CASE WHEN` / equality matches against bare-string literals). Use `->>` directly if you specifically want the SQLite scalar operator.
 
 ## Datasource Config
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,8 @@ Dialect mapping lives in `query_engine.py:_dialect_for_type()`. Dialect-specific
 
 **In-memory SQLite caveat:** `sqlite:///:memory:` (and equivalent URI variants — `sqlite://`, `sqlite:///file::memory:?…`, `mode=memory`) works across `await` calls on a single `SlayerSQLClient` because the client owns a per-instance `StaticPool` engine with `check_same_thread=False`. Two separate `SlayerSQLClient` instances on `:memory:` are isolated from each other. Use a file path or `mode=memory&cache=shared` URI form to share state across clients. File-backed SQLite is unaffected — it routes through the module-level engine cache as before.
 
+**SQLite JSON extraction:** `json_extract(col, '$.path')` in `Column.sql` (or any expression `SQLGenerator` parses on SQLite) is preserved as the function-call form, not rewritten to `col -> '$.path'`. The `->` operator in SQLite returns the JSON-quoted form (e.g. `'"Owned"'` with literal quotes), which silently breaks equality / CASE WHEN matches against bare-string literals; the function form returns the unquoted scalar. Implemented via `slayer/sql/sqlite_dialect.py::rewrite_sqlite_json_extract`, applied uniformly through `SQLGenerator._parse`. Use `->>` (`exp.JSONExtractScalar`) directly if you specifically want the dialect operator — SLayer leaves it untouched.
+
 ## Testing
 
 **Important**: Always use `poetry run` to run tests — this ensures the correct Poetry-managed virtualenv is used (not the system or conda Python).

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -222,6 +222,22 @@ Use **bare column names** (e.g., `"amount"`) — SLayer automatically qualifies 
 
 For complex expressions, use the model name as a table prefix: `"orders.amount * orders.quantity"`.
 
+### SQLite JSON extraction
+
+`json_extract(col, '$.path')` in a `Column.sql` is preserved as the function-call form on SQLite — SLayer does **not** rewrite it to `col -> '$.path'`. The `->` operator in SQLite returns the JSON-quoted form (e.g. `'"Owned"'` with literal quotes), so equality and `CASE WHEN` matches against bare-string literals would silently fail. The function form returns the unquoted scalar.
+
+```yaml
+columns:
+  - name: tier
+    type: string
+    sql: "json_extract(payload, '$.tier')"           # works on SQLite (preserved)
+  - name: is_gold
+    type: number
+    sql: "CASE LOWER(json_extract(payload, '$.tier')) WHEN 'gold' THEN 1 ELSE 0 END"
+```
+
+If you specifically want the SQLite JSON-scalar operator, write `->>` (`exp.JSONExtractScalar`) directly — SLayer leaves it untouched.
+
 ## Joins
 
 Models can declare explicit LEFT JOIN relationships to other models:

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -19,6 +19,7 @@ from slayer.core.enums import (
     TimeGranularity,
 )
 from slayer.engine.enriched import EnrichedMeasure, EnrichedQuery
+from slayer.sql.sqlite_dialect import rewrite_sqlite_json_extract
 
 logger = logging.getLogger(__name__)
 
@@ -263,6 +264,24 @@ class SQLGenerator:
     def __init__(self, dialect: str = "postgres"):
         self.dialect = dialect
 
+    def _parse(self, sql: str, *, dialect: Optional[str] = None) -> exp.Expression:
+        """Parse ``sql`` via sqlglot, applying SLayer-specific AST rewrites.
+
+        On SQLite, rewrites ``exp.JSONExtract`` to the function-call form so
+        ``json_extract(...)`` is preserved (DEV-1331); the default sqlglot
+        SQLite emit is ``col -> '$.path'``, which returns the JSON-quoted
+        form and silently breaks CASE WHEN / equality matches.
+
+        Use this in place of ``sqlglot.parse_one(...)`` everywhere inside
+        ``SQLGenerator`` so the rewrite fires uniformly across every parse
+        site.
+        """
+        d = dialect or self.dialect
+        tree = sqlglot.parse_one(sql, dialect=d)
+        if d == "sqlite":
+            tree = rewrite_sqlite_json_extract(tree)
+        return tree
+
     def generate(self, enriched: EnrichedQuery) -> str:
         """Generate SQL from a fully resolved EnrichedQuery.
 
@@ -359,7 +378,7 @@ class SQLGenerator:
                 # FROM source model
                 if cm.source_sql:
                     source_from = exp.Subquery(
-                        this=sqlglot.parse_one(cm.source_sql, dialect=self.dialect),
+                        this=self._parse(cm.source_sql),
                         alias=exp.to_identifier(cm.source_model_name),
                     )
                 else:
@@ -369,7 +388,7 @@ class SQLGenerator:
                 # JOIN target model
                 if cm.target_model_sql:
                     target_join = exp.Subquery(
-                        this=sqlglot.parse_one(cm.target_model_sql, dialect=self.dialect),
+                        this=self._parse(cm.target_model_sql),
                         alias=exp.to_identifier(cm.target_model_name),
                     )
                 else:
@@ -491,12 +510,12 @@ class SQLGenerator:
                     if target_alias in needed:
                         if target_table.startswith("("):
                             join_target = exp.Subquery(
-                                this=sqlglot.parse_one(target_table, dialect=self.dialect),
+                                this=self._parse(target_table),
                                 alias=exp.to_identifier(target_alias),
                             )
                         else:
                             join_target = exp.to_table(target_table, alias=target_alias)
-                        join_on = sqlglot.parse_one(join_cond, dialect=self.dialect)
+                        join_on = self._parse(join_cond)
                         select = select.join(join_target, on=join_on, join_type=jtype.upper())
 
                 # Only include WHERE conditions whose tables are in this CTE
@@ -838,7 +857,7 @@ class SQLGenerator:
             # measure.filter_sql is a raw SQL string (originates upstream); parse
             # it once via sqlglot so the CASE WHEN ... THEN ... END is a true
             # AST node rather than text glued in.
-            filter_ast = sqlglot.parse_one(measure.filter_sql, dialect=self.dialect)
+            filter_ast = self._parse(measure.filter_sql)
             value_expr = exp.Case(ifs=[exp.If(this=filter_ast, true=value_expr)])
         source_cols.append(value_expr.as_("_w_value"))
 
@@ -896,12 +915,12 @@ class SQLGenerator:
                 continue
             if target_table.startswith("("):
                 join_target = exp.Subquery(
-                    this=sqlglot.parse_one(target_table, dialect=self.dialect),
+                    this=self._parse(target_table),
                     alias=exp.to_identifier(target_alias),
                 )
             else:
                 join_target = exp.to_table(target_table, alias=target_alias)
-            join_on = sqlglot.parse_one(join_cond, dialect=self.dialect)
+            join_on = self._parse(join_cond)
             select = select.join(join_target, on=join_on, join_type=jtype.upper())
 
         scoped = copy.copy(enriched)
@@ -1091,13 +1110,13 @@ class SQLGenerator:
             for target_table, target_alias, join_cond, jtype in resolved_joins:
                 if target_table.startswith("("):
                     # Inline-SQL target: parse as subquery
-                    parsed_target = sqlglot.parse_one(target_table, dialect=self.dialect)
+                    parsed_target = self._parse(target_table)
                     join_target = exp.Subquery(
                         this=parsed_target, alias=exp.to_identifier(target_alias),
                     )
                 else:
                     join_target = exp.to_table(target_table, alias=target_alias)
-                join_on = sqlglot.parse_one(join_cond, dialect=self.dialect)
+                join_on = self._parse(join_cond)
                 select = select.join(join_target, on=join_on, join_type=jtype.upper())
 
         sql = select.sql(dialect=self.dialect, pretty=True)
@@ -1414,14 +1433,11 @@ class SQLGenerator:
             }
             # Week: SQLite weekday 0=Sunday, use date() with weekday modifier
             if gran_str == "week":
-                return sqlglot.parse_one(
-                    f"DATE({col_expr.sql(dialect='sqlite')}, 'weekday 0', '-6 days')",
-                    dialect="sqlite",
-                )
+                return self._parse(f"DATE({col_expr.sql(dialect='sqlite')}, 'weekday 0', '-6 days')", dialect="sqlite")
             if gran_str == "quarter":
                 # Quarter start: derive from month
                 col_sql = col_expr.sql(dialect="sqlite")
-                return sqlglot.parse_one(
+                return self._parse(
                     f"STRFTIME('%Y-', {col_sql}) || CASE "
                     f"WHEN CAST(STRFTIME('%m', {col_sql}) AS INTEGER) <= 3 THEN '01-01' "
                     f"WHEN CAST(STRFTIME('%m', {col_sql}) AS INTEGER) <= 6 THEN '04-01' "
@@ -1564,7 +1580,7 @@ class SQLGenerator:
         if enriched.sql_table:
             return exp.to_table(enriched.sql_table, alias=enriched.model_name)
         elif enriched.sql:
-            parsed = sqlglot.parse_one(sql=enriched.sql, dialect=self.dialect)
+            parsed = self._parse(enriched.sql)
             return exp.Subquery(this=parsed, alias=exp.to_identifier(enriched.model_name))
         else:
             raise ValueError(f"Model '{enriched.model_name}' has neither sql_table nor sql defined")
@@ -1703,7 +1719,7 @@ class SQLGenerator:
         if where_clause is not None:
             ranked_sql += f" WHERE {where_clause.sql(dialect=self.dialect)}"
 
-        parsed = sqlglot.parse_one(ranked_sql, dialect=self.dialect)
+        parsed = self._parse(ranked_sql)
         return (
             exp.Subquery(this=parsed, alias=exp.to_identifier(model)),
             rn_suffix_map,
@@ -1723,7 +1739,7 @@ class SQLGenerator:
         # Use isidentifier() to distinguish column names from literals (e.g. "1")
         if sql.isidentifier():
             return exp.Column(this=exp.to_identifier(sql), table=exp.to_identifier(model_name))
-        return sqlglot.parse_one(sql=sql, dialect=self.dialect)
+        return self._parse(sql)
 
     def _resolve_value_sql(self, measure: "EnrichedMeasure") -> str:
         """Resolve ``measure.sql`` (or ``measure.name``) into a fully-qualified
@@ -1822,7 +1838,7 @@ class SQLGenerator:
                 )
             else:
                 case_sql = f"MAX(CASE WHEN {rn_col} = 1 THEN {measure.model_name}.{col} END)"
-            return sqlglot.parse_one(case_sql, dialect=self.dialect), True
+            return self._parse(case_sql), True
 
         # --- Custom or parameterized aggregation (formula-based) ---
         if agg_name not in _AGG_FUNCTION_MAP:
@@ -1843,7 +1859,7 @@ class SQLGenerator:
             # COUNT(*) — if filtered, use COUNT(CASE WHEN filter THEN 1 END)
             if measure.filter_sql:
                 case_sql = f"CASE WHEN {measure.filter_sql} THEN 1 END"
-                inner = sqlglot.parse_one(case_sql, dialect=self.dialect)
+                inner = self._parse(case_sql)
             else:
                 inner = exp.Star()
         elif measure.sql:
@@ -1858,7 +1874,7 @@ class SQLGenerator:
         if measure.filter_sql and not (agg_name == "count" and measure.sql is None):
             inner_sql = inner.sql(dialect=self.dialect)
             case_sql = f"CASE WHEN {measure.filter_sql} THEN {inner_sql} END"
-            inner = sqlglot.parse_one(case_sql, dialect=self.dialect)
+            inner = self._parse(case_sql)
 
         # --- count_distinct ---
         if agg_name == "count_distinct":
@@ -1934,7 +1950,7 @@ class SQLGenerator:
                 param_expr = _wrap_filter(param_expr, measure.filter_sql)
             substituted = substituted.replace(f"{{{param_name}}}", param_expr)
 
-        return sqlglot.parse_one(substituted, dialect=self.dialect)
+        return self._parse(substituted)
 
     def _build_median(self, inner: exp.Expression) -> exp.Expression:
         """Build a median aggregation expression (dialect-dependent)."""
@@ -1948,12 +1964,9 @@ class SQLGenerator:
         if self.dialect in ("sqlite", "clickhouse"):
             # SQLite: provided by the median() UDF registered on connect.
             # ClickHouse: native median() aggregate.
-            return sqlglot.parse_one(f"median({inner_sql})", dialect=self.dialect)
+            return self._parse(f"median({inner_sql})")
         # Postgres, DuckDB, and most others: PERCENTILE_CONT
-        return sqlglot.parse_one(
-            f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {inner_sql})",
-            dialect=self.dialect,
-        )
+        return self._parse(f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {inner_sql})")
 
     def _build_percentile(self, measure: "EnrichedMeasure") -> exp.Expression:
         """Build a PERCENTILE_CONT(p) aggregation expression (dialect-dependent).
@@ -2007,7 +2020,7 @@ class SQLGenerator:
         else:
             sql_str = f"PERCENTILE_CONT({p}) WITHIN GROUP (ORDER BY {col_expr})"
 
-        return sqlglot.parse_one(sql_str, dialect=self.dialect)
+        return self._parse(sql_str)
 
     def _build_stat_agg(self, measure: "EnrichedMeasure") -> exp.Expression:
         """Build SQL for the statistical aggregations added in DEV-1317.
@@ -2062,7 +2075,7 @@ class SQLGenerator:
             # resolve via the SQLite UDF aliases.
             sql_str = f"{agg_name.upper()}({col_expr})"
 
-        return sqlglot.parse_one(sql_str, dialect=self.dialect)
+        return self._parse(sql_str)
 
     # ------------------------------------------------------------------
     # WHERE / HAVING (filters still use ColumnRef for member resolution)
@@ -2142,11 +2155,11 @@ class SQLGenerator:
         where_clause = None
         if where_parts:
             where_sql = _SQL_AND_JOINER.join(where_parts)
-            where_clause = sqlglot.parse_one(where_sql, dialect=self.dialect)
+            where_clause = self._parse(where_sql)
 
         having_clause = None
         if having_parts:
             having_sql = _SQL_AND_JOINER.join(having_parts)
-            having_clause = sqlglot.parse_one(having_sql, dialect=self.dialect)
+            having_clause = self._parse(having_sql)
 
         return where_clause, having_clause

--- a/slayer/sql/sqlite_dialect.py
+++ b/slayer/sql/sqlite_dialect.py
@@ -1,0 +1,41 @@
+"""SQLite-specific AST rewrites applied before SQL emission.
+
+DEV-1331: sqlglot's default SQLite generator emits ``exp.JSONExtract`` as
+``col -> '$.path'``. In SQLite the ``->`` operator returns the JSON-typed
+form (e.g. ``'"Owned"'`` with literal quotes), whereas ``json_extract`` and
+``->>`` (``exp.JSONExtractScalar``) return the unquoted scalar. The mismatch
+silently breaks ``CASE WHEN`` / equality matches against bare-string
+literals — the bug compiles, executes, and produces wrong answers.
+
+The fix walks an sqlglot AST and rewrites every ``exp.JSONExtract`` node to
+``exp.Anonymous(this='JSON_EXTRACT', expressions=[col, path])`` so the
+emission is the canonical function-call form on every dialect. ``->>``
+(``exp.JSONExtractScalar``) is left untouched — it is correct on SQLite and
+the right answer on Postgres / MySQL too.
+"""
+
+from sqlglot import exp
+
+
+def rewrite_sqlite_json_extract(node: exp.Expression) -> exp.Expression:
+    """Rewrite every ``exp.JSONExtract`` in the tree rooted at ``node`` to the
+    function-call form.
+
+    Returns the (possibly new) root node — callers must use the return value
+    because ``node`` itself may be a ``JSONExtract`` (e.g. when parsing a
+    ``Column.sql`` whose entire expression is ``json_extract(col, path)``),
+    in which case ``Expression.replace`` is a no-op (no parent to rewire)
+    and a fresh root must be returned. Non-root rewrites happen in place.
+    """
+    if isinstance(node, exp.JSONExtract):
+        return _to_anonymous(node)
+    for je in list(node.find_all(exp.JSONExtract)):
+        je.replace(_to_anonymous(je))
+    return node
+
+
+def _to_anonymous(je: exp.JSONExtract) -> exp.Anonymous:
+    return exp.Anonymous(
+        this="JSON_EXTRACT",
+        expressions=[je.this.copy(), je.expression.copy()],
+    )

--- a/slayer/sql/sqlite_dialect.py
+++ b/slayer/sql/sqlite_dialect.py
@@ -26,16 +26,23 @@ def rewrite_sqlite_json_extract(node: exp.Expression) -> exp.Expression:
     ``Column.sql`` whose entire expression is ``json_extract(col, path)``),
     in which case ``Expression.replace`` is a no-op (no parent to rewire)
     and a fresh root must be returned. Non-root rewrites happen in place.
+
+    Loops to a fixed point so nested forms like
+    ``json_extract(json_extract(j, '$.outer'), '$.inner')`` get rewritten at
+    every level, not just the outermost.
     """
-    if isinstance(node, exp.JSONExtract):
-        return _to_anonymous(node)
-    for je in list(node.find_all(exp.JSONExtract)):
+    while True:
+        if isinstance(node, exp.JSONExtract):
+            node = _to_anonymous(node)
+            continue
+        je = node.find(exp.JSONExtract)
+        if je is None:
+            return node
         je.replace(_to_anonymous(je))
-    return node
 
 
 def _to_anonymous(je: exp.JSONExtract) -> exp.Anonymous:
     return exp.Anonymous(
         this="JSON_EXTRACT",
-        expressions=[je.this.copy(), je.expression.copy()],
+        expressions=[je.this, je.expression],
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2315,3 +2315,65 @@ async def test_n_one_bucket_returns_postgres_semantics(tmp_path):
         SlayerQuery(source_model="one", measures=[ModelMeasure(formula="x:var_pop")])
     )
     assert r_var_pop.data[0]["one.x_var_pop"] == 0
+
+
+async def test_json_extract_case_when_matches_in_sqlite(tmp_path):
+    """DEV-1331 reproduction.
+
+    A derived ``Column.sql`` that uses ``json_extract`` inside a CASE WHEN
+    must return the expected aggregate. Pre-fix the SQLite emitter rewrites
+    ``json_extract(...)`` to ``col -> '$.path'``, which returns the
+    JSON-quoted form (``'"Owned"'``); CASE WHEN against the bare-string
+    ``'owned'`` therefore never matches and the sum is 0.
+    """
+    db_path = tmp_path / "households.db"
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE households (id INTEGER PRIMARY KEY, socioeconomic TEXT NOT NULL)"
+    )
+    cur.executemany(
+        "INSERT INTO households VALUES (?, ?)",
+        [
+            (1, '{"Tenure_Type": "Owned"}'),
+            (2, '{"Tenure_Type": "Rented"}'),
+            (3, '{"Tenure_Type": "Owned"}'),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    storage_dir = tmp_path / "storage"
+    storage_dir.mkdir()
+    storage = YAMLStorage(base_dir=str(storage_dir))
+    await storage.save_datasource(
+        DatasourceConfig(name="hh_sqlite", type="sqlite", database=str(db_path))
+    )
+    await storage.save_model(
+        SlayerModel(
+            name="households",
+            sql_table="households",
+            data_source="hh_sqlite",
+            columns=[
+                Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
+                Column(name="socioeconomic", sql="socioeconomic", type=DataType.STRING),
+                Column(
+                    name="is_owner",
+                    sql=(
+                        "CASE LOWER(TRIM(json_extract(socioeconomic, '$.Tenure_Type'))) "
+                        "WHEN 'owned' THEN 1 ELSE 0 END"
+                    ),
+                    type=DataType.NUMBER,
+                ),
+            ],
+        )
+    )
+    engine = SlayerQueryEngine(storage=storage)
+
+    response = await engine.execute(
+        SlayerQuery(
+            source_model="households",
+            measures=[ModelMeasure(formula="is_owner:sum")],
+        )
+    )
+    assert response.data[0]["households.is_owner_sum"] == 2

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1777,7 +1777,7 @@ class TestSqliteJsonExtractInGenerator:
             dimensions=[ColumnRef(name="tier")],
             measures=[ModelMeasure(formula="*:count")],
         )
-        sql = await _generate(gen, query, model_with_json_dim)
+        sql = await _generate(generator=gen, query=query, model=model_with_json_dim)
         assert "JSON_EXTRACT(" in sql, f"missing JSON_EXTRACT in:\n{sql}"
         # The lossy ``payload -> '$.tier'`` form must not appear.
         assert "payload -> '$.tier'" not in sql, sql
@@ -1790,7 +1790,7 @@ class TestSqliteJsonExtractInGenerator:
             source_model="users",
             measures=[ModelMeasure(formula="is_gold:sum")],
         )
-        sql = await _generate(gen, query, model_with_json_dim)
+        sql = await _generate(generator=gen, query=query, model=model_with_json_dim)
         assert "JSON_EXTRACT(" in sql, sql
         assert "payload -> '$.tier'" not in sql, sql
 
@@ -1813,7 +1813,7 @@ class TestSqliteJsonExtractInGenerator:
             dimensions=[ColumnRef(name="tier")],
             measures=[ModelMeasure(formula="*:count")],
         )
-        sql = await _generate(gen, query, model)
+        sql = await _generate(generator=gen, query=query, model=model)
         assert "JSON_EXTRACT(" in sql, sql
         assert "payload -> '$.tier'" not in sql, sql
 
@@ -1833,7 +1833,7 @@ class TestSqliteJsonExtractInGenerator:
             dimensions=[ColumnRef(name="tier")],
             measures=[ModelMeasure(formula="*:count")],
         )
-        sql = await _generate(gen, query, model_with_json_dim)
+        sql = await _generate(generator=gen, query=query, model=model_with_json_dim)
         assert "JSON_EXTRACT" in sql.upper(), sql
 
 

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1737,6 +1737,106 @@ class TestMultiDialectGeneration:
             await _generate(generator=gen, query=query, model=orders_model)
 
 
+class TestSqliteJsonExtractInGenerator:
+    """DEV-1331: ``json_extract(col, '$.path')`` in ``Column.sql`` must not be
+    rewritten to ``col -> '$.path'`` on SQLite — the operator returns the
+    JSON-quoted form, silently breaking equality / CASE WHEN matches.
+    """
+
+    @pytest.fixture
+    def model_with_json_dim(self) -> SlayerModel:
+        return SlayerModel(
+            name="users",
+            sql_table="users",
+            data_source="test",
+            columns=[
+                Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
+                Column(name="payload", sql="payload", type=DataType.STRING),
+                Column(
+                    name="tier",
+                    sql="json_extract(payload, '$.tier')",
+                    type=DataType.STRING,
+                ),
+                Column(
+                    name="is_gold",
+                    sql=(
+                        "CASE LOWER(json_extract(payload, '$.tier')) "
+                        "WHEN 'gold' THEN 1 ELSE 0 END"
+                    ),
+                    type=DataType.NUMBER,
+                ),
+            ],
+        )
+
+    async def test_sqlite_column_sql_with_json_extract_dimension(
+        self, model_with_json_dim: SlayerModel,
+    ) -> None:
+        gen = SQLGenerator(dialect="sqlite")
+        query = SlayerQuery(
+            source_model="users",
+            dimensions=[ColumnRef(name="tier")],
+            measures=[ModelMeasure(formula="*:count")],
+        )
+        sql = await _generate(gen, query, model_with_json_dim)
+        assert "JSON_EXTRACT(" in sql, f"missing JSON_EXTRACT in:\n{sql}"
+        # The lossy ``payload -> '$.tier'`` form must not appear.
+        assert "payload -> '$.tier'" not in sql, sql
+
+    async def test_sqlite_column_sql_with_json_extract_in_case_when(
+        self, model_with_json_dim: SlayerModel,
+    ) -> None:
+        gen = SQLGenerator(dialect="sqlite")
+        query = SlayerQuery(
+            source_model="users",
+            measures=[ModelMeasure(formula="is_gold:sum")],
+        )
+        sql = await _generate(gen, query, model_with_json_dim)
+        assert "JSON_EXTRACT(" in sql, sql
+        assert "payload -> '$.tier'" not in sql, sql
+
+    async def test_sqlite_inline_sql_subquery_with_json_extract(self) -> None:
+        model = SlayerModel(
+            name="users",
+            sql=(
+                "SELECT id, json_extract(payload, '$.tier') AS tier "
+                "FROM raw_users"
+            ),
+            data_source="test",
+            columns=[
+                Column(name="id", sql="id", type=DataType.NUMBER, primary_key=True),
+                Column(name="tier", sql="tier", type=DataType.STRING),
+            ],
+        )
+        gen = SQLGenerator(dialect="sqlite")
+        query = SlayerQuery(
+            source_model="users",
+            dimensions=[ColumnRef(name="tier")],
+            measures=[ModelMeasure(formula="*:count")],
+        )
+        sql = await _generate(gen, query, model)
+        assert "JSON_EXTRACT(" in sql, sql
+        assert "payload -> '$.tier'" not in sql, sql
+
+    async def test_postgres_column_sql_with_json_extract_unchanged(
+        self, model_with_json_dim: SlayerModel,
+    ) -> None:
+        """Regression guard: rewrite is SQLite-only; Postgres path is untouched.
+
+        Postgres has no scalar-vs-JSON quoting bug for ``json_extract``;
+        sqlglot transpiles it to ``JSON_EXTRACT_PATH(j, 'k')``. We just
+        assert the generator produces *some* form of JSON extraction and
+        does not crash.
+        """
+        gen = SQLGenerator(dialect="postgres")
+        query = SlayerQuery(
+            source_model="users",
+            dimensions=[ColumnRef(name="tier")],
+            measures=[ModelMeasure(formula="*:count")],
+        )
+        sql = await _generate(gen, query, model_with_json_dim)
+        assert "JSON_EXTRACT" in sql.upper(), sql
+
+
 class TestMedianPercentilePerDialect:
     """Per-dialect SQL emission for median and percentile aggregations.
 

--- a/tests/test_sqlite_json_extract.py
+++ b/tests/test_sqlite_json_extract.py
@@ -1,0 +1,118 @@
+"""Unit tests for the SQLite ``json_extract`` AST-rewrite helper.
+
+DEV-1331: ``json_extract(col, '$.path')`` parses as ``exp.JSONExtract`` and
+sqlglot's default SQLite generator emits ``col -> '$.path'``. In SQLite,
+``->`` returns the JSON-quoted form (``'"Owned"'``) — different from the
+unquoted scalar that ``json_extract`` / ``->>`` return — which silently
+breaks CASE WHEN / equality matches against bare-string literals.
+
+The rewrite helper walks an sqlglot AST and replaces ``exp.JSONExtract``
+nodes with ``exp.Anonymous(this="JSON_EXTRACT", ...)`` so the emission is
+the function-call form on every dialect (a no-op on dialects that already
+emit ``JSON_EXTRACT(`` natively).
+"""
+
+import sqlite3
+
+import sqlglot
+from sqlglot import exp
+
+from slayer.sql.sqlite_dialect import rewrite_sqlite_json_extract
+
+
+def _parse_rewrite_emit(sql: str, *, dialect: str = "sqlite") -> str:
+    tree = sqlglot.parse_one(sql, dialect=dialect)
+    rewrite_sqlite_json_extract(tree)
+    return tree.sql(dialect=dialect)
+
+
+def test_sqlite_json_extract_emits_function_form() -> None:
+    out = _parse_rewrite_emit("SELECT json_extract(j, '$.k') FROM t")
+    assert "JSON_EXTRACT(" in out, out
+    assert " -> " not in out, out
+
+
+def test_sqlite_json_extract_scalar_unchanged() -> None:
+    """``->>`` (JSONExtractScalar) is correct on SQLite — must not be touched."""
+    out = _parse_rewrite_emit("SELECT j ->> '$.k' FROM t")
+    assert "->>" in out, out
+    assert "JSON_EXTRACT(" not in out, out
+
+
+def test_postgres_json_extract_unchanged() -> None:
+    """The rewrite is idempotent on Postgres (which doesn't have a JSONExtract
+    quoting hazard). It should still produce valid Postgres SQL — sqlglot's
+    Postgres emit for ``json_extract`` is ``JSON_EXTRACT_PATH(...)``.
+    """
+    tree = sqlglot.parse_one("SELECT json_extract(j, '$.k') FROM t")
+    rewrite_sqlite_json_extract(tree)
+    out = tree.sql(dialect="postgres")
+    assert " -> " not in out
+    assert "JSON_EXTRACT" in out.upper()
+
+
+def test_sqlite_json_extract_in_case_when_round_trip() -> None:
+    sql = (
+        "SELECT CASE LOWER(TRIM(json_extract(socioeconomic, '$.Tenure_Type'))) "
+        "WHEN 'owned' THEN 1 ELSE 0 END FROM households"
+    )
+    out = _parse_rewrite_emit(sql)
+    assert "JSON_EXTRACT(" in out, out
+    assert " -> " not in out, out
+
+
+def test_sqlite_json_extract_executes_correctly() -> None:
+    """End-to-end sanity check: round-tripped SQL through real SQLite must
+    return the unquoted scalar so CASE WHEN matches.
+    """
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE t (j TEXT)")
+    cur.executemany(
+        "INSERT INTO t VALUES (?)",
+        [
+            ('{"Tenure_Type": "Owned"}',),
+            ('{"Tenure_Type": "Rented"}',),
+            ('{"Tenure_Type": "Owned"}',),
+        ],
+    )
+    sql = (
+        "SELECT SUM(CASE LOWER(json_extract(j, '$.Tenure_Type')) "
+        "WHEN 'owned' THEN 1 ELSE 0 END) FROM t"
+    )
+    rewritten = _parse_rewrite_emit(sql)
+    (got,) = cur.execute(rewritten).fetchone()
+    conn.close()
+    assert got == 2, f"expected 2, got {got!r} from rewritten SQL:\n{rewritten}"
+
+
+def test_rewrite_walks_nested_subtrees() -> None:
+    """Helper must rewrite JSONExtract nodes anywhere in the tree, not just
+    at the top level.
+    """
+    sql = (
+        "SELECT * FROM ("
+        "SELECT json_extract(payload, '$.tier') AS tier FROM raw"
+        ") sub WHERE tier = 'Gold'"
+    )
+    out = _parse_rewrite_emit(sql)
+    assert "JSON_EXTRACT(" in out, out
+    assert " -> " not in out, out
+
+
+def test_rewrite_returns_same_node_object() -> None:
+    """In-place rewrite — caller's reference to the parsed tree stays valid."""
+    tree = sqlglot.parse_one("SELECT json_extract(j, '$.k') FROM t", dialect="sqlite")
+    before_id = id(tree)
+    result = rewrite_sqlite_json_extract(tree)
+    assert id(tree) == before_id
+    # Either returns the same root or returns None (in-place); accept both shapes.
+    assert result is None or id(result) == before_id
+
+
+def test_rewrite_handles_no_json_extract() -> None:
+    tree = sqlglot.parse_one("SELECT 1 + 1 AS n FROM t", dialect="sqlite")
+    rewrite_sqlite_json_extract(tree)
+    assert tree.sql(dialect="sqlite").upper().startswith("SELECT 1 + 1")
+    # Must not have introduced any JSONExtract nodes
+    assert tree.find(exp.JSONExtract) is None

--- a/tests/test_sqlite_json_extract.py
+++ b/tests/test_sqlite_json_extract.py
@@ -116,3 +116,23 @@ def test_rewrite_handles_no_json_extract() -> None:
     assert tree.sql(dialect="sqlite").upper().startswith("SELECT 1 + 1")
     # Must not have introduced any JSONExtract nodes
     assert tree.find(exp.JSONExtract) is None
+
+
+def test_rewrite_nested_json_extract() -> None:
+    """``json_extract(json_extract(j, '$.outer'), '$.inner')`` must rewrite at
+    every level, not just the outermost — otherwise the inner ``->`` survives
+    and re-introduces the JSON-quoted-form bug.
+    """
+    out = _parse_rewrite_emit(
+        "SELECT json_extract(json_extract(j, '$.outer'), '$.inner') FROM t"
+    )
+    assert " -> " not in out, out
+    assert out.count("JSON_EXTRACT(") == 2, out
+
+
+def test_rewrite_triple_nested_json_extract() -> None:
+    out = _parse_rewrite_emit(
+        "SELECT json_extract(json_extract(json_extract(j,'$.a'),'$.b'),'$.c') FROM t"
+    )
+    assert " -> " not in out, out
+    assert out.count("JSON_EXTRACT(") == 3, out


### PR DESCRIPTION
## Summary

- Linear: [DEV-1331](https://linear.app/motley-ai/issue/DEV-1331/slayer-sql-json-extract-rewritten-to-produces-json-quoted-strings) — Urgent (silent wrong answers).
- sqlglot's SQLite generator emits `exp.JSONExtract` as `col -> '$.path'`, which returns the **JSON-quoted** form (`'"Owned"'` with literal quotes). CASE WHEN / equality matches against bare-string literals therefore silently fail. Three production confirmations (crypto, mental, cold_chain) plus one latent in `households.yaml`.
- Fix: rewrite every `exp.JSONExtract` to `exp.Anonymous("JSON_EXTRACT", ...)` on SQLite, applied through a new `SQLGenerator._parse` that wraps every internal `sqlglot.parse_one`. `exp.JSONExtractScalar` (`->>`) and non-SQLite dialects are untouched.

## Why this approach (and what I rejected)

Three candidates considered:
- **Monkey-patch `SQLite.generator_class.TRANSFORMS`** (smaller diff). Rejected: process-wide global mutation that leaks to every other sqlglot consumer in the same Python process; pokes private internals.
- **Subclass the SQLite dialect/generator**. Rejected: blocked by `TypeError: interpreted classes cannot inherit from compiled` — sqlglot ships compiled generator classes.
- **AST-rewrite at parse time, scoped to SLayer (chosen)**. Public AST APIs only; no global state mutation; testable in isolation. Funneled every parse through `SQLGenerator._parse`.

## Files changed

- `slayer/sql/sqlite_dialect.py` (new) — `rewrite_sqlite_json_extract(node)` helper.
- `slayer/sql/generator.py` — new `SQLGenerator._parse(sql, *, dialect=None)`; every internal `sqlglot.parse_one(...)` routed through it (17 sites).
- `tests/test_sqlite_json_extract.py` (new) — 8 unit tests on the helper, including end-to-end `sqlite3` execution.
- `tests/test_sql_generator.py::TestSqliteJsonExtractInGenerator` — 4 tests covering `Column.sql` flowing through `SQLGenerator` (dimension, CASE WHEN, inline `sql=` subquery, Postgres regression guard).
- `tests/integration/test_integration.py` — `test_json_extract_case_when_matches_in_sqlite`: end-to-end repro. Pre-fix returned 0; post-fix returns 2.
- `CLAUDE.md`, `docs/concepts/models.md`, `.claude/skills/slayer-models.md` — note about the SQLite caveat and the preserved function form.

## Test plan

- [x] `poetry run pytest -m "not integration"` — 1533 passed.
- [x] `poetry run pytest tests/integration/test_integration.py -m integration` — 77 passed.
- [x] `poetry run ruff check slayer/ tests/` — all checks passed.
- [x] Manual: in-memory SQLite verifies the round-tripped SQL returns the unquoted scalar.

## Risk / follow-ups

- A future contributor adding a raw `sqlglot.parse_one(...)` inside `generator.py` without going through `self._parse` would silently re-introduce the bug. Consider a CI guard if it becomes a recurring pattern.
- `slayer/dbt/sql_resolver.py` also parses SQL via sqlglot. Out of scope here — would need its own audit if any dbt model uses SQLite + `json_extract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite JSON extraction preserved as function-call form (json_extract) in CASE/equality contexts to avoid JSON-quoted results breaking comparisons.

* **Documentation**
  * Added guidance and examples showing SQLite JSON extraction behavior and how to get unquoted scalar values when needed.

* **Tests**
  * Added regression and integration tests covering CASE/equality, nested uses, idempotence, generator behavior, and runtime correctness on SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->