### PR TITLE
Forward Jafgen logs when generating demo data

### DIFF
--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -23,7 +23,14 @@ slayer datasources create demo --ingest
 slayer query '{"source_model": "orders", "measures": ["*:count"]}'
 ```
 
-This generates ~4 years of synthetic coffee-shop data into a local DuckDB file under your storage directory and ingests the models (`customers`, `orders`, `items`, `products`, `stores`, `supplies`, `tweets`). Re-running is idempotent — the DuckDB is reused if it already exists. Override the years with `--years N` (the default of 4 ensures all six bundled stores have orders — the last store opens on simulated day 1107).
+This generates ~2 years of synthetic coffee-shop data into a local DuckDB file under your storage directory and ingests the models (`customers`, `orders`, `items`, `products`, `stores`, `supplies`, `tweets`). Re-running is idempotent — the DuckDB is reused if it already exists. Override the years with `--years N`; the default is kept small so `slayer serve --demo` / `slayer mcp --demo` finish quickly enough to fit inside MCP-client startup timeouts. Only the first four bundled stores open within the first two years — bump `--years` to 4+ if you want all six.
+
+Pre-populate once and `--demo` is instant afterwards:
+
+```bash
+slayer datasources create demo --ingest --yes      # builds and ingests upfront
+slayer mcp --demo                                  # subsequent runs reuse the DuckDB
+```
 
 DuckDB and `jafgen` ship with `motley-slayer`, so no extra install is needed.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -162,7 +162,7 @@ slayer datasources create demo --ingest        # bundled Jaffle Shop demo
 | `--schema` | No | (with `--ingest`) Schema to ingest from |
 | `--include` | No | (with `--ingest`) Comma-separated tables to include |
 | `--exclude` | No | (with `--ingest`) Comma-separated tables to exclude |
-| `--years` | No | (demo only) Years of synthetic data to generate (default: 4) |
+| `--years` | No | (demo only) Years of synthetic data to generate (default: 2) |
 | `-y`, `--yes` | No | Overwrite existing datasource / colliding models without prompting |
 | `--storage` | No | Storage path |
 

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -776,6 +776,7 @@ def _prepare_demo(args, storage, *, stream=None):
             storage_path=storage_path,
             ingest_models=True,
             assume_yes=True,
+            stream=out,
         )
     except Exception as e:
         print(f"Failed to set up the Jaffle Shop demo: {e}", file=out)
@@ -1299,7 +1300,9 @@ def _run_datasources_create_demo(args, storage):  # NOSONAR S3776 — linear dem
     db_path = resolve_demo_db_path(storage_path)
 
     try:
-        db_built = build_jaffle_shop(db_path=db_path, years=max(1, args.years))
+        db_built = build_jaffle_shop(
+            db_path=db_path, years=max(1, args.years), stream=sys.stderr
+        )
     except Exception as e:
         print(f"Failed to build Jaffle Shop demo: {e}")
         sys.exit(1)

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -359,8 +359,8 @@ examples:
     datasources_create_parser.add_argument(
         "--years",
         type=int,
-        default=4,
-        help="(demo only) Years of synthetic data to generate (default: 4)",
+        default=2,
+        help="(demo only) Years of synthetic data to generate (default: 2)",
     )
     datasources_create_parser.add_argument(
         "-y",

--- a/slayer/demo/jaffle_shop.py
+++ b/slayer/demo/jaffle_shop.py
@@ -13,8 +13,9 @@ the existing DuckDB file instead of regenerating.
 import datetime as dt
 import os
 import subprocess
+import sys
 import tempfile
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import IO, TYPE_CHECKING, List, Optional, Tuple
 
 from slayer.async_utils import run_sync
 from slayer.core.models import DatasourceConfig, SlayerModel
@@ -123,14 +124,25 @@ def resolve_demo_db_path(storage_path: str) -> str:
     return os.path.join(demo_dir, "jaffle_shop.duckdb")
 
 
-def generate_data(output_dir: str, years: int = 1) -> str:
-    """Run ``jafgen`` into ``output_dir``; return the path to the generated CSVs."""
+def generate_data(
+    output_dir: str,
+    years: int = 1,
+    *,
+    stream: Optional[IO[str]] = None,
+) -> str:
+    """Run ``jafgen`` into ``output_dir``; return the path to the generated CSVs.
+
+    jafgen prints Rich progress bars to its own stdout. To keep them visible
+    (and to avoid corrupting stdio-based protocols like MCP), both jafgen's
+    stdout and stderr are routed to ``stream`` (default: this process's
+    stderr). When ``stream`` is a TTY, Rich animates the bars in place.
+    """
     cmd = ["jafgen", str(max(1, years))]
+    out = stream if stream is not None else sys.stderr
     try:
-        subprocess.run(args=cmd, cwd=output_dir, check=True, capture_output=True)
+        subprocess.run(args=cmd, cwd=output_dir, check=True, stdout=out, stderr=out)
     except subprocess.CalledProcessError as e:
-        stderr = e.stderr.decode("utf-8", errors="replace") if e.stderr else ""
-        raise RuntimeError(f"jafgen failed: {stderr.strip() or e}") from e
+        raise RuntimeError(f"jafgen failed with exit code {e.returncode}") from e
     return os.path.join(output_dir, "jaffle-data")
 
 
@@ -271,14 +283,21 @@ def verify(conn: "duckdb.DuckDBPyConnection") -> dict:
     return results
 
 
-def build_jaffle_shop(db_path: str, *, years: int = 4, force: bool = False) -> bool:
+def build_jaffle_shop(
+    db_path: str,
+    *,
+    years: int = 4,
+    force: bool = False,
+    stream: Optional[IO[str]] = None,
+) -> bool:
     """Generate the Jaffle Shop DuckDB at ``db_path`` if it does not already exist.
 
     Returns ``True`` if the DB was freshly generated, ``False`` if an existing
     file at ``db_path`` was reused. When ``force=True``, any existing file is
     overwritten. On the reuse path, dates are re-shifted so
     ``MAX(orders.ordered_at) == today`` — this keeps the demo feeling current
-    even when the DB was built days or weeks earlier.
+    even when the DB was built days or weeks earlier. ``stream`` is forwarded
+    to ``generate_data`` so jafgen's Rich progress bars stay visible.
     """
     import duckdb
 
@@ -294,7 +313,7 @@ def build_jaffle_shop(db_path: str, *, years: int = 4, force: bool = False) -> b
         os.remove(db_path)
 
     with tempfile.TemporaryDirectory(prefix="jaffle_") as tmpdir:
-        data_dir = generate_data(output_dir=tmpdir, years=years)
+        data_dir = generate_data(output_dir=tmpdir, years=years, stream=stream)
         conn = duckdb.connect(db_path)
         try:
             create_schema(conn)
@@ -312,6 +331,7 @@ def ensure_demo_datasource(
     years: int = 4,
     ingest_models: bool = True,
     assume_yes: bool = True,
+    stream: Optional[IO[str]] = None,
 ) -> Tuple[DatasourceConfig, List[SlayerModel], bool]:
     """Ensure the Jaffle Shop demo is fully set up in ``storage``.
 
@@ -327,7 +347,7 @@ def ensure_demo_datasource(
     freshly generated this call.
     """
     db_path = resolve_demo_db_path(storage_path)
-    db_built = build_jaffle_shop(db_path=db_path, years=years)
+    db_built = build_jaffle_shop(db_path=db_path, years=years, stream=stream)
 
     ds = DatasourceConfig.model_validate(
         {

--- a/slayer/demo/jaffle_shop.py
+++ b/slayer/demo/jaffle_shop.py
@@ -1,16 +1,18 @@
 """Jaffle Shop demo dataset — bundled, one-command setup.
 
-Generates ~4 years of synthetic coffee-shop data via ``jafgen``, loads it into
+Generates ~2 years of synthetic coffee-shop data via ``jafgen``, loads it into
 a DuckDB file under the storage directory, registers a ``jaffle_shop``
-datasource, and (optionally) auto-ingests SLayer models. The default of 4
-years is chosen so all six jafgen stores have orders — the latest one (Los
-Angeles) opens on simulated day 1107 (~3.03 years).
+datasource, and (optionally) auto-ingests SLayer models. The default is kept
+small so ``slayer serve --demo`` / ``slayer mcp --demo`` finish quickly enough
+to fit inside MCP-client startup timeouts; bump ``--years`` for a richer
+dataset (only the first four jafgen stores open within the first 2 years).
 
 All operations are idempotent: re-running with the same storage path reuses
 the existing DuckDB file instead of regenerating.
 """
 
 import datetime as dt
+import io
 import os
 import subprocess
 import sys
@@ -124,6 +126,21 @@ def resolve_demo_db_path(storage_path: str) -> str:
     return os.path.join(demo_dir, "jaffle_shop.duckdb")
 
 
+def _stream_fileno(stream) -> Optional[int]:
+    """Return ``stream.fileno()`` if it points at a real file descriptor, else None.
+
+    ipykernel / nbclient replace ``sys.stdout`` / ``sys.stderr`` with shim
+    streams whose ``fileno()`` raises ``io.UnsupportedOperation``; same with
+    ``io.StringIO``. ``subprocess.run(stdout=stream)`` walks ``fileno()``
+    unconditionally, so we need to detect that up front and fall back to a
+    pumped Popen.
+    """
+    try:
+        return stream.fileno()
+    except (AttributeError, io.UnsupportedOperation, ValueError, OSError):
+        return None
+
+
 def generate_data(
     output_dir: str,
     years: int = 1,
@@ -135,14 +152,38 @@ def generate_data(
     jafgen prints Rich progress bars to its own stdout. To keep them visible
     (and to avoid corrupting stdio-based protocols like MCP), both jafgen's
     stdout and stderr are routed to ``stream`` (default: this process's
-    stderr). When ``stream`` is a TTY, Rich animates the bars in place.
+    stderr). When ``stream`` is a real OS file (e.g. a TTY), the child
+    inherits it directly so Rich can animate the bars in place. When it is a
+    shim without ``fileno()`` (Jupyter ``OutStream``, ``io.StringIO``, …), we
+    pump the child's output line by line into ``stream`` instead.
     """
     cmd = ["jafgen", str(max(1, years))]
     out = stream if stream is not None else sys.stderr
-    try:
-        subprocess.run(args=cmd, cwd=output_dir, check=True, stdout=out, stderr=out)
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"jafgen failed with exit code {e.returncode}") from e
+    if _stream_fileno(out) is not None:
+        try:
+            subprocess.run(args=cmd, cwd=output_dir, check=True, stdout=out, stderr=out)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"jafgen failed with exit code {e.returncode}") from e
+        return os.path.join(output_dir, "jaffle-data")
+
+    with subprocess.Popen(
+        args=cmd,
+        cwd=output_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    ) as proc:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            out.write(line)
+            try:
+                out.flush()
+            except Exception:
+                pass
+        rc = proc.wait()
+    if rc != 0:
+        raise RuntimeError(f"jafgen failed with exit code {rc}")
     return os.path.join(output_dir, "jaffle-data")
 
 
@@ -286,7 +327,7 @@ def verify(conn: "duckdb.DuckDBPyConnection") -> dict:
 def build_jaffle_shop(
     db_path: str,
     *,
-    years: int = 4,
+    years: int = 2,
     force: bool = False,
     stream: Optional[IO[str]] = None,
 ) -> bool:
@@ -328,7 +369,7 @@ def ensure_demo_datasource(
     *,
     storage_path: str,
     name: str = DEMO_NAME,
-    years: int = 4,
+    years: int = 2,
     ingest_models: bool = True,
     assume_yes: bool = True,
     stream: Optional[IO[str]] = None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Demo setup now streams real-time progress output during demo build/ingest so users can monitor live progress.
  * Default demo size reduced from 4 to 2 years for faster generation; the CLI option --years can override this.

* **Documentation**
  * Updated docs and examples to reflect the smaller default, new usage for pre-populating and reusing the demo data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/104)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->