### PR TITLE
docs: add Discord community link to docs, README, and PyPI URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **SLayer** is a semantic layer that lets AI agents query your database, manage data models, and learn from the data.
 
-> If you find SLayer useful, a ⭐ helps others discover it!
+> If you find SLayer useful, a [⭐](https://github.com/MotleyAI/slayer) helps others discover it!
 > Questions, ideas, or feedback? [Join our Discord](https://discord.gg/djtaFyXW).
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **SLayer** is a semantic layer that lets AI agents query your database, manage data models, and learn from the data.
 
-> If you find SLayer useful, a [⭐](https://github.com/MotleyAI/slayer) helps others discover it!
+> If you find SLayer useful, a ⭐ helps others discover it!
 > Questions, ideas, or feedback? [Join our Discord](https://discord.gg/djtaFyXW).
 
 ---

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@
 [![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://motley-slayer.readthedocs.io/)
 [![License](https://img.shields.io/github/license/MotleyAI/slayer)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/MotleyAI/slayer?style=social)](https://github.com/MotleyAI/slayer/stargazers)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/djtaFyXW)
 
 **SLayer** is a semantic layer that lets AI agents query your database, manage data models, and learn from the data.
 
 > If you find SLayer useful, a ⭐ helps others discover it!
+> Questions, ideas, or feedback? [Join our Discord](https://discord.gg/djtaFyXW).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 A lightweight, open-source semantic layer by [MotleyAI](https://github.com/motleyai). Agents describe what data they want — measures, dimensions, filters — and SLayer generates the SQL.
 
-[GitHub](https://github.com/MotleyAI/slayer) | [PyPI](https://pypi.org/project/motley-slayer/)
+[GitHub](https://github.com/MotleyAI/slayer) | [PyPI](https://pypi.org/project/motley-slayer/) | [Discord](https://discord.gg/djtaFyXW)
 
 ## Why?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 [tool.poetry.urls]
 Repository = "https://github.com/MotleyAI/slayer"
 Documentation = "https://motley-slayer.readthedocs.io/"
+Discord = "https://discord.gg/djtaFyXW"
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## What

Surface the community Discord invite (`https://discord.gg/djtaFyXW`) in the main public-facing entry points, which previously had no reference to it.

## Changes

- **`docs/index.md`** — append `Discord` to the `GitHub | PyPI` link row on the docs home page.
- **`README.md`** — add a static Discord shields.io pill to the badge cluster under the hero image, plus a short "Questions, ideas, or feedback? Join our Discord" blurb under the star line.
- **`pyproject.toml`** — add a `Discord` entry to `[tool.poetry.urls]` so it shows on the PyPI project sidebar alongside Repository and Documentation.

## Notes

- A **static** shields badge is used (`Discord-join`) rather than a dynamic member-count badge, because only the invite code is known — not the numeric server ID that `img.shields.io/discord/<id>` requires.
- `mkdocs.yml` was intentionally skipped: the theme is `readthedocs`, which has no clean `extra.social` footer-icon slot.

Docs/config only — no production code changes, so no tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Discord community invite link to the project header and updated the feedback call-to-action to point to the Discord invite.
  * Added the Discord invite URL to the documentation index links.

* **Chores**
  * Updated project metadata to include the Discord community invite link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->