### PR TITLE
DATE_TRUNC: auto-cast unknown-typed time-dimension expressions

### DIFF
--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -1746,7 +1746,20 @@ class SQLGenerator:
         return [(reset_cte, reset_sql)], [(value_cte, value_sql)]
 
     def _build_date_trunc(self, col_expr: exp.Expression, granularity: TimeGranularity) -> exp.Expression:
-        """Build a DATE_TRUNC expression, with SQLite STRFTIME fallback."""
+        """Build a DATE_TRUNC expression, with SQLite STRFTIME fallback.
+
+        When ``col_expr`` is not a bare column reference (e.g., a string
+        literal or other unknown-typed sub-expression), the result is
+        wrapped in ``CAST(... AS TIMESTAMP)`` before being passed to
+        ``DATE_TRUNC``. Postgres has multiple ``date_trunc`` overloads
+        keyed on the second argument's type; an ``unknown``-typed operand
+        (the bare literal `'2025-12-01'`) makes the planner fail with
+        ``function date_trunc(unknown, unknown) is not unique``. The cast
+        pins one overload. Bare columns are left alone — their live DB
+        type is already known, and an explicit cast could strip a
+        ``TIMESTAMPTZ`` to ``TIMESTAMP``. Idempotent: already-cast
+        expressions pass through unchanged.
+        """
         gran_str = _GRANULARITY_MAP.get(granularity, granularity.value)
         if self.dialect == "sqlite":
             # SQLite has no DATE_TRUNC — use STRFTIME
@@ -1777,6 +1790,8 @@ class SQLGenerator:
                 this="STRFTIME",
                 expressions=[exp.Literal.string(fmt), col_expr],
             )
+        if not isinstance(col_expr, (exp.Column, exp.Cast)):
+            col_expr = exp.Cast(this=col_expr, to=exp.DataType.build("TIMESTAMP"))
         return exp.DateTrunc(this=col_expr, unit=exp.Literal.string(gran_str))
 
     @staticmethod

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1877,6 +1877,54 @@ class TestMultiDialectGeneration:
         sql_upper = sql.upper()
         assert any(fn in sql_upper for fn in ["DATE_TRUNC", "STRFTIME", "TRUNC", "STR_TO_DATE"])
 
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql", "bigquery", "duckdb", "snowflake"])
+    async def test_date_trunc_casts_unknown_typed_time_dim(self, dialect: str) -> None:
+        """A time-dimension whose ``sql`` is a bare literal (or any expression
+        whose live type is ``unknown``) must be wrapped in ``CAST(... AS
+        TIMESTAMP)`` before being passed to ``DATE_TRUNC``. Postgres has
+        multiple overloads keyed on the second argument's type and rejects
+        ``DATE_TRUNC('month', '2025-12-01')`` with ``AmbiguousFunctionError``.
+
+        Bare column references stay unwrapped — their live DB type is known,
+        and forcing a cast could strip ``TIMESTAMPTZ`` to ``TIMESTAMP``.
+        """
+        gen = SQLGenerator(dialect=dialect)
+        model = SlayerModel(
+            name="orders",
+            sql_table="public.orders",
+            data_source="test",
+            columns=[
+                Column(name="id", sql="id", type=DataType.INT, primary_key=True),
+                Column(name="ts", sql="'2025-12-01'", type=DataType.TIMESTAMP),
+                Column(name="created_at", sql="created_at", type=DataType.TIMESTAMP),
+            ],
+        )
+        # Bare-literal time dim — must be cast.
+        sql = await _generate(
+            gen,
+            SlayerQuery(
+                source_model="orders",
+                measures=[ModelMeasure(formula="*:count")],
+                time_dimensions=[TimeDimension(dimension=ColumnRef(name="ts"), granularity=TimeGranularity.MONTH)],
+            ),
+            model,
+        )
+        # sqlglot transpiles ``TIMESTAMP`` → ``DATETIME`` on MySQL / BigQuery,
+        # so we don't assert the literal target-type spelling — only that the
+        # literal is wrapped in a CAST.
+        assert "CAST('2025-12-01' AS" in sql, sql
+        # Bare-column time dim — must NOT be cast.
+        sql = await _generate(
+            gen,
+            SlayerQuery(
+                source_model="orders",
+                measures=[ModelMeasure(formula="*:count")],
+                time_dimensions=[TimeDimension(dimension=ColumnRef(name="created_at"), granularity=TimeGranularity.MONTH)],
+            ),
+            model,
+        )
+        assert "CAST(" not in sql.upper(), sql
+
     @pytest.mark.parametrize("dialect", ALL_DIALECTS)
     async def test_calendar_time_shift(self, dialect: str, orders_model: SlayerModel) -> None:
         """Calendar-based time_shift should produce dialect-appropriate date arithmetic in shifted CTE."""


### PR DESCRIPTION
A `SlayerModel` time dimension whose `sql` is a bare string literal (`Column(sql="'2025-12-01'", type=TIMESTAMP)`) — a real pattern for synthetic/reference-data time spines — generated SQL like `DATE_TRUNC('month', '2025-12-01')`, which Postgres rejects at execution time with `function date_trunc(unknown, unknown) is not unique` because the second argument carries no resolvable type and there's no single overload to pick.

This PR fixes the SQL generator's single `_build_date_trunc` helper to wrap non-column, non-already-cast operands in `CAST(... AS TIMESTAMP)` before passing them to `DATE_TRUNC` — bare column references stay untouched (their live DB type is already known, and forcing a cast there could silently strip `TIMESTAMPTZ` to `TIMESTAMP`).

Because all **DATE_TRUNC** emission sites already funnel through that one helper, the fix simultaneously covers regular SELECTs, shifted CTEs, the compare-period builder, and time-bucket window functions. Added a parametrized regression test across `postgres / mysql / bigquery / duckdb / snowflake` asserting both directions: bare-literal time dims get wrapped, bare columns don't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SQL query reliability for date truncation operations across supported database platforms (PostgreSQL, MySQL, BigQuery, DuckDB, Snowflake).

* **Tests**
  * Added test coverage for date truncation functionality across multiple database systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->