### PR TITLE
Fix measure order

### DIFF
--- a/slayer/engine/enrichment.py
+++ b/slayer/engine/enrichment.py
@@ -204,6 +204,20 @@ async def enrich_query(
             )
         named_measures[m.name] = m.formula
 
+    # A bare named-measure reference like ``measures=["companies_count"]`` is
+    # an implicit rename: the user already chose ``companies_count`` as the
+    # surfacing name when they declared the ModelMeasure. Promote it to an
+    # explicit ``qf.name`` so DEV-1443's surface / collision / canonical
+    # machinery (which keys on ``qf.name``) treats it identically to an
+    # explicit ``{"formula": "...", "name": "..."}`` rename. Without this,
+    # the SELECT alias canonicalises off the expanded formula
+    # (``company_name_count_distinct``) while ORDER BY / result-key lookups
+    # still use the declared measure name (``companies_count``) — they
+    # diverge and the emitted SQL references a column that isn't projected.
+    for qf in (query.measures or []):
+        if qf.name is None and qf.formula.strip() in named_measures:
+            qf.name = qf.formula.strip()
+
     # --- Dimensions ---
     dimensions = await _resolve_dimensions(
         query=query,
@@ -1235,7 +1249,10 @@ async def enrich_query(
                 agg_args=spec.agg_args,
                 agg_kwargs=spec.agg_kwargs,
             )
-            if field_name == qfield.formula.replace(" ", "_").replace("/", "_div_").replace(":", "_").replace("*", ""):
+            if (
+                field_name == qfield.formula.replace(" ", "_").replace("/", "_div_").replace(":", "_").replace("*", "")
+                and qfield.formula.strip() not in named_measures
+            ):
                 field_name = canonical_name
 
             if "." in spec.measure_name and spec.measure_name != "*":

--- a/tests/test_named_measures.py
+++ b/tests/test_named_measures.py
@@ -194,3 +194,43 @@ class TestNamedMeasureSQL:
 
         with pytest.raises(ValueError, match="Duplicate saved measure name"):
             await _generate(query, model)
+
+
+class TestBareNamedMeasureAliasing:
+    """Regression: bare named-measure ref must surface the measure NAME as
+    the SELECT alias (not the formula-derived canonical), so ORDER BY by
+    that name and downstream result-key lookups stay consistent.
+    """
+
+    async def test_select_alias_uses_measure_name(self) -> None:
+        model = _orders_model(
+            measures=[ModelMeasure(name="rev_total", formula="revenue:sum")]
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            measures=["rev_total"],
+        )
+        sql = await _generate(query, model)
+        assert '"orders.rev_total"' in sql
+        # The formula-derived canonical alias must NOT leak into SELECT.
+        assert '"orders.revenue_sum"' not in sql
+
+    async def test_order_by_resolves_against_measure_name(self) -> None:
+        """The original bug: SELECT aliased by formula, ORDER BY by name."""
+        model = _orders_model(
+            measures=[
+                ModelMeasure(name="companies_count", formula="revenue:count_distinct"),
+            ]
+        )
+        query = SlayerQuery(
+            source_model="orders",
+            dimensions=["status"],
+            measures=["companies_count"],
+            order=[{"column": "companies_count", "direction": "desc"}],
+        )
+        sql = await _generate(query, model)
+        # The ORDER BY reference must point at the alias we actually emitted.
+        assert '"orders.companies_count"' in sql
+        assert "ORDER BY" in sql
+        # And the canonical formula-derived alias must NOT appear at all.
+        assert "revenue_count_distinct" not in sql


### PR DESCRIPTION
When a `ModelMeasure` is referenced by name in `SlayerQuery.order[*].column`, SLayer's SQL generator emits the **measure name** in the `ORDER BY` clause but aliases the corresponding `SELECT` expression by the **formula-derived name**. The two don't match → PostgreSQL `UndefinedColumnError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent aliasing for saved measures in generated SQL queries.
  * Resolved naming collision issues when saved measures are used as query aliases.
  * Improved consistency in how saved measures are referenced and resolved in ORDER BY clauses.

* **Tests**
  * Added regression tests validating correct SQL alias generation for saved measures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->