### PR TITLE
DEV-1372: MCP query tool accepts inline source_model

### DIFF
--- a/docs/interfaces/mcp.md
+++ b/docs/interfaces/mcp.md
@@ -85,7 +85,7 @@ claude mcp list
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `source_model` | string | Model name (required) |
+| `source_model` | string \| ModelExtension \| SlayerModel | Model name (string), inline `ModelExtension` dict (`{"source_name": "orders", "columns": [...], "joins": [...], "measures": [...]}` — extend a saved model with extras for this query), or inline `SlayerModel` dict (`{"name": "ad_hoc", "sql_table": "...", "data_source": "...", "columns": [...]}` — define a model ad-hoc). Required. |
 | `measures` | list | Aggregated values: column-aggregations, arithmetic, transforms. E.g. `["*:count", {"formula": "revenue:sum / *:count", "name": "aov", "label": "Average Order Value"}, "cumsum(revenue:sum)"]`. Each entry has an optional `label` for human-readable display. Supports nesting: `"change(cumsum(revenue:sum))"`. Bare names resolve to saved `ModelMeasure` formulas on the model. |
 | `dimensions` | list | Dimension names, e.g. `["status"]`. When using the engine directly, dimensions accept an optional `label` via `{"name": "status", "label": "Order Status"}`. |
 | `filters` | list[str] | Filter formula strings, e.g. `["status = 'active'", "amount > 100"]`. Supports operators (`=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `IS NULL`, `IS NOT NULL`, `LIKE`, `NOT LIKE`), boolean logic (`AND`, `OR`, `NOT`), and inline transform expressions (`"change(revenue:sum) > 0"`). Filters on measures are automatically routed to HAVING. |

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -94,7 +94,7 @@ claude mcp list
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `source_model` | string | Model name (required) |
+| `source_model` | string \| ModelExtension \| SlayerModel | Model name (string), inline `ModelExtension` dict (`{"source_name": "orders", "columns": [...], "joins": [...], "measures": [...]}` — extend a saved model with extras for this query), or inline `SlayerModel` dict (`{"name": "ad_hoc", "sql_table": "...", "data_source": "...", "columns": [...]}` — define a model ad-hoc). Required. |
 | `measures` | list | Aggregated values: column-aggregations, arithmetic, transforms. E.g. `["*:count", {"formula": "revenue:sum / *:count", "name": "aov", "label": "Average Order Value"}, "cumsum(revenue:sum)"]`. Each entry has an optional `label` for human-readable display. Supports nesting: `"change(cumsum(revenue:sum))"`. Bare names resolve to saved `ModelMeasure` formulas on the model. |
 | `dimensions` | list | Dimension names, e.g. `["status"]`. When using the engine directly, dimensions accept an optional `label` via `{"name": "status", "label": "Order Status"}`. |
 | `filters` | list[str] | Filter formula strings, e.g. `["status = 'active'", "amount > 100"]`. Supports operators (`=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `IS NULL`, `IS NOT NULL`, `LIKE`, `NOT LIKE`), boolean logic (`AND`, `OR`, `NOT`), and inline transform expressions (`"change(revenue) > 0"`). Filters on measures are automatically routed to HAVING. |

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -1053,7 +1053,7 @@ def create_mcp_server(storage: StorageBackend):
                 target = await storage.get_model(model_name)
                 if target is not None and target.source_queries:
                     result = await engine.execute(
-                        model_name,
+                        query=model_name,
                         variables=variables or {},
                         dry_run=dry_run,
                         explain=explain,

--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -20,7 +20,7 @@ from slayer.core.models import (
     ModelMeasure,
     SlayerModel,
 )
-from slayer.core.query import SlayerQuery
+from slayer.core.query import ModelExtension, SlayerQuery
 from slayer.engine.query_engine import SlayerQueryEngine, SlayerResponse
 from slayer.help import TOPIC_SUMMARY_LINE, render_help
 from slayer.memories.service import MemoryService
@@ -956,7 +956,7 @@ def create_mcp_server(storage: StorageBackend):
 
     @mcp.tool()
     async def query(  # NOSONAR S107 — FastMCP introspects this signature to expose each query option as a typed MCP tool argument; collapsing into a dict would degrade the agent-facing schema
-        source_model: str,
+        source_model: str | ModelExtension | SlayerModel,
         measures: Optional[List[Dict[str, str]]] = None,
         dimensions: Optional[List[str]] = None,
         filters: Optional[List[str]] = None,
@@ -974,7 +974,13 @@ def create_mcp_server(storage: StorageBackend):
         """Query data from a semantic model. Call inspect_model first to see available columns and measures.
 
         Args:
-            source_model: Name of the model to query (from models_summary).
+            source_model: One of three forms:
+                - **Model name** (string) — name of a saved model from models_summary, e.g. ``"orders"``.
+                - **Inline ModelExtension** (dict) — extend an existing model with extra columns/joins/measures
+                  for this one query: ``{"source_name": "orders", "columns": [{"name": "double_amount",
+                  "sql": "amount * 2", "type": "DOUBLE"}]}``.
+                - **Inline SlayerModel** (dict) — define a model ad-hoc:
+                  ``{"name": "ad_hoc", "sql_table": "things", "data_source": "test", "columns": [...]}``.
             measures: Aggregated values to return. Each is a formula: {"formula": "*:count"},
                 {"formula": "revenue:sum / *:count", "name": "aov"} (arithmetic),
                 {"formula": "cumsum(revenue:sum)"} (cumulative sum), {"formula": "change(revenue:sum)"} (diff from previous row),
@@ -1026,22 +1032,28 @@ def create_mcp_server(storage: StorageBackend):
             fmt = format.lower().strip()
             if fmt not in ("json", "csv", "markdown"):
                 raise ValueError(f"Invalid format '{format}'. Must be one of: json, csv, markdown")
-            # Run-by-name shortcut: when only source_model is given (no
-            # measures / dimensions / filters / time_dimensions / order /
-            # limit / offset), dispatch through ``engine.execute(str)`` so
-            # the model's stored backing query runs directly. Variables flow
-            # through with the documented run-by-name precedence.
+            # Run-by-name shortcut: when ``source_model`` is a stored model
+            # name (string) and no overrides are given, dispatch through
+            # ``engine.execute(str)`` so the model's stored backing query
+            # runs directly with run-by-name variable precedence
+            # (``runtime_kwarg > stage > model.query_variables``). Inline
+            # ``ModelExtension`` / ``SlayerModel`` values fall through to
+            # the regular ``SlayerQuery`` path below — they have no stored
+            # backing query and the run-by-name semantics don't apply.
+            # See DEV-1373 for the variable-precedence asymmetry between
+            # the two paths.
             no_overrides = (
                 not measures and not dimensions and not filters
                 and not time_dimensions and not order
                 and limit is None and offset is None
                 and not whole_periods_only
             )
-            if no_overrides:
-                target = await storage.get_model(source_model)
+            if isinstance(source_model, str) and no_overrides:
+                model_name = source_model
+                target = await storage.get_model(model_name)
                 if target is not None and target.source_queries:
                     result = await engine.execute(
-                        source_model,
+                        model_name,
                         variables=variables or {},
                         dry_run=dry_run,
                         explain=explain,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2807,6 +2807,82 @@ class TestRunByNamePlanFlagsMCP:
         assert execute_calls == 0, "dry_run=True must not execute SQL"
 
 
+class TestQueryAcceptsInlineSourceModel:
+    """DEV-1372: the MCP ``query`` tool must accept ``source_model`` as a
+    string (model name), an inline ``ModelExtension`` dict, or an inline
+    ``SlayerModel`` dict — matching ``SlayerQuery.source_model``'s native
+    polymorphism. Previously typed ``str``, which forced agents to JSON-
+    encode dicts and tripped name validation.
+    """
+
+    async def _setup_orders(self, storage: YAMLStorage) -> None:
+        await storage.save_datasource(DatasourceConfig(
+            name="test", type="sqlite", database=":memory:"
+        ))
+        await storage.save_model(SlayerModel(
+            name="orders", sql_table="orders", data_source="test",
+            columns=[
+                Column(name="amount", sql="amount", type=DataType.DOUBLE),
+                Column(name="status", sql="status", type=DataType.TEXT),
+            ],
+        ))
+
+    async def test_string_source_model_still_works(
+        self, mcp_server, storage: YAMLStorage
+    ) -> None:
+        await self._setup_orders(storage)
+        result = await _call(mcp_server, name="query", arguments={
+            "source_model": "orders",
+            "measures": [{"formula": "*:count"}],
+            "dry_run": True,
+        })
+        assert "Invalid model name" not in result
+        assert "SQL:" in result
+        assert "orders" in result.lower()
+
+    async def test_inline_model_extension_dict(
+        self, mcp_server, storage: YAMLStorage
+    ) -> None:
+        await self._setup_orders(storage)
+        result = await _call(mcp_server, name="query", arguments={
+            "source_model": {
+                "source_name": "orders",
+                "columns": [
+                    {"name": "double_amount", "sql": "amount * 2", "type": "DOUBLE"},
+                ],
+            },
+            "measures": [{"formula": "double_amount:sum"}],
+            "dry_run": True,
+        })
+        assert "Invalid model name" not in result
+        assert "SQL:" in result
+        # The inline column's SQL expression must surface in the generated SQL.
+        assert "amount * 2" in result.lower() or "amount*2" in result.lower()
+
+    async def test_inline_slayer_model_dict(
+        self, mcp_server, storage: YAMLStorage
+    ) -> None:
+        # Datasource must exist for SQL-client routing, but the table need not.
+        await storage.save_datasource(DatasourceConfig(
+            name="test", type="sqlite", database=":memory:"
+        ))
+        result = await _call(mcp_server, name="query", arguments={
+            "source_model": {
+                "name": "ad_hoc",
+                "sql_table": "things",
+                "data_source": "test",
+                "columns": [
+                    {"name": "x", "sql": "x", "type": "DOUBLE"},
+                ],
+            },
+            "measures": [{"formula": "x:sum"}],
+            "dry_run": True,
+        })
+        assert "Invalid model name" not in result
+        assert "SQL:" in result
+        assert "things" in result.lower()
+
+
 class TestDatasources:
     async def test_list_empty(self, mcp_server) -> None:
         result = await _call(mcp_server, name="list_datasources")


### PR DESCRIPTION
## Summary

- MCP `query` tool's `source_model` parameter now typed `str | ModelExtension | SlayerModel`, matching `SlayerQuery.source_model`'s native polymorphism. Previously typed `str`, which forced agents to JSON-encode inline dicts — SLayer then validated the JSON blob as a name and rejected it with `Invalid model name '{...}': must not contain '/'`. Wire-level evidence (Haiku 4.5, households_1): 15 / 88 query-tool calls (17 %) on a single 15-task run failed this way.
- Run-by-name shortcut (`engine.execute(str)`) preserved — it layers `model.query_variables → stage → runtime` precedence that the regular `SlayerQuery` path doesn't reach. Gated on `isinstance(source_model, str)` so inline values fall through to `SlayerQuery.model_validate`. The variable-precedence asymmetry that forces this gate is filed separately as [DEV-1373](https://linear.app/motley-ai/issue/DEV-1373/engine-outer-level-variable-precedence-diverges-between).
- Docs updated in `docs/reference/mcp.md` and `docs/interfaces/mcp.md`.

## Test plan

- [x] `tests/test_mcp_server.py::TestQueryAcceptsInlineSourceModel` — three new tests covering string regression, inline `ModelExtension` dict, inline `SlayerModel` dict
- [x] `poetry run pytest -m "not integration"` — 2173 passed
- [x] `poetry run ruff check slayer/ tests/` — clean

Closes DEV-1372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `query` tool now accepts inline model definitions and extensions for the `source_model` parameter, in addition to saved model names.

* **Documentation**
  * Updated tool docs with type descriptions and examples covering the expanded `source_model` options.

* **Tests**
  * Added tests verifying `query` accepts string, inline extension, and inline model payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->