### PR TITLE
DEV-1437: SlayerClient accepts engine's full input union

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ poetry run ruff check slayer/ tests/
 - **SQL client**: Uses native async drivers for Postgres (`asyncpg`) and MySQL (`aiomysql`). Falls back to `asyncio.to_thread` for SQLite, DuckDB, ClickHouse. Connection pools are cached per `SlayerSQLClient` instance.
 - **Tests use `pytest-asyncio`** with `asyncio_mode = "auto"` — test functions can be `async def` and `await` directly.
 - **Sync wrappers**: `run_sync()` in `async_utils.py` bridges async→sync for CLI and MCP tools. Handles both "no event loop" and "inside Jupyter" cases.
+- **Client mirrors engine union** (DEV-1437): every `SlayerClient` query entry point — `query`, `query_sync`, `sql`, `sql_sync`, `explain`, `explain_sync`, `query_df` — accepts the same input shapes as `engine.execute`: `SlayerQuery | dict | list[SlayerQuery | dict] | str`. The list form is the multi-stage DAG (`{"queries": [...]}` body in HTTP mode, same shape as MCP `query_nested`); `str` is run-by-name. `SlayerClient._build_query_body` is the single source of truth for the HTTP body shape; the local-engine path defers all validation to `engine.execute_sync` / `engine.execute`. `variables=` and `data_source=` kwarg forwarding is tracked separately as DEV-1438.
 
 ## CLI
 

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -460,7 +460,7 @@ Sibling stages can also reference each other — any non-final stage may use a *
 
 **Surface coverage.** Query lists work via every surface:
 
-- Python SDK: `engine.execute(query=[...])`.
+- Python SDK: `engine.execute(query=[...])` and `SlayerClient.query`/`query_sync`/`sql`/`sql_sync`/`explain`/`explain_sync`/`query_df` all accept `SlayerQuery | dict | list[SlayerQuery | dict] | str` (str = run-by-name).
 - CLI: `slayer query @file.json` — accepts both a single object and a top-level list.
 - MCP: the `query_nested` tool, `queries=[...]` argument.
 - REST: `POST /query` with body `{"queries": [...], "variables": {...}, "dry_run": ..., "explain": ...}` (the single-query body shape is also still accepted).

--- a/docs/interfaces/python-client.md
+++ b/docs/interfaces/python-client.md
@@ -48,6 +48,26 @@ data = client.query(query)
 df = client.query_df(query)
 ```
 
+### Accepted Input Shapes
+
+`client.query` / `query_sync` / `sql` / `sql_sync` / `explain` / `explain_sync` / `query_df` all accept the same input union (mirroring `engine.execute`):
+
+- A **dict** — a single query.
+- A **`SlayerQuery`** instance.
+- A **list of dicts or `SlayerQuery`** — a multi-stage DAG. Earlier stages are named sub-queries; the last entry is the root. Order doesn't matter (the engine auto-sorts). See [Query Lists](../concepts/queries.md#query-lists).
+- A **string** — runs the backing query of a query-backed model by name.
+
+```python
+# Multi-stage DAG
+client.query_sync([
+    {"name": "by_customer", "source_model": "orders", "measures": [{"formula": "amount:sum"}], "dimensions": [{"name": "customer_id"}]},
+    {"source_model": "by_customer", "measures": [{"formula": "amount_sum:avg"}]},
+])
+
+# Run-by-name (query-backed model)
+client.query_sync("rev_by_region")
+```
+
 ### Other Methods
 
 ```python

--- a/docs/reference/python-client.md
+++ b/docs/reference/python-client.md
@@ -48,6 +48,26 @@ data = client.query(query)
 df = client.query_df(query)
 ```
 
+### Accepted Input Shapes
+
+`client.query` / `query_sync` / `sql` / `sql_sync` / `explain` / `explain_sync` / `query_df` all accept the same input union (mirroring `engine.execute`):
+
+- A **dict** — a single query.
+- A **`SlayerQuery`** instance.
+- A **list of dicts or `SlayerQuery`** — a multi-stage DAG. Earlier stages are named sub-queries; the last entry is the root. Order doesn't matter (the engine auto-sorts). See [Query Lists](../concepts/queries.md#query-lists).
+- A **string** — runs the backing query of a query-backed model by name.
+
+```python
+# Multi-stage DAG
+client.query_sync([
+    {"name": "by_customer", "source_model": "orders", "measures": [{"formula": "amount:sum"}], "dimensions": [{"name": "customer_id"}]},
+    {"source_model": "by_customer", "measures": [{"formula": "amount_sum:avg"}]},
+])
+
+# Run-by-name (query-backed model)
+client.query_sync("rev_by_region")
+```
+
 ### Other Methods
 
 ```python

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -109,6 +109,20 @@ class SlayerClient:
             return resp.json()
 
     @staticmethod
+    def _validated_dump(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        """Round-trip a single-query payload through ``SlayerQuery`` so
+        the server sees the normalised JSON-mode shape. Necessary because
+        the server's ``QueryRequest`` declares ``measures`` /
+        ``dimensions`` as ``List[Dict[str, Any]]`` and FastAPI rejects
+        string-shorthand entries with HTTP 422 before the server can
+        re-coerce them — whereas ``SlayerQuery`` itself accepts shorthand
+        and normalises it to dict form.
+        """
+        return SlayerQuery.model_validate(dict(payload)).model_dump(
+            mode="json", exclude_none=True
+        )
+
+    @staticmethod
     def _build_query_body(
         query: QueryInput,
         *,
@@ -122,10 +136,12 @@ class SlayerClient:
         Shapes (mirroring ``engine.execute``):
 
         * ``str`` → ``{"name": <str>}`` (run-by-name)
-        * ``list`` → ``{"queries": [<item-dict>, ...]}`` — each item is
-          either a ``SlayerQuery`` (JSON-dumped) or a dict (shallow-copied)
-        * ``dict`` → shallow copy of the dict (server's ``QueryRequest``
-          has ``extra="allow"`` so passing through is safe)
+        * ``Sequence`` (list/tuple/...) → ``{"queries": [<item-dict>, ...]}``
+          — each item is either a ``SlayerQuery`` or a ``Mapping``; both
+          are normalised through ``SlayerQuery`` so string-shorthand
+          measures / dimensions round-trip cleanly.
+        * ``Mapping`` (dict/MappingProxyType/...) → normalised
+          ``SlayerQuery`` JSON dump (same reason as above).
         * ``SlayerQuery`` → ``model_dump(mode="json", exclude_none=True)``
 
         ``dry_run`` and ``explain`` are appended at the top of the body
@@ -148,7 +164,7 @@ class SlayerClient:
                         item.model_dump(mode="json", exclude_none=True)
                     )
                 elif isinstance(item, ABCMapping):
-                    serialised.append(dict(item))
+                    serialised.append(SlayerClient._validated_dump(item))
                 else:
                     raise TypeError(
                         f"query[{i}] must be SlayerQuery or Mapping; got "
@@ -156,7 +172,7 @@ class SlayerClient:
                     )
             body = {"queries": serialised}
         elif isinstance(query, ABCMapping):
-            body = dict(query)
+            body = SlayerClient._validated_dump(query)
         else:
             raise TypeError(
                 "query must be SlayerQuery, Mapping, Sequence, or str; got "
@@ -167,6 +183,31 @@ class SlayerClient:
         if explain:
             body["explain"] = True
         return body
+
+    @staticmethod
+    def _normalize_for_engine(query: QueryInput) -> Any:
+        """Coerce ``Mapping``/``Sequence`` inputs to concrete ``dict`` /
+        ``list`` before forwarding to ``engine.execute`` / ``execute_sync``.
+        The engine's dispatch uses ``isinstance(query, dict)`` and
+        ``isinstance(query, list)`` directly, so a tuple or
+        ``MappingProxyType`` would fall through to the SlayerQuery branch
+        and crash. Mirrors the runtime contract advertised by
+        ``QueryInput`` on both local and HTTP transports.
+        """
+        if isinstance(query, str) or isinstance(query, SlayerQuery):
+            return query
+        if isinstance(query, ABCSequence) and not isinstance(
+            query, (bytes, bytearray)
+        ):
+            return [
+                item if isinstance(item, SlayerQuery)
+                else dict(item) if isinstance(item, ABCMapping)
+                else item  # engine raises with the per-item context.
+                for item in query
+            ]
+        if isinstance(query, ABCMapping):
+            return dict(query)
+        return query  # engine raises with the per-input context.
 
     @staticmethod
     def _parse_response(result: dict) -> SlayerResponse:
@@ -209,7 +250,9 @@ class SlayerClient:
         """
         if self._engine is not None:
             return await self._engine.execute(
-                query=query, dry_run=dry_run, explain=explain
+                query=self._normalize_for_engine(query),
+                dry_run=dry_run,
+                explain=explain,
             )
         body = self._build_query_body(
             query, dry_run=dry_run, explain=explain
@@ -427,7 +470,9 @@ class SlayerClient:
         """
         if self._engine is not None:
             return self._engine.execute_sync(
-                query=query, dry_run=dry_run, explain=explain
+                query=self._normalize_for_engine(query),
+                dry_run=dry_run,
+                explain=explain,
             )
         body = self._build_query_body(
             query, dry_run=dry_run, explain=explain

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -1,7 +1,16 @@
 """Python client for SLayer API."""
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 from urllib.parse import quote
 
 from slayer.core.query import SlayerQuery
@@ -15,6 +24,20 @@ if TYPE_CHECKING:
     from slayer.search.service import SearchResponse
 
 logger = logging.getLogger(__name__)
+
+
+# DEV-1437: the full input union accepted by every public query entry point,
+# mirroring ``SlayerQueryEngine.execute`` / ``execute_sync``. The list form is
+# the multi-stage DAG that ``query_nested`` (MCP) and ``POST /query`` with
+# ``{"queries": [...]}`` (REST) also accept; ``str`` runs a query-backed model
+# by name. ``Mapping``/``Sequence`` (not ``Dict``/``List``) so callers passing
+# ``list[dict[str, str]]`` aren't rejected by pyright's invariance check.
+QueryInput = Union[
+    SlayerQuery,
+    Mapping[str, Any],
+    Sequence[Union[SlayerQuery, Mapping[str, Any]]],
+    str,
+]
 
 
 class SlayerClient:
@@ -85,6 +108,62 @@ class SlayerClient:
             return resp.json()
 
     @staticmethod
+    def _build_query_body(
+        query: QueryInput,
+        *,
+        dry_run: bool = False,
+        explain: bool = False,
+    ) -> Dict[str, Any]:
+        """Convert any accepted input shape into the JSON body for
+        ``POST /query``. Single source of truth shared by sync + async
+        transports. Never mutates caller-owned dicts or lists.
+
+        Shapes (mirroring ``engine.execute``):
+
+        * ``str`` → ``{"name": <str>}`` (run-by-name)
+        * ``list`` → ``{"queries": [<item-dict>, ...]}`` — each item is
+          either a ``SlayerQuery`` (JSON-dumped) or a dict (shallow-copied)
+        * ``dict`` → shallow copy of the dict (server's ``QueryRequest``
+          has ``extra="allow"`` so passing through is safe)
+        * ``SlayerQuery`` → ``model_dump(mode="json", exclude_none=True)``
+
+        ``dry_run`` and ``explain`` are appended at the top of the body
+        when truthy (the server's ``QueryRequest`` and ``QueryListRequest``
+        both accept them).
+        """
+        if isinstance(query, str):
+            body: Dict[str, Any] = {"name": query}
+        elif isinstance(query, list):
+            serialised: List[Dict[str, Any]] = []
+            for i, item in enumerate(query):
+                if isinstance(item, SlayerQuery):
+                    serialised.append(
+                        item.model_dump(mode="json", exclude_none=True)
+                    )
+                elif isinstance(item, dict):
+                    serialised.append(dict(item))
+                else:
+                    raise TypeError(
+                        f"query[{i}] must be SlayerQuery or dict; got "
+                        f"{type(item).__name__}"
+                    )
+            body = {"queries": serialised}
+        elif isinstance(query, SlayerQuery):
+            body = query.model_dump(mode="json", exclude_none=True)
+        elif isinstance(query, dict):
+            body = dict(query)
+        else:
+            raise TypeError(
+                "query must be SlayerQuery, dict, list, or str; got "
+                f"{type(query).__name__}"
+            )
+        if dry_run:
+            body["dry_run"] = True
+        if explain:
+            body["explain"] = True
+        return body
+
+    @staticmethod
     def _parse_response(result: dict) -> SlayerResponse:
         """Parse an API JSON response into a SlayerResponse."""
         from slayer.core.format import NumberFormat
@@ -114,32 +193,37 @@ class SlayerClient:
 
     async def query(
         self,
-        query,
+        query: QueryInput,
         *,
         dry_run: bool = False,
         explain: bool = False,
     ) -> SlayerResponse:
-        """Execute a query asynchronously. Accepts SlayerQuery or dict."""
-        if isinstance(query, dict):
-            query = SlayerQuery.model_validate(query)
+        """Execute a query asynchronously. Accepts ``SlayerQuery``, ``dict``,
+        ``list[SlayerQuery | dict]`` (multi-stage DAG; last element is the
+        root), or ``str`` (run a query-backed model by name).
+        """
         if self._engine is not None:
             return await self._engine.execute(
                 query=query, dry_run=dry_run, explain=explain
             )
-        body = query.model_dump(exclude_none=True)
-        if dry_run:
-            body["dry_run"] = True
-        if explain:
-            body["explain"] = True
+        body = self._build_query_body(
+            query, dry_run=dry_run, explain=explain
+        )
         result = await self._request(method="POST", path="/query", json=body)
         return self._parse_response(result)
 
-    async def sql(self, query) -> str:
-        """Generate SQL for a query without executing it."""
+    async def sql(self, query: QueryInput) -> str:
+        """Generate SQL for a query without executing it.
+
+        Accepts the same input union as ``query``.
+        """
         return (await self.query(query=query, dry_run=True)).sql
 
-    async def explain(self, query) -> SlayerResponse:
-        """Run EXPLAIN ANALYZE on a query."""
+    async def explain(self, query: QueryInput) -> SlayerResponse:
+        """Run EXPLAIN ANALYZE on a query.
+
+        Accepts the same input union as ``query``.
+        """
         return await self.query(query=query, explain=True)
 
     async def list_models(self, data_source: Optional[str] = None) -> List[str]:
@@ -327,36 +411,44 @@ class SlayerClient:
 
     def query_sync(
         self,
-        query,
+        query: QueryInput,
         *,
         dry_run: bool = False,
         explain: bool = False,
     ) -> SlayerResponse:
-        """Execute a query synchronously. Accepts SlayerQuery or dict."""
-        if isinstance(query, dict):
-            query = SlayerQuery.model_validate(query)
+        """Execute a query synchronously. Accepts ``SlayerQuery``, ``dict``,
+        ``list[SlayerQuery | dict]`` (multi-stage DAG; last element is the
+        root), or ``str`` (run a query-backed model by name).
+        """
         if self._engine is not None:
             return self._engine.execute_sync(
                 query=query, dry_run=dry_run, explain=explain
             )
-        body = query.model_dump(exclude_none=True)
-        if dry_run:
-            body["dry_run"] = True
-        if explain:
-            body["explain"] = True
+        body = self._build_query_body(
+            query, dry_run=dry_run, explain=explain
+        )
         result = self._request_sync(method="POST", path="/query", json=body)
         return self._parse_response(result)
 
-    def sql_sync(self, query) -> str:
-        """Generate SQL synchronously."""
+    def sql_sync(self, query: QueryInput) -> str:
+        """Generate SQL synchronously.
+
+        Accepts the same input union as ``query_sync``.
+        """
         return self.query_sync(query=query, dry_run=True).sql
 
-    def explain_sync(self, query) -> SlayerResponse:
-        """Run EXPLAIN ANALYZE synchronously."""
+    def explain_sync(self, query: QueryInput) -> SlayerResponse:
+        """Run EXPLAIN ANALYZE synchronously.
+
+        Accepts the same input union as ``query_sync``.
+        """
         return self.query_sync(query=query, explain=True)
 
-    def query_df(self, query: SlayerQuery):
-        """Execute a query and return a pandas DataFrame (sync)."""
+    def query_df(self, query: QueryInput):
+        """Execute a query and return a pandas DataFrame (sync).
+
+        Accepts the same input union as ``query_sync``.
+        """
         try:
             import pandas as pd
         except ImportError:

--- a/slayer/client/slayer_client.py
+++ b/slayer/client/slayer_client.py
@@ -1,6 +1,7 @@
 """Python client for SLayer API."""
 
 import logging
+from collections.abc import Mapping as ABCMapping, Sequence as ABCSequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -133,28 +134,32 @@ class SlayerClient:
         """
         if isinstance(query, str):
             body: Dict[str, Any] = {"name": query}
-        elif isinstance(query, list):
+        elif isinstance(query, SlayerQuery):
+            body = query.model_dump(mode="json", exclude_none=True)
+        elif isinstance(query, ABCSequence) and not isinstance(
+            query, (bytes, bytearray)
+        ):
+            # ``str`` is also a Sequence but already handled above; guard the
+            # binary string types here too so they raise via the else-branch.
             serialised: List[Dict[str, Any]] = []
             for i, item in enumerate(query):
                 if isinstance(item, SlayerQuery):
                     serialised.append(
                         item.model_dump(mode="json", exclude_none=True)
                     )
-                elif isinstance(item, dict):
+                elif isinstance(item, ABCMapping):
                     serialised.append(dict(item))
                 else:
                     raise TypeError(
-                        f"query[{i}] must be SlayerQuery or dict; got "
+                        f"query[{i}] must be SlayerQuery or Mapping; got "
                         f"{type(item).__name__}"
                     )
             body = {"queries": serialised}
-        elif isinstance(query, SlayerQuery):
-            body = query.model_dump(mode="json", exclude_none=True)
-        elif isinstance(query, dict):
+        elif isinstance(query, ABCMapping):
             body = dict(query)
         else:
             raise TypeError(
-                "query must be SlayerQuery, dict, list, or str; got "
+                "query must be SlayerQuery, Mapping, Sequence, or str; got "
                 f"{type(query).__name__}"
             )
         if dry_run:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,8 @@ on list/str inputs is what the original report describes.
 """
 
 import tempfile
-from typing import Any, Dict, List, Optional, Tuple
+from types import MappingProxyType
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import pytest
 
@@ -443,6 +444,36 @@ class TestHttpBodyShape:
                 [{"source_model": "orders"}, 42]  # type: ignore[list-item]
             )
         assert cap.last_body is None
+
+    # --- non-dict/list runtime shapes (Mapping / Sequence) ------------- #
+
+    def test_mappingproxy_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """``MappingProxyType`` is a ``Mapping`` but not a ``dict`` — the
+        helper must honour the declared ``Mapping[str, Any]`` contract."""
+        client, cap = http_client_with_capture
+        payload: Mapping[str, Any] = MappingProxyType(
+            {"source_model": "orders", "measures": [{"formula": "amount:sum"}]}
+        )
+        client.query_sync(payload)
+        assert cap.last_body == dict(payload)
+
+    def test_tuple_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """``tuple`` is a ``Sequence`` but not a ``list`` — honoured."""
+        client, cap = http_client_with_capture
+        items = (
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        )
+        client.query_sync(items)
+        body = cap.last_body
+        assert body is not None
+        assert body["queries"] == list(items)
 
     # --- pass-through of variables (DEV-1438 ergonomics live in body) -- #
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,13 +1,28 @@
-"""Tests for SlayerClient in local mode."""
+"""Tests for SlayerClient — local-mode dispatch + HTTP-mode body shapes.
+
+Covers DEV-1437: the client mirrors the engine's full input union
+``SlayerQuery | dict | list[SlayerQuery | dict] | str`` on every public
+query entry point. Local-mode tests are contract smokes (engine already
+accepts every shape, so local-mode dispatch was already working by
+accident); HTTP-mode tests pin the bug — ``query.model_dump`` blowing up
+on list/str inputs is what the original report describes.
+"""
 
 import tempfile
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
 from slayer.client.slayer_client import SlayerClient
 from slayer.core.enums import DataType
 from slayer.core.models import Column, DatasourceConfig, SlayerModel
+from slayer.core.query import SlayerQuery
 from slayer.storage.yaml_storage import YAMLStorage
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
 
 
 @pytest.fixture
@@ -21,6 +36,108 @@ def client(storage: YAMLStorage) -> SlayerClient:
     return SlayerClient(storage=storage)
 
 
+def _orders_model() -> SlayerModel:
+    return SlayerModel(
+        name="orders",
+        sql_table="orders_t",
+        data_source="ds",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="status", sql="status", type=DataType.TEXT),
+            Column(name="region", sql="region", type=DataType.TEXT),
+            Column(name="amount", sql="amount", type=DataType.DOUBLE),
+            Column(name="customer_id", sql="customer_id", type=DataType.DOUBLE),
+        ],
+    )
+
+
+def _ds() -> DatasourceConfig:
+    return DatasourceConfig(name="ds", type="sqlite", database=":memory:")
+
+
+async def _save_orders(storage: YAMLStorage) -> None:
+    await storage.save_datasource(_ds())
+    await storage.save_model(_orders_model())
+
+
+# Minimal response payload that ``SlayerClient._parse_response`` consumes
+# without complaining. Used by the HTTP-mode mocks.
+_CANNED_RESP: Dict[str, Any] = {
+    "data": [],
+    "columns": [],
+    "sql": "SELECT 1",
+    "attributes": {"dimensions": {}, "measures": {}},
+}
+
+
+class _CapturedRequests:
+    """Captures the JSON body of each ``_request_sync`` / ``_request`` call.
+
+    Two stubs (sync + async) replace the underlying httpx-wrapping methods,
+    so the HTTP-mode body-shape tests can introspect what would have been
+    posted without spinning up an HTTP server.
+    """
+
+    def __init__(self) -> None:
+        self.calls: List[Dict[str, Any]] = []
+
+    def _replace_sync(
+        self,
+        *,
+        method: str,
+        path: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append(
+            {"method": method, "path": path, "json": json, "params": params}
+        )
+        # ``_parse_response`` reads keys; return a fresh dict so callers
+        # cannot mutate the canned response across tests.
+        return dict(_CANNED_RESP)
+
+    async def _replace_async(
+        self,
+        *,
+        method: str,
+        path: str,
+        json: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        self.calls.append(
+            {"method": method, "path": path, "json": json, "params": params}
+        )
+        return dict(_CANNED_RESP)
+
+    @property
+    def last_body(self) -> Optional[Dict[str, Any]]:
+        if not self.calls:
+            return None
+        return self.calls[-1]["json"]
+
+
+@pytest.fixture
+def http_client_with_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Tuple[SlayerClient, _CapturedRequests]:
+    """A remote-mode ``SlayerClient`` whose request-wrappers are stubbed.
+
+    Returns ``(client, capture)`` where ``capture.last_body`` exposes the
+    JSON body of the most recent client→transport call.
+    """
+    client = SlayerClient(url="http://localhost:5143")
+    assert client._engine is None  # remote mode — no storage attached
+    capture = _CapturedRequests()
+    monkeypatch.setattr(client, "_request_sync", capture._replace_sync)
+    monkeypatch.setattr(client, "_request", capture._replace_async)
+    return client, capture
+
+
+# --------------------------------------------------------------------------- #
+# Local-mode tests
+# --------------------------------------------------------------------------- #
+
+
 class TestLocalMode:
     def test_init_local(self, storage: YAMLStorage) -> None:
         client = SlayerClient(storage=storage)
@@ -30,65 +147,439 @@ class TestLocalMode:
         client = SlayerClient(url="http://localhost:5143")
         assert client._engine is None
 
-    async def test_query_dispatches_locally(self, client: SlayerClient, storage: YAMLStorage) -> None:
-        """Local mode query should go through engine, not HTTP."""
-        await storage.save_model(SlayerModel(
-            name="orders",
-            sql_table="public.orders",
-            data_source="test_ds",
-            columns=[
-                Column(name="id", sql="id", type=DataType.DOUBLE),
-                Column(name="revenue", sql="amount", type=DataType.DOUBLE),
-            ],
-        ))
-        await storage.save_datasource(DatasourceConfig(
-            name="test_ds",
-            type="sqlite",
-            database=":memory:",
-        ))
-        # This will fail at SQL execution (no actual table), but proves local dispatch works
-        from slayer.core.query import SlayerQuery
-        query = SlayerQuery(source_model="orders", measures=[{"formula": "revenue:sum"}])
-        with pytest.raises(Exception):
-            client.query_sync(query)
+    async def test_query_dispatches_locally(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """Local-mode ``query_sync`` reaches the engine (not HTTP)."""
+        await _save_orders(storage)
+        query = SlayerQuery(
+            source_model="orders", measures=[{"formula": "amount:sum"}]
+        )
+        resp = client.query_sync(query, dry_run=True)
+        assert resp.sql is not None
+        assert "amount" in resp.sql.lower()
 
-    async def test_query_accepts_dict(self, client: SlayerClient, storage: YAMLStorage) -> None:
-        """client.query_sync() should accept a plain dict and coerce it to SlayerQuery."""
-        await storage.save_model(SlayerModel(
-            name="orders",
-            sql_table="public.orders",
-            data_source="test_ds",
-            columns=[
-                Column(name="id", sql="id", type=DataType.DOUBLE),
-                Column(name="revenue", sql="amount", type=DataType.DOUBLE),
-            ],
-        ))
-        await storage.save_datasource(DatasourceConfig(
-            name="test_ds",
-            type="sqlite",
-            database=":memory:",
-        ))
-        query_dict = {"source_model": "orders", "measures": ["revenue:sum"]}
-        with pytest.raises(Exception):
-            client.query_sync(query_dict)
+    async def test_query_accepts_dict(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """``query_sync`` accepts a plain dict (regression)."""
+        await _save_orders(storage)
+        query_dict = {
+            "source_model": "orders",
+            "measures": [{"formula": "amount:sum"}],
+        }
+        resp = client.query_sync(query_dict, dry_run=True)
+        assert resp.sql is not None
+        assert "amount" in resp.sql.lower()
 
-    async def test_sql_accepts_dict(self, client: SlayerClient, storage: YAMLStorage) -> None:
-        """client.sql_sync() should accept a plain dict."""
-        await storage.save_model(SlayerModel(
-            name="orders",
-            sql_table="public.orders",
-            data_source="test_ds",
-            columns=[
-                Column(name="id", sql="id", type=DataType.DOUBLE),
-                Column(name="revenue", sql="amount", type=DataType.DOUBLE),
-            ],
-        ))
-        await storage.save_datasource(DatasourceConfig(
-            name="test_ds",
-            type="sqlite",
-            database=":memory:",
-        ))
-        query_dict = {"source_model": "orders", "measures": ["revenue:sum"]}
+    async def test_sql_accepts_dict(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """``sql_sync`` accepts a plain dict (regression)."""
+        await _save_orders(storage)
+        query_dict = {
+            "source_model": "orders",
+            "measures": [{"formula": "amount:sum"}],
+        }
         sql = client.sql_sync(query_dict)
         assert isinstance(sql, str)
-        assert "SELECT" in sql
+        assert "SELECT" in sql.upper()
+
+    async def test_query_sync_accepts_list_local_smoke(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """List-of-dicts (multi-stage DAG) reaches the engine in local mode."""
+        await _save_orders(storage)
+        queries = [
+            {
+                "name": "by_customer",
+                "source_model": "orders",
+                "measures": [{"formula": "amount:sum"}],
+                "dimensions": [{"name": "customer_id"}],
+            },
+            {
+                "source_model": "by_customer",
+                "measures": [{"formula": "amount_sum:avg"}],
+            },
+        ]
+        resp = client.query_sync(queries, dry_run=True)
+        assert resp.sql is not None
+        assert "avg(" in resp.sql.lower()
+
+    async def test_query_sync_accepts_str_local_smoke(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """``str`` input runs the backing query of a query-backed model."""
+        await _save_orders(storage)
+        saved = SlayerModel(
+            name="rev_by_region",
+            data_source="ds",
+            source_queries=[
+                SlayerQuery(
+                    source_model="orders",
+                    measures=[{"formula": "amount:sum"}],
+                    dimensions=["region"],
+                )
+            ],
+        )
+        await storage.save_model(saved)
+        resp = client.query_sync("rev_by_region", dry_run=True)
+        assert resp.sql is not None
+        assert "amount" in resp.sql.lower()
+        assert "region" in resp.sql.lower()
+
+
+# --------------------------------------------------------------------------- #
+# HTTP-mode body-shape tests (pins the DEV-1437 bug)
+# --------------------------------------------------------------------------- #
+
+
+class TestHttpBodyShape:
+    """Verify ``query_sync`` / ``query`` post the right JSON body shape for
+    each accepted input form. Uses monkeypatched ``_request_sync`` /
+    ``_request`` (no live HTTP server)."""
+
+    # --- list ---------------------------------------------------------- #
+
+    def test_list_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        queries = [
+            {
+                "name": "a",
+                "source_model": "orders",
+                "measures": [{"formula": "amount:sum"}],
+            },
+            {"source_model": "a"},
+        ]
+        resp = client.query_sync(queries)
+        # Canned response wires through to a SlayerResponse.
+        assert resp.sql == "SELECT 1"
+        body = cap.last_body
+        assert body is not None
+        assert body == {"queries": queries}
+
+    def test_list_with_slayerquery_items(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """Mixed list items (``SlayerQuery`` + dict) each serialise to dict."""
+        client, cap = http_client_with_capture
+        q = SlayerQuery(
+            name="a",
+            source_model="orders",
+            measures=[{"formula": "amount:sum"}],
+        )
+        items: List[Any] = [q, {"source_model": "a"}]
+        client.query_sync(items)
+        body = cap.last_body
+        assert body is not None
+        assert "queries" in body
+        # SlayerQuery is serialised in JSON mode.
+        assert body["queries"][0] == q.model_dump(
+            mode="json", exclude_none=True
+        )
+        assert body["queries"][1] == {"source_model": "a"}
+
+    # --- str ----------------------------------------------------------- #
+
+    def test_str_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        client.query_sync("rev_by_region")
+        assert cap.last_body == {"name": "rev_by_region"}
+
+    # --- dict ---------------------------------------------------------- #
+
+    def test_dict_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        payload = {
+            "source_model": "orders",
+            "measures": [{"formula": "amount:sum"}],
+        }
+        client.query_sync(payload)
+        body = cap.last_body
+        assert body == payload
+        # Helper shallow-copies the dict so dry_run/explain appends don't
+        # mutate the caller. See ``test_does_not_mutate_caller_dict``.
+        assert body is not payload
+
+    # --- SlayerQuery --------------------------------------------------- #
+
+    def test_slayerquery_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        q = SlayerQuery(
+            source_model="orders", measures=[{"formula": "amount:sum"}]
+        )
+        client.query_sync(q)
+        # JSON mode — see codex note (4); matches _coerce_linked_entities.
+        assert cap.last_body == q.model_dump(mode="json", exclude_none=True)
+
+    # --- dry_run / explain --------------------------------------------- #
+
+    def test_dry_run_explain_appended_list(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        items = [
+            {
+                "name": "a",
+                "source_model": "orders",
+                "measures": [{"formula": "amount:sum"}],
+            },
+            {"source_model": "a"},
+        ]
+        client.query_sync(items, dry_run=True, explain=True)
+        body = cap.last_body
+        assert body is not None
+        assert body["dry_run"] is True
+        assert body["explain"] is True
+        assert "queries" in body
+
+    def test_dry_run_explain_appended_str(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        client.query_sync("m", dry_run=True, explain=True)
+        assert cap.last_body == {
+            "name": "m",
+            "dry_run": True,
+            "explain": True,
+        }
+
+    def test_dry_run_explain_appended_dict(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        client.query_sync(
+            {"source_model": "orders"}, dry_run=True, explain=True
+        )
+        body = cap.last_body
+        assert body is not None
+        assert body["source_model"] == "orders"
+        assert body["dry_run"] is True
+        assert body["explain"] is True
+
+    def test_flags_omitted_when_false(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """``dry_run=False`` / ``explain=False`` (defaults) → keys not present."""
+        client, cap = http_client_with_capture
+        client.query_sync({"source_model": "orders"})
+        body = cap.last_body
+        assert body is not None
+        assert "dry_run" not in body
+        assert "explain" not in body
+
+    # --- mutation safety ----------------------------------------------- #
+
+    def test_does_not_mutate_caller_dict(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, _cap = http_client_with_capture
+        payload = {
+            "source_model": "orders",
+            "measures": [{"formula": "amount:sum"}],
+        }
+        snapshot = dict(payload)
+        client.query_sync(payload, dry_run=True, explain=True)
+        assert payload == snapshot
+        assert "dry_run" not in payload
+        assert "explain" not in payload
+
+    def test_does_not_mutate_caller_list(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        items: List[Dict[str, Any]] = [
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        ]
+        snapshot = [dict(item) for item in items]
+        client.query_sync(items, dry_run=True)
+        # Caller's list and items are unchanged.
+        assert items == snapshot
+        # And body items are independent dicts (helper shallow-copies),
+        # so future mutations of caller items don't leak into the body.
+        body = cap.last_body
+        assert body is not None
+        assert body["queries"] is not items
+        assert body["queries"][0] is not items[0]
+        assert body["queries"][1] is not items[1]
+
+    # --- invalid input ------------------------------------------------- #
+
+    def test_rejects_invalid_input_top_level(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        with pytest.raises(TypeError, match="SlayerQuery"):
+            client.query_sync(42)  # type: ignore[arg-type]
+        assert cap.last_body is None
+
+    def test_rejects_invalid_list_item(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        with pytest.raises(TypeError, match=r"query\[1\]"):
+            client.query_sync(
+                [{"source_model": "orders"}, 42]  # type: ignore[list-item]
+            )
+        assert cap.last_body is None
+
+    # --- pass-through of variables (DEV-1438 ergonomics live in body) -- #
+
+    def test_dict_with_variables_preserved(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """A dict input carrying top-level ``variables`` reaches the server
+        verbatim. DEV-1437 doesn't add a ``variables=`` kwarg (see DEV-1438)
+        but the dict-passthrough must not drop or mutate the key.
+        """
+        client, cap = http_client_with_capture
+        payload = {
+            "source_model": "orders",
+            "measures": [{"formula": "amount:sum"}],
+            "variables": {"region": "US"},
+        }
+        client.query_sync(payload)
+        body = cap.last_body
+        assert body is not None
+        assert body.get("variables") == {"region": "US"}
+
+    # --- delegating helpers inherit list / str support ----------------- #
+
+    def test_sql_sync_list_input(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """``sql_sync`` delegates to ``query_sync(dry_run=True)`` — list
+        input must reach the transport with ``dry_run`` set."""
+        client, cap = http_client_with_capture
+        queries = [
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        ]
+        sql = client.sql_sync(queries)
+        assert sql == "SELECT 1"
+        body = cap.last_body
+        assert body is not None
+        assert body.get("queries") == queries
+        assert body.get("dry_run") is True
+
+    def test_sql_sync_str_input(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        sql = client.sql_sync("rev_by_region")
+        assert sql == "SELECT 1"
+        assert cap.last_body == {"name": "rev_by_region", "dry_run": True}
+
+    def test_explain_sync_list_input(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """``explain_sync`` delegates to ``query_sync(explain=True)`` — list
+        input must reach the transport with ``explain`` set."""
+        client, cap = http_client_with_capture
+        queries = [
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        ]
+        resp = client.explain_sync(queries)
+        assert resp.sql == "SELECT 1"
+        body = cap.last_body
+        assert body is not None
+        assert body.get("queries") == queries
+        assert body.get("explain") is True
+
+    def test_explain_sync_str_input(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        client.explain_sync("rev_by_region")
+        assert cap.last_body == {"name": "rev_by_region", "explain": True}
+
+    def test_query_df_accepts_list(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``query_df`` delegates to ``query_sync`` — list input must work,
+        not be re-tightened by a narrower type hint. Issue notes: 'worth a
+        one-line test so nobody re-tightens this later.'"""
+        pd = pytest.importorskip("pandas")
+        client = SlayerClient(url="http://localhost:5143")
+        capture = _CapturedRequests()
+        # Wire a richer canned response so DataFrame has at least one row.
+        def _replace_sync_with_rows(
+            *,
+            method: str,
+            path: str,
+            json: Optional[Dict[str, Any]] = None,
+            params: Optional[Dict[str, Any]] = None,
+        ) -> Dict[str, Any]:
+            capture.calls.append(
+                {"method": method, "path": path, "json": json, "params": params}
+            )
+            return {
+                "data": [{"x": 1}, {"x": 2}],
+                "columns": ["x"],
+                "sql": "SELECT 1",
+                "attributes": {"dimensions": {}, "measures": {}},
+            }
+        monkeypatch.setattr(client, "_request_sync", _replace_sync_with_rows)
+        queries = [
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        ]
+        df = client.query_df(queries)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        # And the list shape did reach the transport.
+        body = capture.last_body
+        assert body is not None
+        assert body.get("queries") == queries
+
+    # --- async mirror -------------------------------------------------- #
+
+    async def test_async_query_list_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """Async ``query`` mirrors sync ``query_sync`` body shape."""
+        client, cap = http_client_with_capture
+        queries = [
+            {"name": "a", "source_model": "orders"},
+            {"source_model": "a"},
+        ]
+        await client.query(queries)
+        assert cap.last_body == {"queries": queries}
+
+    async def test_async_query_str_body_shape(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        client, cap = http_client_with_capture
+        await client.query("rev_by_region")
+        assert cap.last_body == {"name": "rev_by_region"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -96,7 +96,7 @@ class _CapturedRequests:
         # cannot mutate the canned response across tests.
         return dict(_CANNED_RESP)
 
-    async def _replace_async(
+    async def _replace_async(  # NOSONAR(S7503) — must be async def to match the awaited contract of self._request; body has no IO to await
         self,
         *,
         method: str,
@@ -104,10 +104,9 @@ class _CapturedRequests:
         json: Optional[Dict[str, Any]] = None,
         params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        self.calls.append(
-            {"method": method, "path": path, "json": json, "params": params}
+        return self._replace_sync(
+            method=method, path=path, json=json, params=params
         )
-        return dict(_CANNED_RESP)
 
     @property
     def last_body(self) -> Optional[Dict[str, Any]]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -228,6 +228,45 @@ class TestLocalMode:
         assert "amount" in resp.sql.lower()
         assert "region" in resp.sql.lower()
 
+    async def test_query_sync_accepts_tuple_local_mode(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """``tuple`` input reaches the engine in local mode — the client
+        normalises Sequence → list before forwarding so the engine's
+        ``isinstance(query, list)`` dispatch matches."""
+        await _save_orders(storage)
+        queries = (
+            {
+                "name": "by_customer",
+                "source_model": "orders",
+                "measures": [{"formula": "amount:sum"}],
+                "dimensions": [{"name": "customer_id"}],
+            },
+            {
+                "source_model": "by_customer",
+                "measures": [{"formula": "amount_sum:avg"}],
+            },
+        )
+        resp = client.query_sync(queries, dry_run=True)
+        assert resp.sql is not None
+        assert "avg(" in resp.sql.lower()
+
+    async def test_query_sync_accepts_mappingproxy_local_mode(
+        self, client: SlayerClient, storage: YAMLStorage
+    ) -> None:
+        """``MappingProxyType`` input reaches the engine in local mode
+        — the client normalises Mapping → dict before forwarding."""
+        await _save_orders(storage)
+        payload: Mapping[str, Any] = MappingProxyType(
+            {
+                "source_model": "orders",
+                "measures": [{"formula": "amount:sum"}],
+            }
+        )
+        resp = client.query_sync(payload, dry_run=True)
+        assert resp.sql is not None
+        assert "amount" in resp.sql.lower()
+
 
 # --------------------------------------------------------------------------- #
 # HTTP-mode body-shape tests (pins the DEV-1437 bug)
@@ -259,7 +298,15 @@ class TestHttpBodyShape:
         assert resp.sql == "SELECT 1"
         body = cap.last_body
         assert body is not None
-        assert body == {"queries": queries}
+        expected = {
+            "queries": [
+                SlayerQuery.model_validate(q).model_dump(
+                    mode="json", exclude_none=True
+                )
+                for q in queries
+            ]
+        }
+        assert body == expected
 
     def test_list_with_slayerquery_items(
         self,
@@ -281,7 +328,12 @@ class TestHttpBodyShape:
         assert body["queries"][0] == q.model_dump(
             mode="json", exclude_none=True
         )
-        assert body["queries"][1] == {"source_model": "a"}
+        # Dict items are normalised through SlayerQuery (string-shorthand
+        # measures / dimensions become dict-form; defaults like ``version``
+        # surface).
+        assert body["queries"][1] == SlayerQuery.model_validate(
+            {"source_model": "a"}
+        ).model_dump(mode="json", exclude_none=True)
 
     # --- str ----------------------------------------------------------- #
 
@@ -299,6 +351,12 @@ class TestHttpBodyShape:
         self,
         http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
     ) -> None:
+        """Dict input is round-tripped through ``SlayerQuery`` so the
+        server sees the JSON-mode dump (string-shorthand normalised,
+        defaults included). FastAPI's ``QueryRequest`` declares strict
+        list-of-dict types for measures/dimensions; the round-trip is
+        the only way string-shorthand input doesn't 422 server-side.
+        """
         client, cap = http_client_with_capture
         payload = {
             "source_model": "orders",
@@ -306,10 +364,31 @@ class TestHttpBodyShape:
         }
         client.query_sync(payload)
         body = cap.last_body
-        assert body == payload
-        # Helper shallow-copies the dict so dry_run/explain appends don't
-        # mutate the caller. See ``test_does_not_mutate_caller_dict``.
+        assert body == SlayerQuery.model_validate(payload).model_dump(
+            mode="json", exclude_none=True
+        )
+        # Helper doesn't mutate the caller. See
+        # ``test_does_not_mutate_caller_dict``.
         assert body is not payload
+
+    def test_dict_normalizes_string_shorthand(
+        self,
+        http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
+    ) -> None:
+        """String-shorthand measures (e.g. ``"amount:sum"``) become
+        dict-form (``{"formula": "amount:sum"}``) before reaching the
+        server — otherwise FastAPI's ``QueryRequest`` rejects the body
+        with HTTP 422.
+        """
+        client, cap = http_client_with_capture
+        payload = {"source_model": "orders", "measures": ["amount:sum"]}
+        client.query_sync(payload)
+        body = cap.last_body
+        assert body is not None
+        # Each measure landed as a dict, not a bare string.
+        for m in body["measures"]:
+            assert isinstance(m, dict)
+            assert m.get("formula") == "amount:sum"
 
     # --- SlayerQuery --------------------------------------------------- #
 
@@ -452,13 +531,16 @@ class TestHttpBodyShape:
         http_client_with_capture: Tuple[SlayerClient, _CapturedRequests],
     ) -> None:
         """``MappingProxyType`` is a ``Mapping`` but not a ``dict`` — the
-        helper must honour the declared ``Mapping[str, Any]`` contract."""
+        helper must honour the declared ``Mapping[str, Any]`` contract
+        AND route through the SlayerQuery normalisation pipeline."""
         client, cap = http_client_with_capture
         payload: Mapping[str, Any] = MappingProxyType(
             {"source_model": "orders", "measures": [{"formula": "amount:sum"}]}
         )
         client.query_sync(payload)
-        assert cap.last_body == dict(payload)
+        assert cap.last_body == SlayerQuery.model_validate(
+            dict(payload)
+        ).model_dump(mode="json", exclude_none=True)
 
     def test_tuple_body_shape(
         self,
@@ -473,7 +555,13 @@ class TestHttpBodyShape:
         client.query_sync(items)
         body = cap.last_body
         assert body is not None
-        assert body["queries"] == list(items)
+        expected = [
+            SlayerQuery.model_validate(it).model_dump(
+                mode="json", exclude_none=True
+            )
+            for it in items
+        ]
+        assert body["queries"] == expected
 
     # --- pass-through of variables (DEV-1438 ergonomics live in body) -- #
 
@@ -513,7 +601,13 @@ class TestHttpBodyShape:
         assert sql == "SELECT 1"
         body = cap.last_body
         assert body is not None
-        assert body.get("queries") == queries
+        expected = [
+            SlayerQuery.model_validate(q).model_dump(
+                mode="json", exclude_none=True
+            )
+            for q in queries
+        ]
+        assert body.get("queries") == expected
         assert body.get("dry_run") is True
 
     def test_sql_sync_str_input(
@@ -540,7 +634,13 @@ class TestHttpBodyShape:
         assert resp.sql == "SELECT 1"
         body = cap.last_body
         assert body is not None
-        assert body.get("queries") == queries
+        expected = [
+            SlayerQuery.model_validate(q).model_dump(
+                mode="json", exclude_none=True
+            )
+            for q in queries
+        ]
+        assert body.get("queries") == expected
         assert body.get("explain") is True
 
     def test_explain_sync_str_input(
@@ -586,10 +686,17 @@ class TestHttpBodyShape:
         df = client.query_df(queries)
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 2
-        # And the list shape did reach the transport.
+        # And the list shape did reach the transport (normalised through
+        # SlayerQuery — see ``test_dict_normalizes_string_shorthand``).
         body = capture.last_body
         assert body is not None
-        assert body.get("queries") == queries
+        expected = [
+            SlayerQuery.model_validate(q).model_dump(
+                mode="json", exclude_none=True
+            )
+            for q in queries
+        ]
+        assert body.get("queries") == expected
 
     # --- async mirror -------------------------------------------------- #
 
@@ -604,7 +711,15 @@ class TestHttpBodyShape:
             {"source_model": "a"},
         ]
         await client.query(queries)
-        assert cap.last_body == {"queries": queries}
+        expected = {
+            "queries": [
+                SlayerQuery.model_validate(q).model_dump(
+                    mode="json", exclude_none=True
+                )
+                for q in queries
+            ]
+        }
+        assert cap.last_body == expected
 
     async def test_async_query_str_body_shape(
         self,


### PR DESCRIPTION
## Summary

* `SlayerClient.query` / `query_sync` / `sql` / `sql_sync` / `explain` / `explain_sync` / `query_df` now accept the same input union as `engine.execute`: `SlayerQuery | dict | list[SlayerQuery | dict] | str`. Previously HTTP-mode crashed on list/str input (`'list' object has no attribute 'model_dump'`); local-mode silently passed list through while the type hint claimed only `SlayerQuery | dict`.
* New static helper `_build_query_body` is the single source of truth for the input-shape → JSON body mapping. Handles all four shapes (`str` → `{"name": ...}`, `list` → `{"queries": [...]}` with per-item `TypeError` naming the bad index, `dict` → shallow copy, `SlayerQuery` → `model_dump(mode="json", exclude_none=True)`), never mutates caller-owned containers, and appends `dry_run`/`explain` at the top of body when truthy.
* `QueryInput` type alias on the client module uses `Mapping`/`Sequence` (not `Dict`/`List`) so callers passing `list[dict[str, str]]` aren't rejected by pyright's invariance check.
* Sibling [DEV-1438](https://linear.app/motley-ai/issue/DEV-1438) filed for `variables=` / `data_source=` kwarg forwarding (intentionally out of scope here).

Closes [DEV-1437](https://linear.app/motley-ai/issue/DEV-1437).

## Test plan

- [x] `poetry run pytest tests/test_client.py` — 28 pass (was 5; +23 new). Coverage:
  - HTTP body shape for list / str / dict / SlayerQuery and mixed list items
  - `dry_run` / `explain` placement (incl. omission when False)
  - Mutation safety: caller dict and list are immutable, body items shallow-copied
  - Invalid input: top-level `TypeError`, per-list-item `TypeError` with index
  - `variables` key passthrough in dict input
  - `sql_sync` / `explain_sync` / `query_df` inherit list+str support
  - Async (`query`) list+str body shape mirrors sync
  - Local-mode smokes for list / str / dict / SlayerQuery
- [x] `poetry run ruff check slayer/ tests/` — clean
- [x] `poetry run pytest -m "not integration"` — 2788 pass, 250 deselected (integration)
- [x] Reviewed plan + tests with codex MCP before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query entry points now accept single queries, plain dicts, multi-stage DAG lists, and string run-by-name references.

* **Documentation**
  * Added "Accepted Input Shapes" to Python client docs and updated high-level docs; examples for multi-stage DAGs and run-by-name added.
  * Updated CLI/README summary to reflect the expanded input contract.

* **Tests**
  * Expanded contract-focused tests validating body shapes, dry_run/explain flags, mutation-safety, validation, and sync/async behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->