### PR TITLE
DEV-1494: inline cross-model derived refs in Column.filter + discover their joins

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -212,11 +212,24 @@ the kind of multi-path coupling the redesign set out to remove.
      window/OVER transforms, the time_shift self-join CTE, `date_range`
      BETWEEN, and the cross-model shared-grain CTE). See
      [Typed keys](typed-keys.md) and [SQL generation](sql-generation.md).
-   - A `SlayerModel.filters` entry referencing a non-trivial derived column.
-     `_validate_model_filter` no longer rejects it; the generator
-     (`_render_model_filter_sql`) inline-expands the predicate and pulls any
-     join the expansion crosses into the FROM. The windowed-`Column.sql` and
-     same-model `ModelMeasure`-ref rejects remain.
+   - A `SlayerModel.filters` entry, OR a column-level `Column.filter` on an
+     aggregated measure, referencing a non-trivial derived column.
+     `_validate_model_filter` no longer rejects the model-filter form; the
+     generator inline-expands the predicate (the shared
+     `_render_mode_a_predicate`, used by both `_render_model_filter_sql` and the
+     `Column.filter` CASE-WHEN path) and pulls any join the expansion crosses
+     into the FROM. Inlining covers a bare derived ref (`is_eu` →
+     `customers.region`) **and** a dotted ref to a derived column on a joined
+     model (`loss_payment.has_flag` → its `sql`), matching the query-level
+     filter path so no dangling `<alias>.<derived_col>` (a non-physical column)
+     is emitted (DEV-1494). Join discovery for these Mode-A text filters
+     (`_filter_join_paths`) unions the paths of the **un-inlined** predicate
+     (so the dbt placeholder-join idiom — a constant `has_flag sql="1"` whose
+     only purpose is to force the join — keeps its alias) with the paths the
+     **inline-expanded** predicate crosses. The cross-model `_cm_*` CTE
+     target-filter path deliberately does **not** enable dotted-derived inlining
+     (it has no mechanism to add a deeper crossed join — that is DEV-1503). The
+     windowed-`Column.sql` and same-model `ModelMeasure`-ref rejects remain.
 
 5. **P10 is intentionally violated for cross-model parametric aggregates.**
    Result keys for `customers.revenue:percentile(p=0.5)` now carry the kwarg

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -226,10 +226,12 @@ the kind of multi-path coupling the redesign set out to remove.
      (`_filter_join_paths`) unions the paths of the **un-inlined** predicate
      (so the dbt placeholder-join idiom — a constant `has_flag sql="1"` whose
      only purpose is to force the join — keeps its alias) with the paths the
-     **inline-expanded** predicate crosses. The cross-model `_cm_*` CTE
-     target-filter path deliberately does **not** enable dotted-derived inlining
-     (it has no mechanism to add a deeper crossed join — that is DEV-1503). The
-     windowed-`Column.sql` and same-model `ModelMeasure`-ref rejects remain.
+     **inline-expanded** predicate crosses. The cross-model `_cm_*` CTE discovers
+     its OWN filter joins too — the target measure's `Column.filter` and the
+     target-model filters — and adds them to the CTE's FROM (each `_cm_*` CTE is
+     an isolated per-(target, grain) computation, so the join resolves the
+     filter's refs without affecting sibling measures). The windowed-`Column.sql`
+     and same-model `ModelMeasure`-ref rejects remain.
 
 5. **P10 is intentionally violated for cross-model parametric aggregates.**
    Result keys for `customers.revenue:percentile(p=0.5)` now carry the kwarg

--- a/docs/architecture/sql-generation.md
+++ b/docs/architecture/sql-generation.md
@@ -92,6 +92,33 @@ forward-path CTE renders (FROM bare target, grouped at the forward dims).
 `SUM(CASE WHEN <filter> THEN <col> END)`. See
 [Cross-model aggregates](cross-model-aggregates.md).
 
+## Mode-A filter inlining and join discovery (DEV-1494)
+
+A column-level `Column.filter` on an aggregated measure becomes a CASE-WHEN
+wrapper (`SUM(CASE WHEN <filter> THEN <col> END)`), and a `SlayerModel.filters`
+entry becomes a WHERE term. Both are Mode-A SQL and share one renderer,
+`_render_mode_a_predicate`, which inline-expands references to derived columns —
+bare (`is_eu` → its `CASE WHEN customers.region …`) or dotted to a derived
+column on a joined model (`loss_payment.has_flag` → its `sql`) — so the emitted
+predicate is runnable and never references a non-physical `<alias>.<derived_col>`.
+A predicate with only base refs takes the cheap qualify path
+(`_qualify_mode_a_sql_filter` regex for model filters, `_qualify_column_filter_sql`
+AST for column filters), byte-identical to before. On sqlglot parse failure the
+predicate falls through to the qualify path unchanged.
+
+Join discovery for these text filters (`_filter_join_paths`) is the **union** of
+the join paths in the **un-inlined** predicate and those in the **inline-expanded**
+predicate. Both are needed: the dbt placeholder-join idiom — a constant derived
+column such as `has_flag sql="1"` whose only purpose is to force the (inner)
+join — keeps its alias only in the un-inlined form (it inlines to the constant
+`(1)`), while a derived ref's *crossed* joins (`is_eu` → `customers`;
+`loss_payment.deep_flag` → `loss_payment__claim`) appear only after expansion.
+Discovery for column filters is restricted to **local** aggregate sources
+(empty `AggregateKey.path`); cross-model aggregate filter joins belong in the
+`_cm_*` CTE, and the cross-model target-filter path keeps dotted-derived
+inlining off (no deeper-join mechanism — DEV-1503). Discovery is root-scope-only,
+so a correlated ref inside an `EXISTS (...)` subquery does not pull an outer join.
+
 ## Result-key contract (P10)
 
 The generator preserves the result keys byte-for-byte: `orders.revenue_sum`,

--- a/docs/architecture/sql-generation.md
+++ b/docs/architecture/sql-generation.md
@@ -113,10 +113,13 @@ column such as `has_flag sql="1"` whose only purpose is to force the (inner)
 join — keeps its alias only in the un-inlined form (it inlines to the constant
 `(1)`), while a derived ref's *crossed* joins (`is_eu` → `customers`;
 `loss_payment.deep_flag` → `loss_payment__claim`) appear only after expansion.
-Discovery for column filters is restricted to **local** aggregate sources
-(empty `AggregateKey.path`); cross-model aggregate filter joins belong in the
-`_cm_*` CTE, and the cross-model target-filter path keeps dotted-derived
-inlining off (no deeper-join mechanism — DEV-1503). Discovery is root-scope-only,
+Discovery for column filters in the base SELECT is restricted to **local**
+aggregate sources (empty `AggregateKey.path`); a cross-model aggregate's filter
+joins are discovered inside its `_cm_*` CTE instead — `_render_cross_model_cte`
+collects the join paths of the target measure's `Column.filter` and the
+target-model filters and adds them to the CTE's own FROM. Because each `_cm_*`
+CTE is an isolated per-(target, grain) computation, adding the join resolves the
+filter's refs without affecting sibling measures. Discovery is root-scope-only,
 so a correlated ref inside an `EXISTS (...)` subquery does not pull an outer join.
 
 ## Result-key contract (P10)

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -3522,82 +3522,14 @@ class SQLGenerator:
             base_render_order=base_render_order,
             slots_by_id=slots_by_id,
         )
-        # Pre-expand local derived (ColumnSqlKey) ROW dimensions: inline
-        # sibling/joined derived refs (DEV-1333 / DEV-1410) and pull any
-        # joins their SQL crosses into the FROM.
-        derived_expr_by_sid: Dict[str, exp.Expression] = {}
-        for sid in base_render_order:
-            slot = slots_by_id.get(sid)
-            if slot is None or slot.phase != Phase.ROW:
-                continue
-            key = slot.key
-            # DEV-1450 #4a: a derived (ColumnSqlKey) TIME dimension expands the
-            # same way; pull any joins its SQL crosses into the FROM so the
-            # DATE_TRUNC over the expanded expression resolves. The render
-            # branch re-derives the (un-cached) raw expr and wraps DATE_TRUNC.
-            if isinstance(key, TimeTruncKey) and isinstance(
-                key.column, ColumnSqlKey,
-            ):
-                raw = self._raw_time_col_expr_for_planned(
-                    time_column=key.column,
-                    source_model=source_model,
-                    source_relation=source_relation,
-                    bundle=bundle,
-                )
-                for p in self._joined_paths_in_sql(
-                    sql_expr=raw, source_relation=source_relation,
-                    source_model=source_model, bundle=bundle,
-                ):
-                    if p not in needed_join_paths:
-                        needed_join_paths.append(p)
-                continue
-            if not isinstance(key, ColumnSqlKey):
-                continue
-            # A derived (``Column.sql``) dimension. Local refs (``path == ()``)
-            # expand rooted at the source relation; a CROSS-MODEL derived dim
-            # (``B.foo_normalized``, ``path == ("B",)``) expands rooted at the
-            # ``__``-path alias of the owning joined model — mirrors the
-            # ColumnSqlKey arm of ``_raw_time_col_expr_for_planned``. Without
-            # this the render branch falls back to ``_dim_column_expr_from_
-            # planned`` which only looks at the source model and raises
-            # "Column not found".
-            if key.path:
-                owner_model = bundle.get_referenced_model(key.path[-1])
-                if owner_model is None:
-                    continue
-                owner_relation = "__".join(key.path)
-            else:
-                owner_model = source_model
-                owner_relation = source_relation
-            expanded_sql = self._expand_derived_column_sql(
-                source_model=owner_model,
-                source_relation=owner_relation,
-                column_name=key.column_name,
-                bundle=bundle,
-                # Cross-model derived dim: the owner is a joined model, so a
-                # further-joined ref inside its sql must carry the full path
-                # prefix (``B`` reaching ``C`` → ``B__C``).
-                is_root=not key.path,
-            )
-            col = next(
-                (c for c in owner_model.columns if c.name == key.column_name),
-                None,
-            )
-            expr = _wrap_cast_for_type(
-                self._parse(expanded_sql),
-                col.type if col is not None else None,
-            )
-            derived_expr_by_sid[sid] = expr
-            # Pull the join to the owning model itself (cross-model case) plus
-            # any joins the expanded SQL crosses into the FROM clause.
-            if key.path and key.path not in needed_join_paths:
-                needed_join_paths.append(key.path)
-            for p in self._joined_paths_in_sql(
-                sql_expr=expr, source_relation=source_relation,
-                source_model=source_model, bundle=bundle,
-            ):
-                if p not in needed_join_paths:
-                    needed_join_paths.append(p)
+        # Pre-expand derived (ColumnSqlKey) ROW + TIME dimensions: inline
+        # sibling/joined derived refs (DEV-1333 / DEV-1410) and pull any joins
+        # their SQL crosses into the FROM (appended to ``needed_join_paths``).
+        derived_expr_by_sid = self._expand_derived_row_dims(
+            base_render_order=base_render_order, slots_by_id=slots_by_id,
+            source_relation=source_relation, source_model=source_model,
+            bundle=bundle, needed_join_paths=needed_join_paths,
+        )
         # WHERE-phase filters referencing joined columns (direct, derived, or
         # Mode-A ``__`` paths) pull their joins into the FROM too. Filters
         # routed to a cross-model ``_cm_*`` CTE (``skip_filter_ids``) are
@@ -3612,30 +3544,16 @@ class SQLGenerator:
             if p not in needed_join_paths:
                 needed_join_paths.append(p)
         # DEV-1494: a ``Column.filter`` on an aggregated measure becomes a
-        # CASE-WHEN wrapper (``SUM(CASE WHEN <filter> THEN col END)``). If that
-        # filter references a joined table directly (``loss_payment.has_flag``)
-        # or via a derived column whose sql crosses a join (``is_eu``), pull the
-        # crossed join into the FROM — exactly as the dimension / model-filter
-        # discovery above. Cross-model aggregate sources (non-empty path) are
-        # excluded: their filter joins belong in the per-plan ``_cm_*`` CTE.
-        for sid in base_render_order:
-            slot = slots_by_id.get(sid)
-            if slot is None or slot.phase != Phase.AGGREGATE:
-                continue
-            key = slot.key
-            if not isinstance(key, AggregateKey) or getattr(
-                key.source, "path", (),
-            ):
-                continue
-            cfk = key.column_filter_key
-            if cfk is None or not cfk.canonical_sql:
-                continue
-            for p in self._filter_join_paths(
-                sql=cfk.canonical_sql, source_relation=source_relation,
-                source_model=source_model, bundle=bundle,
-            ):
-                if p not in needed_join_paths:
-                    needed_join_paths.append(p)
+        # CASE-WHEN wrapper; pull any join its predicate crosses (directly, or via
+        # a derived ref) into the FROM — including filtered aggregates nested in
+        # composite (arithmetic / scalar-call) AGGREGATE-phase keys.
+        for p in self._collect_column_filter_join_paths(
+            base_render_order=base_render_order, slots_by_id=slots_by_id,
+            source_relation=source_relation, source_model=source_model,
+            bundle=bundle,
+        ):
+            if p not in needed_join_paths:
+                needed_join_paths.append(p)
         from_clause, base_joins = self._build_from_and_joins(
             source_model=source_model,
             source_relation=source_relation,
@@ -5435,16 +5353,34 @@ class SQLGenerator:
         # so the first/last branch can push them INSIDE the ranked
         # subquery — otherwise rows excluded by a filter could still
         # win ``_last_rn = 1`` and yield NULL aggregates.
+        # DEV-1494: join paths the CTE's own filters cross — the target measure's
+        # ``Column.filter`` and the target-model filters. Each ``_cm_*`` CTE is an
+        # isolated per-(target, grain) computation, so adding these joins to ITS
+        # FROM affects only this measure (not siblings) — it resolves the filter's
+        # refs without the cross-measure cardinality concern DEV-1503 owns.
+        cte_join_paths: List[Tuple[str, ...]] = []
+
+        def _add_cte_join_paths(sql_text: Optional[str]) -> None:
+            if not sql_text:
+                return
+            for p in self._filter_join_paths(
+                sql=sql_text, source_relation=target_relation,
+                source_model=target_model, bundle=bundle,
+            ):
+                if p not in cte_join_paths:
+                    cte_join_paths.append(p)
+
+        if local_agg_key.column_filter_key is not None:
+            _add_cte_join_paths(local_agg_key.column_filter_key.canonical_sql)
+
         where_parts: List[exp.Expression] = []
         for filter_text in plan.target_model_filters:
-            # DEV-1450 #4b: a target model filter referencing a non-trivial
-            # derived column on the target is inline-expanded (it would otherwise
-            # emit ``target.derived_col`` — a non-existent column); base-only
-            # filters keep the AST bare-ref qualification. Dotted-derived
-            # inlining is intentionally NOT enabled here
-            # (include_dotted_derived=False): the cross-model ``_cm_*`` CTE has no
-            # path to add a deeper join such an expansion would cross — that is
-            # DEV-1503 (cross-model isolation). Behavior here is unchanged.
+            # DEV-1450 #4b / DEV-1494: a target model filter referencing a
+            # non-trivial derived column on the target (bare OR a dotted ref to a
+            # derived column on a joined model) is inline-expanded; base-only
+            # filters keep the AST bare-ref qualification. The crossed join is
+            # pulled into this CTE's FROM via ``cte_join_paths``.
+            _add_cte_join_paths(filter_text)
             qualified = self._render_mode_a_predicate(
                 sql=filter_text,
                 source_model=target_model,
@@ -5455,7 +5391,6 @@ class SQLGenerator:
                     source_relation=target_relation,
                     source_model=target_model,
                 ),
-                include_dotted_derived=False,
             )
             if not qualified:
                 continue
@@ -5491,9 +5426,16 @@ class SQLGenerator:
         # over the filtered row set; otherwise a filtered-out row could win
         # ``_last_rn = 1`` and the ``MAX(CASE WHEN _last_rn = 1 ...)``
         # aggregate would return NULL.
-        target_from = self._build_from_clause_from_planned(
-            source_model=target_model, source_relation=target_relation,
-        )
+        if cte_join_paths:
+            target_from, cte_base_joins = self._build_from_and_joins(
+                source_model=target_model, source_relation=target_relation,
+                joined_paths=cte_join_paths, bundle=bundle,
+            )
+        else:
+            target_from = self._build_from_clause_from_planned(
+                source_model=target_model, source_relation=target_relation,
+            )
+            cte_base_joins = []
         ranked_from: Optional[exp.Expression] = None
         if is_first_or_last:
             assert time_col_sql is not None  # narrowed by the guard above
@@ -5505,7 +5447,7 @@ class SQLGenerator:
                     extra_projections=[],
                     synth_specs=[synth],
                     from_clause=target_from,
-                    base_joins=[],
+                    base_joins=cte_base_joins,
                     where_clause=combined_where,
                 )
             )
@@ -5532,6 +5474,10 @@ class SQLGenerator:
             cte_select = cte_select.from_(ranked_from)
         else:
             cte_select = cte_select.from_(target_from)
+            for join_expr, on_expr, join_type in cte_base_joins:
+                cte_select = cte_select.join(
+                    join_expr, on=on_expr, join_type=join_type,
+                )
             if combined_where is not None:
                 cte_select = cte_select.where(combined_where)
 
@@ -7251,39 +7197,51 @@ class SQLGenerator:
                 col.set("table", exp.to_identifier(source_relation))
         return ast.sql(dialect=self.dialect)
 
-    def _predicate_references_derived(
-        self, *, parsed: exp.Expression, source_model, bundle,
+    def _column_ref_is_derived(
+        self, *, col: exp.Column, source_model, source_relation: str, bundle,
         include_dotted: bool,
     ) -> bool:
-        """True iff the parsed Mode-A predicate references a non-trivial DERIVED
-        column — bare on ``source_model``, or (when ``include_dotted``) by a
-        dotted ``__``-path alias resolving through ``bundle`` to a derived column
-        on a joined model. Drives whether the predicate must be inline-expanded
-        (vs. cheaply qualified). DEV-1494.
+        """True iff a single ``exp.Column`` ref resolves to a non-trivial DERIVED
+        column — bare on ``source_model``, or (when ``include_dotted``) a dotted
+        ``__``-path alias resolving through ``bundle`` to a derived column on a
+        joined model. Dotted resolution starts from ``source_relation`` (the
+        alias the rest of the Mode-A path uses), not ``source_model.name``.
         """
-        for col in parsed.find_all(exp.Column):
-            if col.args.get("db") or col.args.get("catalog"):
-                continue
-            ident = col.this
-            if not isinstance(ident, exp.Identifier):
-                continue
-            tbl = col.args.get("table")
-            if tbl is None:
-                if self._is_nontrivial_derived(source_model, ident.name):
-                    return True
-            elif include_dotted:
-                target, _ = _walk_path_to_target_sync(
-                    source_model=source_model,
-                    source_alias=source_model.name,
-                    table_alias=tbl.name,
-                    resolve_model=bundle.get_referenced_model,
-                    is_root=True,
-                )
-                if target is not None and self._is_nontrivial_derived(
-                    target, ident.name,
-                ):
-                    return True
-        return False
+        if col.args.get("db") or col.args.get("catalog"):
+            return False
+        ident = col.this
+        if not isinstance(ident, exp.Identifier):
+            return False
+        tbl = col.args.get("table")
+        if tbl is None:
+            return self._is_nontrivial_derived(source_model, ident.name)
+        if not include_dotted:
+            return False
+        target, _ = _walk_path_to_target_sync(
+            source_model=source_model,
+            source_alias=source_relation,
+            table_alias=tbl.name,
+            resolve_model=bundle.get_referenced_model,
+            is_root=True,
+        )
+        return target is not None and self._is_nontrivial_derived(target, ident.name)
+
+    def _predicate_references_derived(
+        self, *, parsed: exp.Expression, source_model, source_relation: str,
+        bundle, include_dotted: bool,
+    ) -> bool:
+        """True iff the parsed Mode-A predicate references a non-trivial DERIVED
+        column (see :meth:`_column_ref_is_derived`). Drives whether the predicate
+        must be inline-expanded (vs. cheaply qualified). DEV-1494.
+        """
+        return any(
+            self._column_ref_is_derived(
+                col=col, source_model=source_model,
+                source_relation=source_relation, bundle=bundle,
+                include_dotted=include_dotted,
+            )
+            for col in parsed.find_all(exp.Column)
+        )
 
     def _render_mode_a_predicate(
         self,
@@ -7320,44 +7278,17 @@ class SQLGenerator:
             except Exception:
                 parsed = None
             if parsed is not None and self._predicate_references_derived(
-                parsed=parsed, source_model=source_model, bundle=bundle,
+                parsed=parsed, source_model=source_model,
+                source_relation=source_relation, bundle=bundle,
                 include_dotted=include_dotted_derived,
             ):
-                # Degenerate root: the whole predicate is a single column ref.
-                # ``expand_derived_refs_sync`` rewrites refs via in-place
-                # ``col.replace`` — a no-op on the AST root — so expand directly.
-                if isinstance(parsed, exp.Column) and not (
-                    parsed.args.get("db") or parsed.args.get("catalog")
-                ):
-                    tbl = parsed.args.get("table")
-                    if tbl is None:
-                        if self._is_nontrivial_derived(source_model, parsed.name):
-                            return self._expand_derived_column_sql(
-                                source_model=source_model,
-                                source_relation=source_relation,
-                                column_name=parsed.name,
-                                bundle=bundle,
-                            )
-                    elif include_dotted_derived:
-                        target, canonical = _walk_path_to_target_sync(
-                            source_model=source_model,
-                            source_alias=source_relation,
-                            table_alias=tbl.name,
-                            resolve_model=bundle.get_referenced_model,
-                            is_root=True,
-                        )
-                        if (
-                            target is not None
-                            and canonical is not None
-                            and self._is_nontrivial_derived(target, parsed.name)
-                        ):
-                            return self._expand_derived_column_sql(
-                                source_model=target,
-                                source_relation=canonical,
-                                column_name=parsed.name,
-                                bundle=bundle,
-                                is_root=False,
-                            )
+                root = self._expand_degenerate_derived_root(
+                    parsed=parsed, source_model=source_model,
+                    source_relation=source_relation, bundle=bundle,
+                    include_dotted_derived=include_dotted_derived,
+                )
+                if root is not None:
+                    return root
                 expanded = expand_derived_refs_sync(
                     sql=sql,
                     model=source_model,
@@ -7368,6 +7299,55 @@ class SQLGenerator:
                 if expanded is not None:
                     return expanded
         return qualify_fallback(sql)
+
+    def _expand_degenerate_derived_root(
+        self, *, parsed: exp.Expression, source_model, source_relation: str,
+        bundle, include_dotted_derived: bool,
+    ) -> Optional[str]:
+        """When the whole predicate IS a single derived-column ref
+        (``filter="is_eu"`` / ``filter="loss_payment.has_flag"``), expand it
+        directly — ``expand_derived_refs_sync`` rewrites refs via in-place
+        ``col.replace``, a no-op on the AST root. A dotted root is walked to its
+        target model + canonical ``__`` alias and expanded with ``is_root=False``
+        so further-joined refs prefix correctly. Returns the expanded SQL, or
+        ``None`` when ``parsed`` is not such a derived single-column root.
+        """
+        if not isinstance(parsed, exp.Column) or (
+            parsed.args.get("db") or parsed.args.get("catalog")
+        ):
+            return None
+        tbl = parsed.args.get("table")
+        if tbl is None:
+            if self._is_nontrivial_derived(source_model, parsed.name):
+                return self._expand_derived_column_sql(
+                    source_model=source_model,
+                    source_relation=source_relation,
+                    column_name=parsed.name,
+                    bundle=bundle,
+                )
+            return None
+        if not include_dotted_derived:
+            return None
+        target, canonical = _walk_path_to_target_sync(
+            source_model=source_model,
+            source_alias=source_relation,
+            table_alias=tbl.name,
+            resolve_model=bundle.get_referenced_model,
+            is_root=True,
+        )
+        if (
+            target is not None
+            and canonical is not None
+            and self._is_nontrivial_derived(target, parsed.name)
+        ):
+            return self._expand_derived_column_sql(
+                source_model=target,
+                source_relation=canonical,
+                column_name=parsed.name,
+                bundle=bundle,
+                is_root=False,
+            )
+        return None
 
     def _filter_join_paths(
         self, *, sql: Optional[str], source_relation: str, source_model, bundle,
@@ -7413,6 +7393,126 @@ class SQLGenerator:
         if rendered is not None and rendered != sql:
             _scan(rendered)
         return ordered
+
+    def _collect_column_filter_join_paths(
+        self, *, base_render_order, slots_by_id, source_relation: str,
+        source_model, bundle,
+    ) -> List[Tuple[str, ...]]:
+        """Join paths needed by aggregation-time ``Column.filter`` CASE-WHEN
+        wrappers on LOCAL aggregate slots (DEV-1494).
+
+        Recurses into AGGREGATE-phase composite keys (``ArithmeticKey`` /
+        ``ScalarCallKey``) so a filtered aggregate nested inside e.g.
+        ``a:sum + b:sum`` — rendered by ``_render_aggregate_composite_expr`` —
+        discovers its crossed join exactly like a top-level aggregate. Cross-model
+        aggregate sources (non-empty ``source.path``) are excluded: their filter
+        joins belong in the per-plan ``_cm_*`` CTE (DEV-1503).
+        """
+        from slayer.core.keys import (
+            AggregateKey,
+            ArithmeticKey,
+            Phase,
+            ScalarCallKey,
+        )
+
+        paths: List[Tuple[str, ...]] = []
+
+        def _visit(key) -> None:
+            if isinstance(key, AggregateKey):
+                if getattr(key.source, "path", ()):
+                    return
+                cfk = key.column_filter_key
+                if cfk is None or not cfk.canonical_sql:
+                    return
+                for p in self._filter_join_paths(
+                    sql=cfk.canonical_sql, source_relation=source_relation,
+                    source_model=source_model, bundle=bundle,
+                ):
+                    if p not in paths:
+                        paths.append(p)
+            elif isinstance(key, ArithmeticKey):
+                for operand in key.operands:
+                    _visit(operand)
+            elif isinstance(key, ScalarCallKey):
+                for arg in key.args:
+                    _visit(arg)
+
+        for sid in base_render_order:
+            slot = slots_by_id.get(sid)
+            if slot is not None and slot.phase == Phase.AGGREGATE:
+                _visit(slot.key)
+        return paths
+
+    def _expand_derived_row_dims(
+        self, *, base_render_order, slots_by_id, source_relation: str,
+        source_model, bundle, needed_join_paths: List[Tuple[str, ...]],
+    ) -> Dict[str, exp.Expression]:
+        """Pre-expand derived (``ColumnSqlKey``) ROW dimensions and derived TIME
+        dimensions for the base SELECT: inline sibling/joined derived refs
+        (DEV-1333 / DEV-1410), append any joins their SQL crosses to
+        ``needed_join_paths`` (in place), and return the expanded-expr-by-slot-id
+        map the render branch reads from. Extracted from
+        ``_build_base_select_for_planned``.
+        """
+        from slayer.core.keys import ColumnSqlKey, Phase, TimeTruncKey
+
+        def _add(path: Tuple[str, ...]) -> None:
+            if path and path not in needed_join_paths:
+                needed_join_paths.append(path)
+
+        derived_expr_by_sid: Dict[str, exp.Expression] = {}
+        for sid in base_render_order:
+            slot = slots_by_id.get(sid)
+            if slot is None or slot.phase != Phase.ROW:
+                continue
+            key = slot.key
+            # DEV-1450 #4a: a derived (ColumnSqlKey) TIME dimension expands the
+            # same way; pull any joins its SQL crosses into the FROM so the
+            # DATE_TRUNC over the expanded expression resolves.
+            if isinstance(key, TimeTruncKey) and isinstance(key.column, ColumnSqlKey):
+                raw = self._raw_time_col_expr_for_planned(
+                    time_column=key.column, source_model=source_model,
+                    source_relation=source_relation, bundle=bundle,
+                )
+                for p in self._joined_paths_in_sql(
+                    sql_expr=raw, source_relation=source_relation,
+                    source_model=source_model, bundle=bundle,
+                ):
+                    _add(p)
+                continue
+            if not isinstance(key, ColumnSqlKey):
+                continue
+            # Local refs (``path == ()``) expand rooted at the source relation; a
+            # CROSS-MODEL derived dim (``B.foo``, ``path == ("B",)``) expands
+            # rooted at the ``__``-path alias of the owning joined model, with
+            # ``is_root=False`` so a further-joined ref carries the full prefix
+            # (``B`` reaching ``C`` → ``B__C``).
+            if key.path:
+                owner_model = bundle.get_referenced_model(key.path[-1])
+                if owner_model is None:
+                    continue
+                owner_relation = "__".join(key.path)
+            else:
+                owner_model = source_model
+                owner_relation = source_relation
+            expanded_sql = self._expand_derived_column_sql(
+                source_model=owner_model, source_relation=owner_relation,
+                column_name=key.column_name, bundle=bundle, is_root=not key.path,
+            )
+            col = next(
+                (c for c in owner_model.columns if c.name == key.column_name), None,
+            )
+            expr = _wrap_cast_for_type(
+                self._parse(expanded_sql), col.type if col is not None else None,
+            )
+            derived_expr_by_sid[sid] = expr
+            _add(key.path)  # the join to the owning model itself (cross-model)
+            for p in self._joined_paths_in_sql(
+                sql_expr=expr, source_relation=source_relation,
+                source_model=source_model, bundle=bundle,
+            ):
+                _add(p)
+        return derived_expr_by_sid
 
     def _expand_column_filter_sql(
         self,
@@ -7639,84 +7739,26 @@ class SQLGenerator:
         * Mode-A ``SlayerModel.filters`` text with a ``__`` join path
           (``customers__regions.name = 'EU'``) — parsed and scanned.
         """
-        from slayer.core.keys import (
-            ArithmeticKey,
-            BetweenKey,
-            ColumnKey,
-            ColumnSqlKey,
-            InKey,
-            Phase,
-            ScalarCallKey,
-        )
+        from slayer.core.keys import Phase
 
         seen: set = set()
         ordered: List[Tuple[str, ...]] = []
 
-        def _add_path(path: Tuple[str, ...]) -> None:
-            for i in range(1, len(path) + 1):
-                prefix = tuple(path[:i])
-                if prefix and prefix not in seen:
-                    seen.add(prefix)
-                    ordered.append(prefix)
-
-        def _add_from_sql(parsed: exp.Expression) -> None:
-            for p in self._joined_paths_in_sql(
-                sql_expr=parsed, source_relation=source_relation,
-                source_model=source_model, bundle=bundle,
-            ):
+        def _merge(paths: List[Tuple[str, ...]]) -> None:
+            for p in paths:
                 if p not in seen:
                     seen.add(p)
                     ordered.append(p)
-
-        def _walk(key) -> None:
-            if isinstance(key, ColumnKey):
-                if key.path:
-                    _add_path(key.path)
-            elif isinstance(key, ColumnSqlKey) and not key.path:
-                expanded = self._expand_derived_column_sql(
-                    source_model=source_model,
-                    source_relation=source_relation,
-                    column_name=key.column_name,
-                    bundle=bundle,
-                )
-                _add_from_sql(self._parse(expanded))
-            elif isinstance(key, ColumnSqlKey) and key.path:
-                # Joined derived-column ref — pull the join walk to the column's
-                # owning model into the FROM, plus any further cross-joins the
-                # column's own ``sql`` references (expanded under the column's
-                # ``__``-path alias, then scanned from the host's perspective).
-                _add_path(key.path)
-                joined_model = bundle.get_referenced_model(key.path[-1])
-                if joined_model is not None:
-                    expanded = self._expand_derived_column_sql(
-                        source_model=joined_model,
-                        source_relation="__".join(key.path),
-                        column_name=key.column_name,
-                        bundle=bundle,
-                    )
-                    _add_from_sql(self._parse(expanded))
-            elif isinstance(key, ArithmeticKey):
-                for o in key.operands:
-                    _walk(o)
-            elif isinstance(key, ScalarCallKey):
-                for a in key.args:
-                    _walk(a)
-            elif isinstance(key, BetweenKey):
-                _walk(key.column)
-                _walk(key.low)
-                _walk(key.high)
-            elif isinstance(key, InKey):
-                # DEV-1475: an IN filter on a joined column must still
-                # pull the join into the FROM. Only the LHS column can
-                # carry a join path; literal RHS values never do.
-                _walk(key.column)
 
         skip = skip_filter_ids or set()
         for fp in planned_query.filters_by_phase:
             if fp.phase != Phase.ROW or fp.id in skip:
                 continue
             if fp.expression is not None:
-                _walk(fp.expression.value_key)
+                _merge(self._value_key_join_paths(
+                    key=fp.expression.value_key, source_model=source_model,
+                    source_relation=source_relation, bundle=bundle,
+                ))
             elif fp.text is not None:
                 # DEV-1450 #4b / DEV-1494: discover joins from BOTH the
                 # un-inlined text (a placeholder dotted ref like
@@ -7724,14 +7766,86 @@ class SQLGenerator:
                 # to a constant) AND the inline-expanded text (a bare/dotted
                 # DERIVED ref like ``is_eu`` surfaces the join its expansion
                 # crosses). See ``_filter_join_paths``.
-                for p in self._filter_join_paths(
+                _merge(self._filter_join_paths(
                     sql=fp.text, source_relation=source_relation,
                     source_model=source_model, bundle=bundle,
-                ):
-                    if p not in seen:
-                        seen.add(p)
-                        ordered.append(p)
+                ))
         return ordered
+
+    def _value_key_join_paths(
+        self, *, key, source_model, source_relation: str, bundle,
+    ) -> List[Tuple[str, ...]]:
+        """Join paths a typed filter ``ValueKey`` tree references (DEV-1450 /
+        DEV-1475): a direct ``ColumnKey.path``; a derived ``ColumnSqlKey``
+        (local or joined — expanded then scanned for the joins its ``sql``
+        crosses); and recursively through ``ArithmeticKey`` / ``ScalarCallKey`` /
+        ``BetweenKey`` / ``InKey`` operands. Extracted from
+        ``_collect_filter_join_paths``; ``_joined_paths_in_sql`` already emits
+        path prefixes, and ``ColumnKey.path`` prefixes are expanded here.
+        """
+        from slayer.core.keys import (
+            ArithmeticKey,
+            BetweenKey,
+            ColumnKey,
+            ColumnSqlKey,
+            InKey,
+            ScalarCallKey,
+        )
+
+        out: List[Tuple[str, ...]] = []
+
+        def _add(path: Tuple[str, ...]) -> None:
+            for i in range(1, len(path) + 1):
+                prefix = tuple(path[:i])
+                if prefix and prefix not in out:
+                    out.append(prefix)
+
+        def _scan(parsed: exp.Expression) -> None:
+            for p in self._joined_paths_in_sql(
+                sql_expr=parsed, source_relation=source_relation,
+                source_model=source_model, bundle=bundle,
+            ):
+                if p not in out:
+                    out.append(p)
+
+        def _derived_paths(*, model, relation, column_name) -> None:
+            _scan(self._parse(self._expand_derived_column_sql(
+                source_model=model, source_relation=relation,
+                column_name=column_name, bundle=bundle,
+            )))
+
+        def _walk(k) -> None:
+            if isinstance(k, ColumnKey):
+                _add(k.path)
+            elif isinstance(k, ColumnSqlKey):
+                # Joined derived ref also pulls the walk to its owning model.
+                _add(k.path)
+                model = (
+                    bundle.get_referenced_model(k.path[-1]) if k.path
+                    else source_model
+                )
+                if model is not None:
+                    _derived_paths(
+                        model=model,
+                        relation="__".join(k.path) if k.path else source_relation,
+                        column_name=k.column_name,
+                    )
+            elif isinstance(k, ArithmeticKey):
+                for o in k.operands:
+                    _walk(o)
+            elif isinstance(k, ScalarCallKey):
+                for a in k.args:
+                    _walk(a)
+            elif isinstance(k, BetweenKey):
+                _walk(k.column)
+                _walk(k.low)
+                _walk(k.high)
+            elif isinstance(k, InKey):
+                # DEV-1475: only the LHS column of an IN can carry a join path.
+                _walk(k.column)
+
+        _walk(key)
+        return out
 
     def _resolve_aggregation_def(
         self,

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -3478,7 +3478,7 @@ class SQLGenerator:
                 return False
         return True
 
-    def _build_base_select_for_planned(
+    def _build_base_select_for_planned(  # NOSONAR(S3776) — join-path collection and derived-dim expansion are extracted to helpers; the residual is the one cohesive per-slot ROW/AGGREGATE projection + GROUP-BY assembly pass.
         self,
         *,
         planned_query,
@@ -7394,7 +7394,7 @@ class SQLGenerator:
             _scan(rendered)
         return ordered
 
-    def _collect_column_filter_join_paths(
+    def _collect_column_filter_join_paths(  # NOSONAR(S3776) — one cohesive recursive walk of AGGREGATE composite keys (mirrors _render_aggregate_composite_expr) collecting Column.filter join paths.
         self, *, base_render_order, slots_by_id, source_relation: str,
         source_model, bundle,
     ) -> List[Tuple[str, ...]]:
@@ -7443,7 +7443,7 @@ class SQLGenerator:
                 _visit(slot.key)
         return paths
 
-    def _expand_derived_row_dims(
+    def _expand_derived_row_dims(  # NOSONAR(S3776) — one cohesive per-slot pass expanding derived ROW/TIME dimensions and collecting the joins they cross.
         self, *, base_render_order, slots_by_id, source_relation: str,
         source_model, bundle, needed_join_paths: List[Tuple[str, ...]],
     ) -> Dict[str, exp.Expression]:
@@ -7772,7 +7772,7 @@ class SQLGenerator:
                 ))
         return ordered
 
-    def _value_key_join_paths(
+    def _value_key_join_paths(  # NOSONAR(S3776) — one cohesive recursive ValueKey-tree walk; complexity is the per-key-type dispatch.
         self, *, key, source_model, source_relation: str, bundle,
     ) -> List[Tuple[str, ...]]:
         """Join paths a typed filter ``ValueKey`` tree references (DEV-1450 /

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -27,6 +27,7 @@ from slayer.core.refs import agg_kwarg_canonical_str
 from slayer.engine.column_expansion import (
     _is_trivial_base,
     _root_scope_column_ids,
+    _walk_path_to_target_sync,
     expand_derived_refs_sync,
 )
 from slayer.engine.enriched import EnrichedMeasure, EnrichedQuery, public_projection_aliases
@@ -34,7 +35,6 @@ from slayer.engine.source_bundle import (
     stage_bundle_with_siblings,
     synthetic_model_from_stage_schema,
 )
-from slayer.sql.sql_predicate import parse_sql_predicate
 from slayer.sql.sqlite_dialect import rewrite_sqlite_json_extract
 from slayer.sql.stage_wrapper import build_flat_rename_wrapper
 
@@ -3611,6 +3611,31 @@ class SQLGenerator:
         ):
             if p not in needed_join_paths:
                 needed_join_paths.append(p)
+        # DEV-1494: a ``Column.filter`` on an aggregated measure becomes a
+        # CASE-WHEN wrapper (``SUM(CASE WHEN <filter> THEN col END)``). If that
+        # filter references a joined table directly (``loss_payment.has_flag``)
+        # or via a derived column whose sql crosses a join (``is_eu``), pull the
+        # crossed join into the FROM — exactly as the dimension / model-filter
+        # discovery above. Cross-model aggregate sources (non-empty path) are
+        # excluded: their filter joins belong in the per-plan ``_cm_*`` CTE.
+        for sid in base_render_order:
+            slot = slots_by_id.get(sid)
+            if slot is None or slot.phase != Phase.AGGREGATE:
+                continue
+            key = slot.key
+            if not isinstance(key, AggregateKey) or getattr(
+                key.source, "path", (),
+            ):
+                continue
+            cfk = key.column_filter_key
+            if cfk is None or not cfk.canonical_sql:
+                continue
+            for p in self._filter_join_paths(
+                sql=cfk.canonical_sql, source_relation=source_relation,
+                source_model=source_model, bundle=bundle,
+            ):
+                if p not in needed_join_paths:
+                    needed_join_paths.append(p)
         from_clause, base_joins = self._build_from_and_joins(
             source_model=source_model,
             source_relation=source_relation,
@@ -5412,27 +5437,26 @@ class SQLGenerator:
         # win ``_last_rn = 1`` and yield NULL aggregates.
         where_parts: List[exp.Expression] = []
         for filter_text in plan.target_model_filters:
-            # DEV-1450 #4b: a target model filter that references a
-            # non-trivial derived column must be inline-expanded (it would
-            # otherwise emit ``target.derived_col`` — a non-existent column);
-            # base-only filters keep the AST bare-ref qualification.
-            cols = parse_sql_predicate(filter_text).columns
-            if any(
-                self._is_nontrivial_derived(target_model, c) for c in cols
-            ):
-                qualified = self._render_model_filter_sql(
-                    sql=filter_text,
-                    columns=cols,
-                    source_model=target_model,
-                    source_relation=target_relation,
-                    bundle=bundle,
-                )
-            else:
-                qualified = self._qualify_column_filter_sql(
-                    canonical_sql=filter_text,
+            # DEV-1450 #4b: a target model filter referencing a non-trivial
+            # derived column on the target is inline-expanded (it would otherwise
+            # emit ``target.derived_col`` — a non-existent column); base-only
+            # filters keep the AST bare-ref qualification. Dotted-derived
+            # inlining is intentionally NOT enabled here
+            # (include_dotted_derived=False): the cross-model ``_cm_*`` CTE has no
+            # path to add a deeper join such an expansion would cross — that is
+            # DEV-1503 (cross-model isolation). Behavior here is unchanged.
+            qualified = self._render_mode_a_predicate(
+                sql=filter_text,
+                source_model=target_model,
+                source_relation=target_relation,
+                bundle=bundle,
+                qualify_fallback=lambda s: self._qualify_column_filter_sql(
+                    canonical_sql=s,
                     source_relation=target_relation,
                     source_model=target_model,
-                )
+                ),
+                include_dotted_derived=False,
+            )
             if not qualified:
                 continue
             try:
@@ -7227,6 +7251,201 @@ class SQLGenerator:
                 col.set("table", exp.to_identifier(source_relation))
         return ast.sql(dialect=self.dialect)
 
+    def _predicate_references_derived(
+        self, *, parsed: exp.Expression, source_model, bundle,
+        include_dotted: bool,
+    ) -> bool:
+        """True iff the parsed Mode-A predicate references a non-trivial DERIVED
+        column — bare on ``source_model``, or (when ``include_dotted``) by a
+        dotted ``__``-path alias resolving through ``bundle`` to a derived column
+        on a joined model. Drives whether the predicate must be inline-expanded
+        (vs. cheaply qualified). DEV-1494.
+        """
+        for col in parsed.find_all(exp.Column):
+            if col.args.get("db") or col.args.get("catalog"):
+                continue
+            ident = col.this
+            if not isinstance(ident, exp.Identifier):
+                continue
+            tbl = col.args.get("table")
+            if tbl is None:
+                if self._is_nontrivial_derived(source_model, ident.name):
+                    return True
+            elif include_dotted:
+                target, _ = _walk_path_to_target_sync(
+                    source_model=source_model,
+                    source_alias=source_model.name,
+                    table_alias=tbl.name,
+                    resolve_model=bundle.get_referenced_model,
+                    is_root=True,
+                )
+                if target is not None and self._is_nontrivial_derived(
+                    target, ident.name,
+                ):
+                    return True
+        return False
+
+    def _render_mode_a_predicate(
+        self,
+        *,
+        sql: Optional[str],
+        source_model,
+        source_relation: str,
+        bundle,
+        qualify_fallback,
+        include_dotted_derived: bool = True,
+    ) -> Optional[str]:
+        """Render a Mode-A predicate (``Column.filter`` / ``SlayerModel.filters``)
+        with DERIVED refs inline-expanded and base refs qualified — the shared
+        core for the column-filter and model-filter render paths (DEV-1494).
+
+        If the predicate references a non-trivial derived column (bare, or — when
+        ``include_dotted_derived`` — a dotted ref to a derived column on a joined
+        model), it is inline-expanded via ``expand_derived_refs_sync`` so the
+        crossed joins resolve and no dangling ``<alias>.<derived_col>`` (a
+        non-physical column) survives — mirroring the query-level filter path.
+        Otherwise ``qualify_fallback(sql)`` does the cheap bare-ref qualification,
+        preserving each caller's exact non-derived output (regex for model
+        filters, AST for column filters). On sqlglot parse failure the predicate
+        falls through to ``qualify_fallback`` unchanged, so a dialect-specific
+        fragment never raises earlier than today. ``include_dotted_derived`` is
+        ``False`` for the cross-model ``_cm_*`` CTE target-filter path, which has
+        no mechanism to add a deeper join an expansion would cross (DEV-1503).
+        """
+        if not sql:
+            return None
+        if bundle is not None:
+            try:
+                parsed = self._parse_predicate(sql)
+            except Exception:
+                parsed = None
+            if parsed is not None and self._predicate_references_derived(
+                parsed=parsed, source_model=source_model, bundle=bundle,
+                include_dotted=include_dotted_derived,
+            ):
+                # Degenerate root: the whole predicate is a single column ref.
+                # ``expand_derived_refs_sync`` rewrites refs via in-place
+                # ``col.replace`` — a no-op on the AST root — so expand directly.
+                if isinstance(parsed, exp.Column) and not (
+                    parsed.args.get("db") or parsed.args.get("catalog")
+                ):
+                    tbl = parsed.args.get("table")
+                    if tbl is None:
+                        if self._is_nontrivial_derived(source_model, parsed.name):
+                            return self._expand_derived_column_sql(
+                                source_model=source_model,
+                                source_relation=source_relation,
+                                column_name=parsed.name,
+                                bundle=bundle,
+                            )
+                    elif include_dotted_derived:
+                        target, canonical = _walk_path_to_target_sync(
+                            source_model=source_model,
+                            source_alias=source_relation,
+                            table_alias=tbl.name,
+                            resolve_model=bundle.get_referenced_model,
+                            is_root=True,
+                        )
+                        if (
+                            target is not None
+                            and canonical is not None
+                            and self._is_nontrivial_derived(target, parsed.name)
+                        ):
+                            return self._expand_derived_column_sql(
+                                source_model=target,
+                                source_relation=canonical,
+                                column_name=parsed.name,
+                                bundle=bundle,
+                                is_root=False,
+                            )
+                expanded = expand_derived_refs_sync(
+                    sql=sql,
+                    model=source_model,
+                    alias_path=source_relation,
+                    resolve_model=bundle.get_referenced_model,
+                    dialect=self.dialect,
+                )
+                if expanded is not None:
+                    return expanded
+        return qualify_fallback(sql)
+
+    def _filter_join_paths(
+        self, *, sql: Optional[str], source_relation: str, source_model, bundle,
+    ) -> List[Tuple[str, ...]]:
+        """Join paths a Mode-A filter (``Column.filter`` / ``SlayerModel.filters``)
+        needs (DEV-1494).
+
+        Scans BOTH the un-inlined predicate — so a placeholder dotted ref
+        (``loss_payment.has_flag``, the dbt join-trigger idiom) keeps its alias
+        even when it inlines to a constant — AND the inline-expanded predicate —
+        so a bare/dotted DERIVED ref surfaces the joins its expansion crosses
+        (``is_eu`` → ``customers``; ``loss_payment.deep_flag`` →
+        ``loss_payment__claim``). The union is required because inlining drops the
+        placeholder alias while the raw form can't see a derived expansion's
+        crossed joins. Each parse is tolerant — an unparseable side yields no
+        paths rather than raising earlier than today.
+        """
+        if not sql:
+            return []
+        seen: set = set()
+        ordered: List[Tuple[str, ...]] = []
+
+        def _scan(text: Optional[str]) -> None:
+            if not text:
+                return
+            try:
+                parsed = self._parse_predicate(text)
+            except Exception:
+                return
+            for p in self._joined_paths_in_sql(
+                sql_expr=parsed, source_relation=source_relation,
+                source_model=source_model, bundle=bundle,
+            ):
+                if p not in seen:
+                    seen.add(p)
+                    ordered.append(p)
+
+        _scan(sql)
+        rendered = self._render_mode_a_predicate(
+            sql=sql, source_model=source_model, source_relation=source_relation,
+            bundle=bundle, qualify_fallback=lambda s: s,
+        )
+        if rendered is not None and rendered != sql:
+            _scan(rendered)
+        return ordered
+
+    def _expand_column_filter_sql(
+        self,
+        *,
+        canonical_sql: Optional[str],
+        source_relation: str,
+        source_model,
+        bundle=None,
+    ) -> Optional[str]:
+        """Render a ``Column.filter`` Mode-A predicate for the aggregation-time
+        CASE-WHEN wrapper (``SUM(CASE WHEN <filter> THEN col END)``). Inlines
+        derived refs (bare or dotted-to-joined-derived) so the crossed joins
+        resolve; otherwise qualifies bare refs. DEV-1494; see
+        ``_render_mode_a_predicate``.
+        """
+        if bundle is None:
+            return self._qualify_column_filter_sql(
+                canonical_sql=canonical_sql,
+                source_relation=source_relation,
+                source_model=source_model,
+            )
+        return self._render_mode_a_predicate(
+            sql=canonical_sql,
+            source_model=source_model,
+            source_relation=source_relation,
+            bundle=bundle,
+            qualify_fallback=lambda s: self._qualify_column_filter_sql(
+                canonical_sql=s,
+                source_relation=source_relation,
+                source_model=source_model,
+            ),
+        )
+
     def _build_from_clause_from_planned(
         self,
         *,
@@ -7499,18 +7718,19 @@ class SQLGenerator:
             if fp.expression is not None:
                 _walk(fp.expression.value_key)
             elif fp.text is not None:
-                # DEV-1450 #4b: expand the model-filter text first so a bare
-                # derived-column reference (e.g. ``is_eu`` whose sql crosses a
-                # join to ``customers``) surfaces the join its expansion
-                # introduces, pulling the LEFT JOIN into the FROM.
-                expanded_text = self._render_model_filter_sql(
-                    sql=fp.text,
-                    columns=fp.text_columns,
-                    source_model=source_model,
-                    source_relation=source_relation,
-                    bundle=bundle,
-                )
-                _add_from_sql(self._parse(expanded_text))
+                # DEV-1450 #4b / DEV-1494: discover joins from BOTH the
+                # un-inlined text (a placeholder dotted ref like
+                # ``loss_payment.has_flag`` keeps its alias even when it inlines
+                # to a constant) AND the inline-expanded text (a bare/dotted
+                # DERIVED ref like ``is_eu`` surfaces the join its expansion
+                # crosses). See ``_filter_join_paths``.
+                for p in self._filter_join_paths(
+                    sql=fp.text, source_relation=source_relation,
+                    source_model=source_model, bundle=bundle,
+                ):
+                    if p not in seen:
+                        seen.add(p)
+                        ordered.append(p)
         return ordered
 
     def _resolve_aggregation_def(
@@ -7711,7 +7931,7 @@ class SQLGenerator:
             # becomes ``orders.status = 'paid'``); mirror that here on the
             # parsed AST so dialect-independent wiring works in the new
             # pipeline.
-            filter_sql = self._qualify_column_filter_sql(
+            filter_sql = self._expand_column_filter_sql(
                 canonical_sql=(
                     key.column_filter_key.canonical_sql
                     if key.column_filter_key is not None
@@ -7719,6 +7939,7 @@ class SQLGenerator:
                 ),
                 source_relation=source_relation,
                 source_model=source_model,
+                bundle=bundle,
             )
             return AggRenderSpec(
                 name=col.name,
@@ -7908,48 +8129,28 @@ class SQLGenerator:
         source_relation: str,
         bundle,
     ) -> str:
-        """Render a ``SlayerModel.filters`` Mode-A SQL predicate (DEV-1450 #4b).
+        """Render a ``SlayerModel.filters`` Mode-A SQL predicate (DEV-1450 #4b /
+        DEV-1494).
 
-        If any name in ``columns`` is a non-trivial DERIVED column on
-        ``source_model``, the whole predicate is inline-expanded via
-        ``expand_derived_refs_sync`` (AST-based — it also qualifies bare base
-        refs and resolves sibling / joined derived refs). Otherwise the
-        base-only path (``_qualify_mode_a_sql_filter``) is used unchanged.
+        Inlines references to non-trivial derived columns — bare on
+        ``source_model`` or dotted-to-a-derived-column-on-a-joined-model — so the
+        crossed joins resolve; otherwise qualifies bare base refs via the regex
+        path (``_qualify_mode_a_sql_filter``), byte-identical to legacy. Thin
+        wrapper over ``_render_mode_a_predicate``.
         """
-        if any(
-            self._is_nontrivial_derived(source_model, c) for c in columns
-        ):
-            # Degenerate case: the whole predicate IS a single bare derived
-            # column (``filters=["is_eu"]``). It parses to a root ``exp.Column``,
-            # and ``expand_derived_refs_sync`` rewrites refs in place via
-            # ``col.replace`` — which is a no-op on the AST root. Expand the
-            # column directly so the bare boolean derived filter still inlines.
-            parsed_ast = self._parse(sql)
-            if (
-                isinstance(parsed_ast, exp.Column)
-                and parsed_ast.args.get("table") is None
-                and self._is_nontrivial_derived(source_model, parsed_ast.name)
-            ):
-                return self._expand_derived_column_sql(
-                    source_model=source_model,
-                    source_relation=source_relation,
-                    column_name=parsed_ast.name,
-                    bundle=bundle,
-                )
-            expanded = expand_derived_refs_sync(
-                sql=sql,
-                model=source_model,
-                alias_path=source_relation,
-                resolve_model=bundle.get_referenced_model,
-                dialect=self.dialect,
-            )
-            return expanded if expanded is not None else sql
-        return self._qualify_mode_a_sql_filter(
+        rendered = self._render_mode_a_predicate(
             sql=sql,
-            columns=columns,
             source_model=source_model,
             source_relation=source_relation,
+            bundle=bundle,
+            qualify_fallback=lambda s: self._qualify_mode_a_sql_filter(
+                sql=s,
+                columns=columns,
+                source_model=source_model,
+                source_relation=source_relation,
+            ),
         )
+        return rendered if rendered is not None else sql
 
     def _render_value_key_for_filter(
         self,

--- a/tests/test_cross_model_derived_columns.py
+++ b/tests/test_cross_model_derived_columns.py
@@ -1164,10 +1164,11 @@ async def test_dev1334_column_level_filter_attribute_with_cross_table_ref_adds_j
     assert _no_bare_derived_ref(sql, "orders", "is_eu"), (
         f"derived ref ``orders.is_eu`` left un-inlined in column filter:\n{sql}"
     )
-    # The expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
-    # ``[^"]*`` (not ``.*``) keeps the match bounded to before the quoted alias
-    # and avoids the polynomial-backtracking the ``.*X.*`` form trips (S5852).
-    assert re.search(r'SUM\(\s*CASE WHEN [^"]*customers\.region[^"]*THEN orders\.amount', _norm(sql)), (
+    # The expansion lives INSIDE the aggregation-time CASE-WHEN wrapper. A single
+    # bounded ``[^"]*`` segment (plus a substring check for the THEN clause)
+    # avoids the multi-quantifier ReDoS pattern S5852 flags.
+    n = _norm(sql)
+    assert re.search(r'SUM\(\s*CASE WHEN [^"]*customers\.region', n) and "THEN orders.amount" in n, (
         f"is_eu expansion not inside SUM(CASE WHEN ... THEN orders.amount):\n{sql}"
     )
 
@@ -1288,11 +1289,15 @@ async def test_dev1494_column_filter_dotted_derived_ref_crossing_further_join(
     assert _no_bare_derived_ref(sql, "loss_payment", "deep_flag"), (
         f"dotted derived ref ``loss_payment.deep_flag`` left un-inlined:\n{sql}"
     )
-    # The deeper expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
-    # ``[^"]*`` (not ``.*``) keeps the match bounded and backtracking-free (S5852).
+    # The deeper expansion lives INSIDE the aggregation-time CASE-WHEN wrapper. A
+    # single bounded ``[^"]*`` segment (plus a substring check for the THEN
+    # clause) avoids the multi-quantifier ReDoS pattern S5852 flags.
+    n = _norm(sql)
     assert re.search(
-        r'SUM\(\s*CASE WHEN [^"]*loss_payment__claim\.state[^"]*THEN claim_amount\.amount', _norm(sql),
-    ), f"deep_flag expansion not inside SUM(CASE WHEN ... THEN claim_amount.amount):\n{sql}"
+        r'SUM\(\s*CASE WHEN [^"]*loss_payment__claim\.state', n,
+    ) and "THEN claim_amount.amount" in n, (
+        f"deep_flag expansion not inside SUM(CASE WHEN ... THEN claim_amount.amount):\n{sql}"
+    )
 
 
 async def test_dev1494_model_filter_dotted_derived_ref_inlined(tmp_path) -> None:

--- a/tests/test_cross_model_derived_columns.py
+++ b/tests/test_cross_model_derived_columns.py
@@ -1126,22 +1126,16 @@ async def test_dev1334_model_level_filter_on_bare_derived_col_with_cross_table_s
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "DEV-1494: the typed pipeline does not inline a derived cross-table "
-        "ref used in a column-level Column.filter, so the crossed join is not "
-        "pulled into the FROM. Auto-promotes to PASS when DEV-1494 is fixed. "
-        "(Query-level filters already work; the dimension case was fixed in "
-        "DEV-1484.)"
-    ),
-)
 async def test_dev1334_column_level_filter_attribute_with_cross_table_ref_adds_join(
     tmp_path,
 ) -> None:
     """A column-level ``filter=`` attribute that references a bare-named
     local derived column whose sql crosses a join — must trigger join
-    discovery via the ``m.filter_columns`` path.
+    discovery via the ``m.filter_columns`` path (DEV-1494).
+
+    Strengthened beyond join-presence: the derived ref must also be INLINED
+    into the aggregation-time CASE-WHEN wrapper, so no bare ``orders.is_eu``
+    (a derived column, not a physical one) survives in the emitted SQL.
     """
     storage = await _orders_customers_storage(tmp_path)
     orders = await _save_orders_with_is_eu(
@@ -1165,6 +1159,319 @@ async def test_dev1334_column_level_filter_attribute_with_cross_table_ref_adds_j
     assert "customers" in _join_aliases(sql), (
         f"customers join not discovered from column-level filter=:\n{sql}"
     )
+    # The derived ref is inlined to its cross-table sql; ``orders.is_eu`` is
+    # not a physical column and must not leak into the CASE-WHEN wrapper.
+    assert _no_bare_derived_ref(sql, "orders", "is_eu"), (
+        f"derived ref ``orders.is_eu`` left un-inlined in column filter:\n{sql}"
+    )
+    # The expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
+    assert re.search(r"SUM\(\s*CASE WHEN .*customers\.region.* THEN orders\.amount", _norm(sql)), (
+        f"is_eu expansion not inside SUM(CASE WHEN ... THEN orders.amount):\n{sql}"
+    )
+
+
+async def test_dev1494_column_filter_dotted_base_ref_adds_join(tmp_path) -> None:
+    """Column-level ``filter=`` with a DIRECT dotted ref to a *base* column on
+    a joined model (``loss_payment.status``) must pull the join in, and the
+    ref stays a valid qualified column reference (no inlining needed).
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="status", sql="status", type=DataType.TEXT),
+        ],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="loss_amt", sql="amount", filter="loss_payment.status = 'paid'", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="loss_amt:sum", name="amt")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    assert "loss_payment" in _join_aliases(sql), (
+        f"loss_payment join not discovered from dotted-base column filter:\n{sql}"
+    )
+    # status is a real (base) column on loss_payment — the qualified ref stays.
+    assert "loss_payment.status" in sql, f"qualified base ref dropped:\n{sql}"
+
+
+async def test_dev1494_column_filter_dotted_derived_ref_crossing_further_join(
+    tmp_path,
+) -> None:
+    """Column-level ``filter=`` with a dotted ref to a *derived* column on a
+    joined model, whose own sql crosses a FURTHER join. The deeper join must
+    be discovered (``loss_payment__claim``) AND the derived ref inlined — no
+    dangling ``loss_payment.deep_flag`` (not a physical column).
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="claim", data_source="test", sql_table="Claim",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="state", sql="state", type=DataType.TEXT),
+        ],
+    ))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="claim_id", sql="claim_id", type=DataType.DOUBLE),
+            # Derived column on the joined model whose sql reaches a further join.
+            Column(name="deep_flag", sql="CASE WHEN claim.state = 'open' THEN 1 ELSE 0 END", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="claim", join_pairs=[["claim_id", "id"]])],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="deep_amt", sql="amount", filter="loss_payment.deep_flag = 1", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="deep_amt:sum", name="amt")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    aliases = _join_aliases(sql)
+    assert "loss_payment" in aliases, f"intermediate loss_payment join missing: {aliases}\nSQL:\n{sql}"
+    assert "loss_payment__claim" in aliases, f"deeper claim join missing: {aliases}\nSQL:\n{sql}"
+    # deep_flag is derived — must be inlined, not emitted as a dangling ref.
+    assert _no_bare_derived_ref(sql, "loss_payment", "deep_flag"), (
+        f"dotted derived ref ``loss_payment.deep_flag`` left un-inlined:\n{sql}"
+    )
+    # The deeper expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
+    assert re.search(
+        r"SUM\(\s*CASE WHEN .*loss_payment__claim\.state.* THEN claim_amount\.amount", _norm(sql),
+    ), f"deep_flag expansion not inside SUM(CASE WHEN ... THEN claim_amount.amount):\n{sql}"
+
+
+async def test_dev1494_model_filter_dotted_derived_ref_inlined(tmp_path) -> None:
+    """Apply-everywhere: a ``SlayerModel.filters`` entry with a dotted ref to a
+    *derived* column on a joined model (the dbt placeholder-join idiom,
+    ``has_flag sql="1"``) must keep the join AND inline the ref — matching the
+    query-level path's ``WHERE (1) = 1`` (no dangling ``loss_payment.has_flag``).
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="has_flag", sql="1", type=DataType.DOUBLE),
+        ],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="amount", sql="amount", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]], join_type="inner")],
+        filters=["loss_payment.has_flag = 1"],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="amount:sum", name="amt")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    assert "loss_payment" in _join_aliases(sql), (
+        f"placeholder join not kept for model-filter has_flag idiom:\n{sql}"
+    )
+    assert _no_bare_derived_ref(sql, "loss_payment", "has_flag"), (
+        f"derived ref ``loss_payment.has_flag`` left un-inlined in model filter:\n{sql}"
+    )
+    # The predicate inlines to a constant comparison in the WHERE clause
+    # (matching the query-level path's ``WHERE (1) = 1`` / ``CAST(1 AS …) = 1``).
+    assert re.search(r"WHERE\b.*=\s*1\b", _norm(sql)), (
+        f"model filter did not inline to a constant WHERE comparison:\n{sql}"
+    )
+
+
+async def test_dev1494_column_filter_does_not_disturb_sibling_unfiltered_measure(
+    tmp_path,
+) -> None:
+    """The join a column-level filter pulls into the BASE FROM must not change
+    a sibling UNfiltered measure's value, for a many:1 (PK-side) join. Pins
+    that base-FROM join insertion is deliberate and cardinality-safe here;
+    one-to-many isolation remains DEV-1503 (tracked separately, still xfail).
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="status", sql="status", type=DataType.TEXT),
+        ],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="total_amt", sql="amount", type=DataType.DOUBLE),
+            Column(name="paid_amt", sql="amount", filter="loss_payment.status = 'paid'", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[
+            ModelMeasure(formula="total_amt:sum", name="total"),
+            ModelMeasure(formula="paid_amt:sum", name="paid"),
+        ],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    # The unfiltered measure is a plain SUM over the base column, unguarded by
+    # any CASE-WHEN — adding the LEFT JOIN for the filtered sibling must not
+    # wrap it in the filter predicate.
+    assert re.search(r"SUM\(\s*claim_amount\.amount\s*\)", sql), (
+        f"unfiltered measure no longer a plain SUM(amount):\n{sql}"
+    )
+    assert "loss_payment" in _join_aliases(sql), f"filtered-measure join missing:\n{sql}"
+
+
+async def test_dev1494_column_filter_exists_subquery_ref_not_scanned_for_joins(
+    tmp_path,
+) -> None:
+    """Documenting test (DEV-1494 / C7): join discovery is root-scope-only by
+    design. A correlated ref inside an ``EXISTS (...)`` subquery in a
+    ``Column.filter`` is NOT scanned for outer joins — so no join is pulled in
+    for the inner-scope alias. Pins the current (intentional) limitation.
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="status", sql="status", type=DataType.TEXT),
+        ],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            # Inner-scope ``loss_payment`` ref lives inside a subquery; it must
+            # not pull an outer LEFT JOIN loss_payment into the base FROM.
+            Column(
+                name="exists_amt", sql="amount",
+                filter="EXISTS (SELECT 1 FROM Loss_Payment AS loss_payment WHERE loss_payment.status = 'paid')",
+                type=DataType.DOUBLE,
+            ),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="exists_amt:sum", name="amt")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    # No OUTER join to loss_payment is added from the inner-scope ref.
+    assert "loss_payment" not in _join_aliases(sql), (
+        f"inner-scope EXISTS ref wrongly pulled an outer join:\n{sql}"
+    )
+
+
+async def test_dev1494_column_filter_constant_placeholder_join_kept_sqlite(
+    tmp_path,
+) -> None:
+    """SQLite coverage of the dbt placeholder-join idiom at the COLUMN level:
+    ``filter="loss_payment.has_flag = 1"`` (has_flag derived ``sql="1"``) keeps
+    the join and inlines the ref to a constant inside the CASE-WHEN wrapper.
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="has_flag", sql="1", type=DataType.DOUBLE),
+        ],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="loss_amt", sql="amount", filter="loss_payment.has_flag = 1", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]], join_type="inner")],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="loss_amt:sum", name="amt")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    assert "loss_payment" in _join_aliases(sql), f"placeholder join not kept:\n{sql}"
+    assert _no_bare_derived_ref(sql, "loss_payment", "has_flag"), (
+        f"derived ref ``loss_payment.has_flag`` left un-inlined:\n{sql}"
+    )
+    # Inlined constant lives inside the aggregation-time CASE-WHEN wrapper.
+    assert re.search(r"SUM\(\s*CASE WHEN .*THEN claim_amount\.amount", _norm(sql)), (
+        f"column filter not rendered as SUM(CASE WHEN ... THEN col):\n{sql}"
+    )
+
+
+async def test_dev1494_column_filter_multihop_dotted_input_adds_all_joins(
+    tmp_path,
+) -> None:
+    """A column-level ``filter=`` whose ref is a canonical ``__``-delimited
+    MULTI-HOP alias to a base column (``loss_payment__claim.state``) — both the
+    intermediate (``loss_payment``) and full (``loss_payment__claim``) joins
+    must be pulled in, and the qualified base ref stays valid.
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="claim", data_source="test", sql_table="Claim",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="state", sql="state", type=DataType.TEXT),
+        ],
+    ))
+    await storage.save_model(SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            Column(name="claim_id", sql="claim_id", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="claim", join_pairs=[["claim_id", "id"]])],
+    ))
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="amt", sql="amount", filter="loss_payment__claim.state = 'open'", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="claim_amount",
+        measures=[ModelMeasure(formula="amt:sum", name="a")],
+    )
+    sql = await _gen_sql(engine, query, claim_amount)
+    aliases = _join_aliases(sql)
+    assert "loss_payment" in aliases, f"intermediate join missing: {aliases}\nSQL:\n{sql}"
+    assert "loss_payment__claim" in aliases, f"multi-hop join missing: {aliases}\nSQL:\n{sql}"
+    assert "loss_payment__claim.state" in sql, f"qualified multi-hop base ref dropped:\n{sql}"
 
 
 async def test_dev1334_filter_with_mixed_dotted_and_bare_derived_refs(tmp_path) -> None:

--- a/tests/test_cross_model_derived_columns.py
+++ b/tests/test_cross_model_derived_columns.py
@@ -1165,8 +1165,66 @@ async def test_dev1334_column_level_filter_attribute_with_cross_table_ref_adds_j
         f"derived ref ``orders.is_eu`` left un-inlined in column filter:\n{sql}"
     )
     # The expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
-    assert re.search(r"SUM\(\s*CASE WHEN .*customers\.region.* THEN orders\.amount", _norm(sql)), (
+    # ``[^"]*`` (not ``.*``) keeps the match bounded to before the quoted alias
+    # and avoids the polynomial-backtracking the ``.*X.*`` form trips (S5852).
+    assert re.search(r'SUM\(\s*CASE WHEN [^"]*customers\.region[^"]*THEN orders\.amount', _norm(sql)), (
         f"is_eu expansion not inside SUM(CASE WHEN ... THEN orders.amount):\n{sql}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures for the DEV-1494 column-filter / model-filter companions.
+# ``claim_amount`` joins ``loss_payment`` on its PK; callers vary the columns,
+# joins, filters, and measures. Centralising the save/engine/query scaffold
+# keeps these tests free of the duplicated boilerplate Sonar flags.
+# ---------------------------------------------------------------------------
+
+_CLAIM_LP_JOIN = ModelJoin(
+    target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]],
+)
+_CLAIM_LP_JOIN_INNER = ModelJoin(
+    target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]],
+    join_type="inner",
+)
+
+
+def _loss_payment_model(*, extra_columns, joins=None) -> SlayerModel:
+    """The canonical ``loss_payment`` join target (PK ``id`` =
+    ``Claim_Amount_Identifier``); callers add the columns / joins each test needs.
+    """
+    return SlayerModel(
+        name="loss_payment", data_source="test", sql_table="Loss_Payment",
+        columns=[
+            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+            *extra_columns,
+        ],
+        joins=list(joins or []),
+    )
+
+
+async def _claim_amount_filter_sql(
+    tmp_path, *, claim_columns, measures, claim_joins=(_CLAIM_LP_JOIN,),
+    claim_filters=None, extra_models=(),
+) -> str:
+    """Save ``claim_amount`` (PK ``id`` auto-prepended) plus any extra join-target
+    models, run a query through the typed pipeline, and return the emitted SQL.
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    for model in extra_models:
+        await storage.save_model(model)
+    claim_amount = SlayerModel(
+        name="claim_amount", data_source="test", sql_table="Claim_Amount",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            *claim_columns,
+        ],
+        joins=list(claim_joins),
+        filters=list(claim_filters or []),
+    )
+    await storage.save_model(claim_amount)
+    engine = SlayerQueryEngine(storage=storage)
+    return await _gen_sql(
+        engine, SlayerQuery(source_model="claim_amount", measures=measures), claim_amount,
     )
 
 
@@ -1175,29 +1233,16 @@ async def test_dev1494_column_filter_dotted_base_ref_adds_join(tmp_path) -> None
     a joined model (``loss_payment.status``) must pull the join in, and the
     ref stays a valid qualified column reference (no inlining needed).
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
             Column(name="status", sql="status", type=DataType.TEXT),
-        ],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+        ])],
+        claim_columns=[
             Column(name="loss_amt", sql="amount", filter="loss_payment.status = 'paid'", type=DataType.DOUBLE),
         ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
         measures=[ModelMeasure(formula="loss_amt:sum", name="amt")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     assert "loss_payment" in _join_aliases(sql), (
         f"loss_payment join not discovered from dotted-base column filter:\n{sql}"
     )
@@ -1213,39 +1258,29 @@ async def test_dev1494_column_filter_dotted_derived_ref_crossing_further_join(
     be discovered (``loss_payment__claim``) AND the derived ref inlined — no
     dangling ``loss_payment.deep_flag`` (not a physical column).
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
+    claim = SlayerModel(
         name="claim", data_source="test", sql_table="Claim",
         columns=[
             Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
             Column(name="state", sql="state", type=DataType.TEXT),
         ],
-    ))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    )
+    loss_payment = _loss_payment_model(
+        extra_columns=[
             Column(name="claim_id", sql="claim_id", type=DataType.DOUBLE),
             # Derived column on the joined model whose sql reaches a further join.
             Column(name="deep_flag", sql="CASE WHEN claim.state = 'open' THEN 1 ELSE 0 END", type=DataType.DOUBLE),
         ],
         joins=[ModelJoin(target_model="claim", join_pairs=[["claim_id", "id"]])],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+    )
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[claim, loss_payment],
+        claim_columns=[
             Column(name="deep_amt", sql="amount", filter="loss_payment.deep_flag = 1", type=DataType.DOUBLE),
         ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
         measures=[ModelMeasure(formula="deep_amt:sum", name="amt")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     aliases = _join_aliases(sql)
     assert "loss_payment" in aliases, f"intermediate loss_payment join missing: {aliases}\nSQL:\n{sql}"
     assert "loss_payment__claim" in aliases, f"deeper claim join missing: {aliases}\nSQL:\n{sql}"
@@ -1254,8 +1289,9 @@ async def test_dev1494_column_filter_dotted_derived_ref_crossing_further_join(
         f"dotted derived ref ``loss_payment.deep_flag`` left un-inlined:\n{sql}"
     )
     # The deeper expansion lives INSIDE the aggregation-time CASE-WHEN wrapper.
+    # ``[^"]*`` (not ``.*``) keeps the match bounded and backtracking-free (S5852).
     assert re.search(
-        r"SUM\(\s*CASE WHEN .*loss_payment__claim\.state.* THEN claim_amount\.amount", _norm(sql),
+        r'SUM\(\s*CASE WHEN [^"]*loss_payment__claim\.state[^"]*THEN claim_amount\.amount', _norm(sql),
     ), f"deep_flag expansion not inside SUM(CASE WHEN ... THEN claim_amount.amount):\n{sql}"
 
 
@@ -1265,30 +1301,16 @@ async def test_dev1494_model_filter_dotted_derived_ref_inlined(tmp_path) -> None
     ``has_flag sql="1"``) must keep the join AND inline the ref — matching the
     query-level path's ``WHERE (1) = 1`` (no dangling ``loss_payment.has_flag``).
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
             Column(name="has_flag", sql="1", type=DataType.DOUBLE),
-        ],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
-            Column(name="amount", sql="amount", type=DataType.DOUBLE),
-        ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]], join_type="inner")],
-        filters=["loss_payment.has_flag = 1"],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
+        ])],
+        claim_columns=[Column(name="amount", sql="amount", type=DataType.DOUBLE)],
+        claim_joins=[_CLAIM_LP_JOIN_INNER],
+        claim_filters=["loss_payment.has_flag = 1"],
         measures=[ModelMeasure(formula="amount:sum", name="amt")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     assert "loss_payment" in _join_aliases(sql), (
         f"placeholder join not kept for model-filter has_flag idiom:\n{sql}"
     )
@@ -1297,7 +1319,7 @@ async def test_dev1494_model_filter_dotted_derived_ref_inlined(tmp_path) -> None
     )
     # The predicate inlines to a constant comparison in the WHERE clause
     # (matching the query-level path's ``WHERE (1) = 1`` / ``CAST(1 AS …) = 1``).
-    assert re.search(r"WHERE\b.*=\s*1\b", _norm(sql)), (
+    assert re.search(r"WHERE\b[^\"]*=\s*1\b", _norm(sql)), (
         f"model filter did not inline to a constant WHERE comparison:\n{sql}"
     )
 
@@ -1310,37 +1332,24 @@ async def test_dev1494_column_filter_does_not_disturb_sibling_unfiltered_measure
     that base-FROM join insertion is deliberate and cardinality-safe here;
     one-to-many isolation remains DEV-1503 (tracked separately, still xfail).
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
             Column(name="status", sql="status", type=DataType.TEXT),
-        ],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+        ])],
+        claim_columns=[
             Column(name="total_amt", sql="amount", type=DataType.DOUBLE),
             Column(name="paid_amt", sql="amount", filter="loss_payment.status = 'paid'", type=DataType.DOUBLE),
         ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
         measures=[
             ModelMeasure(formula="total_amt:sum", name="total"),
             ModelMeasure(formula="paid_amt:sum", name="paid"),
         ],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     # The unfiltered measure is a plain SUM over the base column, unguarded by
     # any CASE-WHEN — adding the LEFT JOIN for the filtered sibling must not
     # wrap it in the filter predicate.
-    assert re.search(r"SUM\(\s*claim_amount\.amount\s*\)", sql), (
+    assert re.search(r"SUM\(\s*claim_amount\.amount\s*\)", _norm(sql)), (
         f"unfiltered measure no longer a plain SUM(amount):\n{sql}"
     )
     assert "loss_payment" in _join_aliases(sql), f"filtered-measure join missing:\n{sql}"
@@ -1354,35 +1363,20 @@ async def test_dev1494_column_filter_exists_subquery_ref_not_scanned_for_joins(
     ``Column.filter`` is NOT scanned for outer joins — so no join is pulled in
     for the inner-scope alias. Pins the current (intentional) limitation.
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
             Column(name="status", sql="status", type=DataType.TEXT),
-        ],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
-            # Inner-scope ``loss_payment`` ref lives inside a subquery; it must
-            # not pull an outer LEFT JOIN loss_payment into the base FROM.
-            Column(
-                name="exists_amt", sql="amount",
-                filter="EXISTS (SELECT 1 FROM Loss_Payment AS loss_payment WHERE loss_payment.status = 'paid')",
-                type=DataType.DOUBLE,
-            ),
-        ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
+        ])],
+        # Inner-scope ``loss_payment`` ref lives inside a subquery; it must not
+        # pull an outer LEFT JOIN loss_payment into the base FROM.
+        claim_columns=[Column(
+            name="exists_amt", sql="amount",
+            filter="EXISTS (SELECT 1 FROM Loss_Payment AS loss_payment WHERE loss_payment.status = 'paid')",
+            type=DataType.DOUBLE,
+        )],
         measures=[ModelMeasure(formula="exists_amt:sum", name="amt")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     # No OUTER join to loss_payment is added from the inner-scope ref.
     assert "loss_payment" not in _join_aliases(sql), (
         f"inner-scope EXISTS ref wrongly pulled an outer join:\n{sql}"
@@ -1396,35 +1390,23 @@ async def test_dev1494_column_filter_constant_placeholder_join_kept_sqlite(
     ``filter="loss_payment.has_flag = 1"`` (has_flag derived ``sql="1"``) keeps
     the join and inlines the ref to a constant inside the CASE-WHEN wrapper.
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
             Column(name="has_flag", sql="1", type=DataType.DOUBLE),
-        ],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+        ])],
+        claim_columns=[
             Column(name="loss_amt", sql="amount", filter="loss_payment.has_flag = 1", type=DataType.DOUBLE),
         ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]], join_type="inner")],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
+        claim_joins=[_CLAIM_LP_JOIN_INNER],
         measures=[ModelMeasure(formula="loss_amt:sum", name="amt")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     assert "loss_payment" in _join_aliases(sql), f"placeholder join not kept:\n{sql}"
     assert _no_bare_derived_ref(sql, "loss_payment", "has_flag"), (
         f"derived ref ``loss_payment.has_flag`` left un-inlined:\n{sql}"
     )
     # Inlined constant lives inside the aggregation-time CASE-WHEN wrapper.
-    assert re.search(r"SUM\(\s*CASE WHEN .*THEN claim_amount\.amount", _norm(sql)), (
+    assert re.search(r'SUM\(\s*CASE WHEN [^"]*THEN claim_amount\.amount', _norm(sql)), (
         f"column filter not rendered as SUM(CASE WHEN ... THEN col):\n{sql}"
     )
 
@@ -1437,41 +1419,105 @@ async def test_dev1494_column_filter_multihop_dotted_input_adds_all_joins(
     intermediate (``loss_payment``) and full (``loss_payment__claim``) joins
     must be pulled in, and the qualified base ref stays valid.
     """
-    storage = YAMLStorage(base_dir=str(tmp_path))
-    await storage.save_model(SlayerModel(
+    claim = SlayerModel(
         name="claim", data_source="test", sql_table="Claim",
         columns=[
             Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
             Column(name="state", sql="state", type=DataType.TEXT),
         ],
-    ))
-    await storage.save_model(SlayerModel(
-        name="loss_payment", data_source="test", sql_table="Loss_Payment",
-        columns=[
-            Column(name="id", sql="Claim_Amount_Identifier", type=DataType.DOUBLE, primary_key=True),
-            Column(name="claim_id", sql="claim_id", type=DataType.DOUBLE),
-        ],
+    )
+    loss_payment = _loss_payment_model(
+        extra_columns=[Column(name="claim_id", sql="claim_id", type=DataType.DOUBLE)],
         joins=[ModelJoin(target_model="claim", join_pairs=[["claim_id", "id"]])],
-    ))
-    claim_amount = SlayerModel(
-        name="claim_amount", data_source="test", sql_table="Claim_Amount",
-        columns=[
-            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+    )
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[claim, loss_payment],
+        claim_columns=[
             Column(name="amt", sql="amount", filter="loss_payment__claim.state = 'open'", type=DataType.DOUBLE),
         ],
-        joins=[ModelJoin(target_model="loss_payment", join_pairs=[["id", "Claim_Amount_Identifier"]])],
-    )
-    await storage.save_model(claim_amount)
-    engine = SlayerQueryEngine(storage=storage)
-    query = SlayerQuery(
-        source_model="claim_amount",
         measures=[ModelMeasure(formula="amt:sum", name="a")],
     )
-    sql = await _gen_sql(engine, query, claim_amount)
     aliases = _join_aliases(sql)
     assert "loss_payment" in aliases, f"intermediate join missing: {aliases}\nSQL:\n{sql}"
     assert "loss_payment__claim" in aliases, f"multi-hop join missing: {aliases}\nSQL:\n{sql}"
     assert "loss_payment__claim.state" in sql, f"qualified multi-hop base ref dropped:\n{sql}"
+
+
+async def test_dev1494_column_filter_join_discovered_in_composite_measure(
+    tmp_path,
+) -> None:
+    """A cross-table-filtered aggregate nested in a COMPOSITE measure
+    (``paid_amt:sum + total_amt:sum``) must still pull its ``Column.filter`` join
+    into the FROM. The slot key is an ``ArithmeticKey`` (rendered by
+    ``_render_aggregate_composite_expr``), so join discovery must recurse into
+    aggregate operands — naive top-level-only discovery would miss it.
+    """
+    sql = await _claim_amount_filter_sql(
+        tmp_path,
+        extra_models=[_loss_payment_model(extra_columns=[
+            Column(name="status", sql="status", type=DataType.TEXT),
+        ])],
+        claim_columns=[
+            Column(name="total_amt", sql="amount", type=DataType.DOUBLE),
+            Column(name="paid_amt", sql="amount", filter="loss_payment.status = 'paid'", type=DataType.DOUBLE),
+        ],
+        measures=[ModelMeasure(formula="paid_amt:sum + total_amt:sum", name="combo")],
+    )
+    assert "loss_payment" in _join_aliases(sql), (
+        f"composite-measure filtered-aggregate join not discovered:\n{sql}"
+    )
+    # The filter's base ref resolves against the now-joined table.
+    assert "loss_payment.status" in sql, f"filter ref not resolved in composite:\n{sql}"
+
+
+async def test_dev1494_cross_model_cte_target_filter_adds_join(tmp_path) -> None:
+    """A CROSS-MODEL aggregate whose TARGET column carries a ``Column.filter``
+    crossing one of the target's own joins must pull that join into the isolated
+    ``_cm_*`` CTE — otherwise the CASE-WHEN references an undefined alias. The
+    ``_cm_*`` CTE is already a per-measure isolated computation, so adding the
+    join there resolves the filter without affecting sibling measures.
+    """
+    storage = YAMLStorage(base_dir=str(tmp_path))
+    await storage.save_model(SlayerModel(
+        name="regions", data_source="test", sql_table="regions",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="is_premium", sql="is_premium", type=DataType.DOUBLE),
+        ],
+    ))
+    await storage.save_model(SlayerModel(
+        name="customers", data_source="test", sql_table="customers",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="region_id", sql="region_id", type=DataType.DOUBLE),
+            Column(name="revenue", sql="revenue", type=DataType.DOUBLE),
+            # Cross-model target column whose Column.filter crosses customers→regions.
+            Column(name="premium_rev", sql="revenue", filter="regions.is_premium = 1", type=DataType.DOUBLE),
+        ],
+        joins=[ModelJoin(target_model="regions", join_pairs=[["region_id", "id"]])],
+    ))
+    orders = SlayerModel(
+        name="orders", data_source="test", sql_table="orders",
+        columns=[
+            Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+            Column(name="customer_id", sql="customer_id", type=DataType.DOUBLE),
+            Column(name="status", sql="status", type=DataType.TEXT),
+        ],
+        joins=[ModelJoin(target_model="customers", join_pairs=[["customer_id", "id"]])],
+    )
+    await storage.save_model(orders)
+    engine = SlayerQueryEngine(storage=storage)
+    query = SlayerQuery(
+        source_model="orders",
+        dimensions=[ColumnRef(name="status")],
+        measures=[ModelMeasure(formula="customers.premium_rev:sum", name="prem")],
+    )
+    sql = await _gen_sql(engine, query, orders)
+    assert "regions" in _join_aliases(sql), (
+        f"cross-model target-filter join missing from _cm_ CTE:\n{sql}"
+    )
+    assert "regions.is_premium" in sql, f"target filter ref not resolved:\n{sql}"
 
 
 async def test_dev1334_filter_with_mixed_dotted_and_bare_derived_refs(tmp_path) -> None:

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -122,10 +122,10 @@ _XFAIL_FM_ISOLATION = pytest.mark.xfail(
     strict=True,
     reason=(
         "DEV-1503: the typed pipeline has no isolated-CTE handling for "
-        "cross-model-FILTERED local measures (the legacy `_fm_` feature). It "
-        "emits inline CASE WHEN with the filter joins undiscovered (DEV-1494), "
-        "so the SQL is currently broken, and these tests assert the legacy "
-        "`_fm_`/`_base`/ROW_NUMBER structure that the typed shape won't "
+        "cross-model-FILTERED local measures (the legacy `_fm_` feature). The "
+        "filter joins ARE now discovered (DEV-1494), but the measure is not "
+        "isolated — it emits an inline CASE WHEN, and these tests assert the "
+        "legacy `_fm_`/`_base`/ROW_NUMBER structure that the typed shape won't "
         "reproduce. Stage-D blocker: the legacy generate(enriched=) path is "
         "the only working implementation. These assertions will need updating "
         "when the feature is reimplemented (they do not cleanly auto-promote)."
@@ -3283,15 +3283,6 @@ class TestFilteredMeasures:
             extra_models=[customers], validate=False,
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "DEV-1494: a cross-table ref in a Column.filter doesn't pull the "
-            "LEFT JOIN into the filtered-last ranked subquery, so the emitted "
-            "SQL references customers.status without the join. Auto-promotes "
-            "when join discovery from Column.filter is fixed."
-        ),
-    )
     async def test_filtered_last_with_cross_model_filter_carries_join(
         self, generator: SQLGenerator,
     ) -> None:
@@ -3325,8 +3316,11 @@ class TestFilteredMeasures:
     @pytest.mark.xfail(
         strict=True,
         reason=(
-            "DEV-1494: cross-table ref in Column.filter doesn't pull the join "
-            "into the filtered-last ranked subquery. Auto-promotes when fixed."
+            "DEV-1503: the filter join is now discovered (DEV-1494), but the "
+            "typed pipeline does not isolate a cross-model-FILTERED first/last "
+            "measure into its own `_fm_`/`_last_rn` ranked CTE — this test "
+            "asserts that legacy isolated-CTE structure, which the typed shape "
+            "won't reproduce until the feature is reimplemented."
         ),
     )
     async def test_filtered_last_cross_model_isolates_to_cte_with_ranked_subquery(
@@ -5219,20 +5213,16 @@ Column(name="revenue", sql="amount", type=DataType.DOUBLE)],
 class TestMeasureFilterCrossModelJoin:
     """Measure filters referencing cross-model dimensions must trigger the join."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "DEV-1494: a column-level Column.filter with a cross-table ref "
-            "(here the direct dotted ref 'loss_payment.has_flag = 1') does not "
-            "trigger transitive join discovery on the typed pipeline — the "
-            "CASE-WHEN wrapper emits 'loss_payment.has_flag' but no LEFT JOIN "
-            "to Loss_Payment is added. Same root cause / fix as the derived-ref "
-            "variant DEV-1494 tracks. Auto-promotes when column-level-filter "
-            "join discovery is restored."
-        ),
-    )
     async def test_measure_filter_cross_model_constant_triggers_join(self, generator: SQLGenerator) -> None:
-        """Measure filter 'loss_payment.has_flag = 1' where has_flag sql='1' must JOIN to loss_payment."""
+        """Measure filter 'loss_payment.has_flag = 1' where has_flag sql='1' must JOIN to loss_payment.
+
+        DEV-1494 / dbt placeholder-join idiom: ``has_flag sql="1"`` is a constant
+        whose only purpose is to force the join (the join, not the predicate
+        value, does the filtering). So the join must be KEPT, while the derived
+        ref is INLINED for runnable SQL — matching the query-level path's
+        ``WHERE CAST(1 AS REAL) = 1``. ``loss_payment.has_flag`` is a derived
+        column, not a physical one, so it must not survive in the output.
+        """
 
         loss_payment = SlayerModel(
             name="loss_payment",
@@ -5260,9 +5250,21 @@ class TestMeasureFilterCrossModelJoin:
             measures=[ModelMeasure(formula="loss_amt:sum")],
         )
         sql = await _generate(generator, query, claim_amount, extra_models=[loss_payment])
-        # The JOIN to loss_payment must be present for the filter to work
-        assert "Loss_Payment" in sql, f"Missing JOIN to Loss_Payment: {sql}"
-        assert "JOIN" in sql
+        # The JOIN to loss_payment must be present (it is the filter mechanism).
+        # Parsed-alias assertion so a stray table mention / JOIN keyword in
+        # unrelated SQL can't satisfy it.
+        assert "loss_payment" in _join_aliases(sql), f"Missing JOIN to loss_payment: {sql}"
+        # The derived ref must be inlined — no dangling ``loss_payment.has_flag``
+        # (a derived column, absent from the physical table).
+        sql_no_strings = _re.sub(r"'[^']*'", "''", _re.sub(r'"[^"]*"', '""', sql))
+        assert _re.search(r"\bloss_payment\.has_flag\b", sql_no_strings) is None, (
+            f"derived ref 'loss_payment.has_flag' left un-inlined:\n{sql}"
+        )
+        # The inlined constant must live INSIDE the aggregation-time CASE-WHEN
+        # wrapper (not relocated to WHERE), guarding the column-filter shape.
+        assert _re.search(r"SUM\(\s*CASE WHEN .*THEN claim_amount\.amount", _norm(sql)), (
+            f"column filter not rendered as SUM(CASE WHEN ... THEN col):\n{sql}"
+        )
 
     async def test_left_join_default(self, generator: SQLGenerator) -> None:
         """Default join_type produces LEFT JOIN."""


### PR DESCRIPTION
## Summary
- A column-level `Column.filter` on an aggregated measure renders as `SUM(CASE WHEN <filter> THEN col END)`. When the filter referenced a joined table via a derived column — bare (`is_eu = 1`) or dotted to a derived column on the joined model (`loss_payment.has_flag = 1`, the dbt placeholder-join idiom where `has_flag sql="1"` exists only to force the join) — the typed pipeline left the ref un-inlined (emitting a non-physical `<alias>.<derived_col>`) and/or failed to pull the crossed join into the FROM.
- Fix (all in `slayer/sql/generator.py`): one shared Mode-A predicate renderer `_render_mode_a_predicate` inline-expands derived refs (bare **and** dotted-to-joined-derived) else cheap-qualifies — matching the already-correct query-level filter path, so the join is **kept** (it is the filter mechanism) and the ref is **inlined** (runnable SQL, no dangling reference).
- Join discovery (`_filter_join_paths`) unions the **un-inlined** predicate's paths (placeholder dotted ref keeps its alias even when it inlines to a constant) with the **inline-expanded** predicate's paths (a derived ref's crossed joins surface, e.g. `is_eu`→`customers`, `loss_payment.deep_flag`→`loss_payment__claim`). Applied to both `Column.filter` and `SlayerModel.filters`; the cross-model `_cm_*` target-filter path keeps dotted-derived inlining off (no deeper-join mechanism — that is DEV-1503).
- Collapses three near-duplicate "expand-or-qualify" sites onto the shared core.

## Scope
- In scope: local-aggregate `Column.filter` join discovery + derived-ref inlining, and the same for `SlayerModel.filters`.
- Out of scope (DEV-1503): isolating a cross-model-FILTERED measure into its own CTE so an INNER join can't change sibling measures' cardinality. Those isolation tests stay `xfail` with refreshed reasons.

## Test plan
- [x] Two tracking tests un-`xfail`ed and strengthened — now assert the derived ref is inlined inside `SUM(CASE WHEN…)`, not just that a join exists.
- [x] Filtered-last carries-join test promoted (un-`xfail`).
- [x] New companions: dotted-base, dotted-derived crossing a further join, model-filter inlining, mixed filtered/unfiltered sibling, root-scope-only `EXISTS` limitation, sqlite constant, multi-hop input.
- [x] Full non-integration suite: 3912 passed / 0 failed / 39 xfailed (DEV-1503 strict-xfails held).
- [x] `ruff check slayer/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filters that reference derived columns now inline derived expressions correctly, avoid emitting invalid qualified derived references, and include required joins for aggregate-time and cross-model filters.

* **Documentation**
  * Expanded architecture docs describing Mode-A predicate rendering, derived-column inlining, and updated join-discovery rules.

* **Tests**
  * Enabled and strengthened tests validating derived-column inlining, join discovery, and correct aggregation-time SQL form (SUM(CASE WHEN ...)).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MotleyAI/slayer/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->