### PR TITLE
DEV-1376: parse path-qualified LIKE; clearer error for subquery-in-filter

### DIFF
--- a/slayer/core/formula.py
+++ b/slayer/core/formula.py
@@ -818,12 +818,12 @@ class ParsedFilter(BaseModel):
 
 _LIKE_RE = re.compile(
     r"\b((?:\w+\.)*\w+)\s+(not\s+)?like\s+('[^']*')",
-    re.IGNORECASE,
+    flags=re.IGNORECASE,
 )
 
 _SUBQUERY_IN_FILTER_RE = re.compile(
     r"\b(?:not\s+in|in|exists)\s*\(\s*select\b",
-    re.IGNORECASE,
+    flags=re.IGNORECASE,
 )
 
 
@@ -939,8 +939,10 @@ def parse_filter(
     # DEV-1376: detect SQL-style subqueries before ast.parse, so the agent
     # gets a pointer at `source_queries` / `Column.sql` / joins instead of
     # Python's "Perhaps you forgot a comma?" advice (which sends agents
-    # off on a nonsense recovery path).
-    if _SUBQUERY_IN_FILTER_RE.search(formula):
+    # off on a nonsense recovery path). Strip string literals first so the
+    # sniff doesn't false-positive on subquery-shaped text inside a
+    # comparison literal like ``note = 'in (select …)'``.
+    if _SUBQUERY_IN_FILTER_RE.search(_STRING_LITERAL_RE.sub("''", formula)):
         raise ValueError(
             f"Subqueries are not allowed in DSL filters: {formula!r}. "
             "Express the inner relation via `source_queries`, a derived "

--- a/slayer/core/formula.py
+++ b/slayer/core/formula.py
@@ -816,37 +816,39 @@ class ParsedFilter(BaseModel):
     )
 
 
-def _preprocess_like(formula: str) -> str:
-    """Convert `like` and `not like` operators to internal function calls for AST parsing.
+_LIKE_RE = re.compile(
+    r"\b((?:\w+\.)*\w+)\s+(not\s+)?like\s+('[^']*')",
+    re.IGNORECASE,
+)
 
-    "name like '%acme%'"       → "__like__(name, '%acme%')"
-    "name not like '%acme%'"   → "__notlike__(name, '%acme%')"
+_SUBQUERY_IN_FILTER_RE = re.compile(
+    r"\b(?:not\s+in|in|exists)\s*\(\s*select\b",
+    re.IGNORECASE,
+)
+
+
+def _preprocess_like(formula: str) -> str:
+    """Convert SQL ``LIKE`` / ``NOT LIKE`` operators to internal function calls.
+
+    Examples::
+
+        "name like '%acme%'"            → "__like__(name, '%acme%')"
+        "name not like '%acme%'"        → "__notlike__(name, '%acme%')"
+        "customers.email like '%@x.io'" → "__like__(customers.email, '%@x.io')"
+
+    The LHS may be a bare identifier or a dotted path through joined
+    models — the same shape the rest of the DSL accepts in
+    ``dimensions`` / ``measures`` references.
     """
-    # Skip if already preprocessed (contains __like__ or __notlike__)
     if "__like__" in formula or "__notlike__" in formula:
         return formula
-    formula = re.sub(
-        r'\b(\w+)\s+not\s+like\s+',
-        r'__notlike__(\1, ',
-        formula, flags=re.IGNORECASE,
-    )
-    # Close the parenthesis: find the string argument and close after it
-    formula = re.sub(
-        r'(__notlike__\([^,]+,\s*\'[^\']*\')',
-        r'\1)',
-        formula,
-    )
-    formula = re.sub(
-        r'\b(\w+)\s+like\s+',
-        r'__like__(\1, ',
-        formula, flags=re.IGNORECASE,
-    )
-    formula = re.sub(
-        r'(__like__\([^,]+,\s*\'[^\']*\')',
-        r'\1)',
-        formula,
-    )
-    return formula
+
+    def _sub(m: "re.Match[str]") -> str:
+        lhs, neg, pat = m.group(1), m.group(2), m.group(3)
+        fn = "__notlike__" if neg else "__like__"
+        return f"{fn}({lhs}, {pat})"
+
+    return _LIKE_RE.sub(_sub, formula)
 
 
 _STRING_LITERAL_RE = re.compile(r"'(?:[^'\\]|\\.)*'")
@@ -934,6 +936,17 @@ def parse_filter(
     # below points at SLayer's transforms / Column.sql / multi-stage models.
     if has_window_function(formula):
         raise ValueError(f"Filter '{formula}' {WINDOW_IN_FILTER_ERROR}")
+    # DEV-1376: detect SQL-style subqueries before ast.parse, so the agent
+    # gets a pointer at `source_queries` / `Column.sql` / joins instead of
+    # Python's "Perhaps you forgot a comma?" advice (which sends agents
+    # off on a nonsense recovery path).
+    if _SUBQUERY_IN_FILTER_RE.search(formula):
+        raise ValueError(
+            f"Subqueries are not allowed in DSL filters: {formula!r}. "
+            "Express the inner relation via `source_queries`, a derived "
+            "`Column.sql`, or by adding the related table to "
+            "`source_model.joins`."
+        )
 
     if mode == "sql":
         # SQL mode: reject DSL-only constructs early so users get a clear

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -599,6 +599,12 @@ class TestParseFilterInjection:
         with pytest.raises(ValueError, match="Subqueries are not allowed"):
             parse_filter("exists (select 1 from t)")
 
+    def test_filter_subquery_shape_inside_string_literal_does_not_raise(self) -> None:
+        """The subquery sniff must ignore SQL-shaped text that lives inside a
+        string-literal RHS of a comparison — it's data, not syntax."""
+        result = parse_filter("note = 'in (select 1 from t)'")
+        assert "note = 'in (select 1 from t)'" in result.sql
+
 
 # ---------------------------------------------------------------------------
 # Function-style aggregation rewrite

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -556,6 +556,49 @@ class TestParseFilterInjection:
             return
         assert result.sql.count("OR") >= 100
 
+    # --- DEV-1376: path-qualified LIKE / NOT LIKE ---------------------------
+
+    def test_like_path_qualified_simple_literal(self) -> None:
+        """``<joined_model>.<col> like '...'`` must parse — agents reach for
+        this shape because dotted refs work in dimensions/measures."""
+        result = parse_filter("infrastructure.wateraccess like '%yes%'")
+        assert "infrastructure.wateraccess LIKE '%yes%'" in result.sql
+
+    def test_like_path_qualified_messy_literal(self) -> None:
+        """Literal content (commas, spaces, mixed case) must not affect
+        whether path-qualified LIKE parses. Reproduces the original
+        benchmark failure (households_14)."""
+        result = parse_filter(
+            "infrastructure.wateraccess like '%Yes, available at least in one room%'"
+        )
+        assert (
+            "infrastructure.wateraccess LIKE "
+            "'%Yes, available at least in one room%'"
+        ) in result.sql
+
+    def test_not_like_path_qualified(self) -> None:
+        """NOT LIKE on a dotted path mirrors the LIKE fix."""
+        result = parse_filter("customers.email not like '%spam.com'")
+        assert "customers.email NOT LIKE '%spam.com'" in result.sql
+
+    # --- DEV-1376: subquery-in-filter helpful error -------------------------
+
+    def test_filter_subquery_in_clause_raises(self) -> None:
+        """``IN (SELECT ...)`` should surface the targeted error instead of
+        Python's misleading "Perhaps you forgot a comma" advice."""
+        with pytest.raises(ValueError, match="Subqueries are not allowed"):
+            parse_filter("housenum in (select houselink from properties)")
+
+    def test_filter_subquery_not_in_clause_raises(self) -> None:
+        """``NOT IN (SELECT ...)`` is also a subquery shape."""
+        with pytest.raises(ValueError, match="Subqueries are not allowed"):
+            parse_filter("id not in (select id from t)")
+
+    def test_filter_exists_subquery_raises(self) -> None:
+        """``EXISTS (SELECT ...)`` is also a subquery shape."""
+        with pytest.raises(ValueError, match="Subqueries are not allowed"):
+            parse_filter("exists (select 1 from t)")
+
 
 # ---------------------------------------------------------------------------
 # Function-style aggregation rewrite


### PR DESCRIPTION
## Summary

Two DSL filter-parser gaps surfaced by the bird-interact-agents benchmark.

- **Path-qualified `LIKE` / `NOT LIKE`.** `<joined_model>.<col> like '...'` was rejected with `Unsupported filter syntax` because `_preprocess_like`'s LHS regex `\b(\w+)` excluded `.`. Consolidates the 4-step preprocess into a single regex (`_LIKE_RE`) whose LHS accepts dotted paths and whose pattern group captures the closing quote in one shot — the close-paren post-passes are gone.
- **Subquery-in-filter error message.** `housenum in (select …)` surfaced Python's misleading "Perhaps you forgot a comma?" advice, sending agents on a nonsense recovery path. Adds `_SUBQUERY_IN_FILTER_RE` and an early-reject in `parse_filter` next to the existing `has_window_function` check that points at `source_queries` / `Column.sql` / `joins`. Narrowly scoped to `IN (SELECT…)` / `NOT IN (SELECT…)` / `EXISTS (SELECT…)`; existing `UNION SELECT` / `; SELECT 1` tests keep their original path.

The third candidate from `~/.claude/plans/slayer-dsl-issues-verify-and-file.md` (`BETWEEN`) was deliberately dropped — agents can express bounds as `x >= a and x <= b` rather than expanding the DSL with new operator syntax.

Note: probe also revealed that `infrastructure.wateraccess` in the WHERE doesn't auto-add a JOIN. That's DEV-1367 territory and out of scope for this branch.

## Test plan

- [x] `poetry run pytest -m "not integration"` — 2215 passed
- [x] `poetry run ruff check slayer/ tests/` — clean
- [x] Re-ran the verification probe (`/tmp/claude/verify_dsl_gaps.py`) — 1A/1B path-qualified LIKE accepted; 1C/1D regression cases still pass; 2A surfaces the new targeted error; BETWEEN probes still rejected (intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LIKE and NOT LIKE filter operators now support dotted/path-qualified column references and preserve expected SQL output.

* **Bug Fixes**
  * SQL-style subquery-shaped expressions in filter text (IN/NOT IN/EXISTS) are detected early and rejected with a clear error directing to supported alternatives.

* **Tests**
  * Added coverage for LIKE/NOT LIKE behavior and subquery rejection, plus a regression test ensuring literals containing subquery-like text are allowed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/110)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->