### PR TITLE
DEV-1500: recognize joined-model custom aggregations in FUNC_STYLE_AGG slack rule

### DIFF
--- a/slayer/engine/normalization.py
+++ b/slayer/engine/normalization.py
@@ -568,19 +568,39 @@ def normalize_query(
     return NormalizationResult(query=query, warnings=all_warnings)
 
 
-def normalize_model(model: SlayerModel) -> NormalizationResult:
+def normalize_model(
+    model: SlayerModel,
+    *,
+    custom_agg_names: Optional[frozenset[str]] = None,
+) -> NormalizationResult:
     """Apply slack rules to a ``SlayerModel`` before persistence.
 
     Mode-A rewrites (``DOT_PATH_IN_SQL``) target ``Column.sql``,
     ``Column.filter``, and ``SlayerModel.filters``. Mode-B rewrites
     (``FUNC_STYLE_AGG``) target ``ModelMeasure.formula``. The rewrite
     semantics match ``normalize_query``.
+
+    ``custom_agg_names`` lets the caller supply the full reachable
+    aggregation set (model's own aggregations PLUS any defined on joined
+    models the caller has resolved through storage) so a funcstyle measure
+    over a joined-model custom aggregation gets rewritten — mirrors
+    ``normalize_query``'s param. Sharp edges:
+
+    * ``custom_agg_names=None`` (default) → fall back to the model's own
+      ``aggregations`` (backward-compatible; matches the pre-DEV-1500
+      behaviour for direct callers and tests that don't resolve joins).
+    * ``custom_agg_names=frozenset()`` → empty set is honoured AS-IS: the
+      model's-own fallback is suppressed. Pass an explicit empty frozenset
+      only when you want builtins-only recognition.
     """
     all_warnings: List[NormalizationWarning] = []
 
     # FUNC_STYLE_AGG on ModelMeasure.formula entries.
     if model.measures:
-        custom_names = frozenset(a.name for a in (model.aggregations or []))
+        if custom_agg_names is not None:
+            custom_names = custom_agg_names
+        else:
+            custom_names = frozenset(a.name for a in (model.aggregations or []))
         new_measures = []
         for i, mm in enumerate(model.measures):
             formula = mm.formula

--- a/slayer/engine/normalization.py
+++ b/slayer/engine/normalization.py
@@ -568,6 +568,88 @@ def normalize_query(
     return NormalizationResult(query=query, warnings=all_warnings)
 
 
+def _normalize_model_measures(
+    model: SlayerModel, *, custom_agg_names: Optional[frozenset[str]],
+) -> Tuple[SlayerModel, List[NormalizationWarning]]:
+    """FUNC_STYLE_AGG over ``model.measures`` (Mode-B). See
+    :func:`normalize_model` for the ``custom_agg_names`` contract.
+    """
+    if not model.measures:
+        return model, []
+    if custom_agg_names is not None:
+        custom_names = custom_agg_names
+    else:
+        custom_names = frozenset(a.name for a in (model.aggregations or []))
+    warnings: List[NormalizationWarning] = []
+    new_measures = []
+    for i, mm in enumerate(model.measures):
+        formula = mm.formula
+        rewritten, ws = _apply_func_style_agg(
+            formula,
+            location=f"measures[{i}].formula",
+            custom_agg_names=custom_names,
+        )
+        warnings.extend(ws)
+        if rewritten != formula:
+            mm = mm.model_copy(update={"formula": rewritten})
+        new_measures.append(mm)
+    return model.model_copy(update={"measures": new_measures}), warnings
+
+
+def _normalize_column_dot_paths(
+    model: SlayerModel,
+) -> Tuple[SlayerModel, List[NormalizationWarning]]:
+    """DOT_PATH_IN_SQL over ``Column.sql`` / ``Column.filter`` (Mode-A)."""
+    warnings: List[NormalizationWarning] = []
+    new_columns = []
+    changed = False
+    for i, c in enumerate(model.columns):
+        updates: dict = {}
+        if c.sql is not None:
+            rewritten_sql, ws = _apply_dot_path_in_sql(
+                c.sql, location=f"columns[{i}].sql", model=model,
+            )
+            warnings.extend(ws)
+            if rewritten_sql != c.sql:
+                updates["sql"] = rewritten_sql
+        if c.filter is not None:
+            rewritten_filter, ws = _apply_dot_path_in_sql(
+                c.filter, location=f"columns[{i}].filter", model=model,
+            )
+            warnings.extend(ws)
+            if rewritten_filter != c.filter:
+                updates["filter"] = rewritten_filter
+        if updates:
+            c = c.model_copy(update=updates)
+            changed = True
+        new_columns.append(c)
+    if changed:
+        model = model.model_copy(update={"columns": new_columns})
+    return model, warnings
+
+
+def _normalize_model_filter_dot_paths(
+    model: SlayerModel,
+) -> Tuple[SlayerModel, List[NormalizationWarning]]:
+    """DOT_PATH_IN_SQL over ``SlayerModel.filters`` (Mode-A)."""
+    if not model.filters:
+        return model, []
+    warnings: List[NormalizationWarning] = []
+    new_filters = []
+    changed = False
+    for i, f in enumerate(model.filters):
+        rewritten, ws = _apply_dot_path_in_sql(
+            f, location=f"filters[{i}]", model=model,
+        )
+        warnings.extend(ws)
+        if rewritten != f:
+            changed = True
+        new_filters.append(rewritten if rewritten is not None else f)
+    if changed:
+        model = model.model_copy(update={"filters": new_filters})
+    return model, warnings
+
+
 def normalize_model(
     model: SlayerModel,
     *,
@@ -594,66 +676,13 @@ def normalize_model(
       only when you want builtins-only recognition.
     """
     all_warnings: List[NormalizationWarning] = []
-
-    # FUNC_STYLE_AGG on ModelMeasure.formula entries.
-    if model.measures:
-        if custom_agg_names is not None:
-            custom_names = custom_agg_names
-        else:
-            custom_names = frozenset(a.name for a in (model.aggregations or []))
-        new_measures = []
-        for i, mm in enumerate(model.measures):
-            formula = mm.formula
-            rewritten, ws = _apply_func_style_agg(
-                formula,
-                location=f"measures[{i}].formula",
-                custom_agg_names=custom_names,
-            )
-            all_warnings.extend(ws)
-            if rewritten != formula:
-                mm = mm.model_copy(update={"formula": rewritten})
-            new_measures.append(mm)
-        model = model.model_copy(update={"measures": new_measures})
-
-    # DOT_PATH_IN_SQL (Mode-A only): Column.sql, Column.filter, SlayerModel.filters.
+    model, ws = _normalize_model_measures(
+        model, custom_agg_names=custom_agg_names,
+    )
+    all_warnings.extend(ws)
     if model.joins:
-        new_columns = []
-        column_changed = False
-        for i, c in enumerate(model.columns):
-            updates: dict = {}
-            if c.sql is not None:
-                rewritten_sql, ws = _apply_dot_path_in_sql(
-                    c.sql, location=f"columns[{i}].sql", model=model,
-                )
-                all_warnings.extend(ws)
-                if rewritten_sql != c.sql:
-                    updates["sql"] = rewritten_sql
-            if c.filter is not None:
-                rewritten_filter, ws = _apply_dot_path_in_sql(
-                    c.filter, location=f"columns[{i}].filter", model=model,
-                )
-                all_warnings.extend(ws)
-                if rewritten_filter != c.filter:
-                    updates["filter"] = rewritten_filter
-            if updates:
-                c = c.model_copy(update=updates)
-                column_changed = True
-            new_columns.append(c)
-        if column_changed:
-            model = model.model_copy(update={"columns": new_columns})
-
-        if model.filters:
-            new_filters = []
-            filters_changed = False
-            for i, f in enumerate(model.filters):
-                rewritten, ws = _apply_dot_path_in_sql(
-                    f, location=f"filters[{i}]", model=model,
-                )
-                all_warnings.extend(ws)
-                if rewritten != f:
-                    filters_changed = True
-                new_filters.append(rewritten if rewritten is not None else f)
-            if filters_changed:
-                model = model.model_copy(update={"filters": new_filters})
-
+        model, ws = _normalize_column_dot_paths(model)
+        all_warnings.extend(ws)
+        model, ws = _normalize_model_filter_dot_paths(model)
+        all_warnings.extend(ws)
     return NormalizationResult(model=model, warnings=all_warnings)

--- a/slayer/engine/query_engine.py
+++ b/slayer/engine/query_engine.py
@@ -33,7 +33,7 @@ from slayer.engine.enriched import (
     EnrichedMeasure,
     EnrichedQuery,
 )
-from slayer.engine.enrichment import enrich_query
+from slayer.engine.enrichment import _collect_reachable_agg_names, enrich_query
 from slayer.engine.normalization import normalize_model, normalize_query
 from slayer.engine.path_resolution import NoJoinError as _NoJoinError
 from slayer.engine.path_resolution import walk_join_chain
@@ -582,8 +582,12 @@ class SlayerQueryEngine:
         else:
             model = bundle.source_model
         custom_aggs: Optional[frozenset[str]] = None
-        if model is not None and model.aggregations:
-            custom_aggs = frozenset(a.name for a in model.aggregations)
+        if model is not None:
+            # DEV-1500: scoped per-stage BFS over the pre-resolved bundle,
+            # so funcstyle calls over joined-model custom aggregations
+            # (``rolling_avg(customers.score)`` where ``rolling_avg`` lives
+            # on ``customers``) are recognised by the slack rewrite.
+            custom_aggs = bundle.reachable_aggregation_names(start=model)
         norm = normalize_query(query, model=model, custom_agg_names=custom_aggs)
         out = norm.query if norm.query is not None else query
         return out, list(norm.warnings)
@@ -1586,8 +1590,43 @@ class SlayerQueryEngine:
         incoming model so persisted formulas land in canonical form. The
         legacy in-tree rewriters still fire during enrichment for callers
         that load and re-execute persisted models.
+
+        DEV-1500 — when the model has any measures to normalise, do a
+        best-effort storage walk of the join graph so the FUNC_STYLE_AGG
+        rewrite recognises custom aggregations defined on joined models.
+        Failures (missing target, ``AmbiguousModelError``, any storage
+        hiccup) are swallowed; the walk degrades to the model's own
+        aggregations.
         """
-        norm_model = normalize_model(model)
+        custom_aggs: Optional[frozenset[str]] = None
+        if model.measures:
+            async def _resolve_join_target_for_save(
+                target_model_name: str, named_queries,  # noqa: ARG001
+            ):
+                if not self.storage:
+                    return None
+                try:
+                    if model.data_source:
+                        target = await self.storage.get_model(
+                            target_model_name, data_source=model.data_source,
+                        )
+                    else:
+                        target = await self.storage.get_model(target_model_name)
+                except Exception:  # noqa: BLE001 — best-effort; AmbiguousModelError + misc
+                    return None
+                if target is None:
+                    return None
+                return (None, target)
+
+            try:
+                custom_aggs = await _collect_reachable_agg_names(
+                    model=model,
+                    resolve_join_target=_resolve_join_target_for_save,
+                    named_queries={},
+                )
+            except Exception:  # noqa: BLE001 — never let the walk abort a save
+                custom_aggs = None
+        norm_model = normalize_model(model, custom_agg_names=custom_aggs)
         if norm_model.model is not None:
             model = norm_model.model
         # Capture the *previous* data_source for this name so we can clean

--- a/slayer/engine/query_engine.py
+++ b/slayer/engine/query_engine.py
@@ -1579,6 +1579,46 @@ class SlayerQueryEngine:
         # can use the returned model directly.
         return await self._validate_and_populate_cache(model)
 
+    async def _reachable_aggs_for_save(
+        self, model: SlayerModel,
+    ) -> Optional[frozenset[str]]:
+        """Best-effort storage BFS over the join graph collecting custom
+        aggregation names (DEV-1500). Returns ``None`` when ``model`` has no
+        measures to normalise or when the walk yields nothing; absent join
+        targets and storage errors (incl. ``AmbiguousModelError``) are
+        swallowed so a save never aborts on a flaky join-target lookup.
+        """
+        if not model.measures:
+            return None
+
+        storage = self.storage
+        data_source = model.data_source
+
+        async def _resolver(
+            target_model_name: str, named_queries,  # noqa: ARG001
+        ):
+            if not storage:
+                return None
+            try:
+                if data_source:
+                    target = await storage.get_model(
+                        target_model_name, data_source=data_source,
+                    )
+                else:
+                    target = await storage.get_model(target_model_name)
+            except Exception:  # noqa: BLE001 — best-effort; AmbiguousModelError + misc
+                return None
+            return (None, target) if target is not None else None
+
+        try:
+            return await _collect_reachable_agg_names(
+                model=model,
+                resolve_join_target=_resolver,
+                named_queries={},
+            )
+        except Exception:  # noqa: BLE001 — never let the walk abort a save
+            return None
+
     async def save_model(self, model: SlayerModel) -> SlayerModel:
         """Persist a SlayerModel through the engine.
 
@@ -1591,41 +1631,12 @@ class SlayerQueryEngine:
         legacy in-tree rewriters still fire during enrichment for callers
         that load and re-execute persisted models.
 
-        DEV-1500 — when the model has any measures to normalise, do a
-        best-effort storage walk of the join graph so the FUNC_STYLE_AGG
-        rewrite recognises custom aggregations defined on joined models.
-        Failures (missing target, ``AmbiguousModelError``, any storage
-        hiccup) are swallowed; the walk degrades to the model's own
-        aggregations.
+        DEV-1500 — the FUNC_STYLE_AGG rewrite recognises custom aggregations
+        defined on joined models via ``_reachable_aggs_for_save`` (best-effort
+        storage walk; swallowed on missing target / AmbiguousModelError /
+        storage hiccup).
         """
-        custom_aggs: Optional[frozenset[str]] = None
-        if model.measures:
-            async def _resolve_join_target_for_save(
-                target_model_name: str, named_queries,  # noqa: ARG001
-            ):
-                if not self.storage:
-                    return None
-                try:
-                    if model.data_source:
-                        target = await self.storage.get_model(
-                            target_model_name, data_source=model.data_source,
-                        )
-                    else:
-                        target = await self.storage.get_model(target_model_name)
-                except Exception:  # noqa: BLE001 — best-effort; AmbiguousModelError + misc
-                    return None
-                if target is None:
-                    return None
-                return (None, target)
-
-            try:
-                custom_aggs = await _collect_reachable_agg_names(
-                    model=model,
-                    resolve_join_target=_resolve_join_target_for_save,
-                    named_queries={},
-                )
-            except Exception:  # noqa: BLE001 — never let the walk abort a save
-                custom_aggs = None
+        custom_aggs = await self._reachable_aggs_for_save(model)
         norm_model = normalize_model(model, custom_agg_names=custom_aggs)
         if norm_model.model is not None:
             model = norm_model.model

--- a/slayer/engine/schema_drift.py
+++ b/slayer/engine/schema_drift.py
@@ -1309,12 +1309,41 @@ def _first_dropped_cause(
     return None
 
 
+def _reachable_agg_names_from_state(
+    *, start: SlayerModel, state: "_CascadeState",
+) -> Set[str]:
+    """Sync BFS over ``state.models_by_name`` collecting custom aggregation
+    names reachable from ``start`` via the join graph. DEV-1500 — lets the
+    measure-cascade rule recognise function-style references to custom
+    aggregations defined on joined models (``rolling_avg(customers.score)``
+    where ``rolling_avg`` lives on the joined ``customers``). Visited-guarded,
+    unbounded depth; absent targets are skipped (best-effort).
+    """
+    names: Set[str] = set()
+    visited: Set[str] = set()
+    queue: List[SlayerModel] = [start]
+    while queue:
+        current = queue.pop(0)
+        if current.name in visited:
+            continue
+        visited.add(current.name)
+        if current.aggregations:
+            names.update(a.name for a in current.aggregations)
+        for join in current.joins:
+            if join.target_model in visited:
+                continue
+            nxt = state.models_by_name.get(join.target_model)
+            if nxt is not None:
+                queue.append(nxt)
+    return names
+
+
 def _cascade_measures(*, model: SlayerModel, state: _CascadeState) -> bool:
     """Rule 2: ``ModelMeasure.formula`` referencing a dropped column or
     dropped measure."""
     changed = False
     dropped_set = state.dropped_measures.get(model.name, set())
-    custom_agg_names = {a.name for a in (model.aggregations or [])}
+    custom_agg_names = _reachable_agg_names_from_state(start=model, state=state)
     for measure in model.measures:
         if measure.name is None or measure.name in dropped_set:
             continue

--- a/slayer/engine/source_bundle.py
+++ b/slayer/engine/source_bundle.py
@@ -69,6 +69,45 @@ class ResolvedSourceBundle(BaseModel):
                 return m
         return None
 
+    def reachable_aggregation_names(
+        self, *, start: SlayerModel,
+    ) -> Optional[frozenset[str]]:
+        """Custom aggregation names reachable from ``start`` via the join
+        graph, resolved against this bundle's pre-loaded
+        ``referenced_models``. Sync mirror of
+        ``enrichment._collect_reachable_agg_names`` — used by the slack
+        FUNC_STYLE_AGG normalizer so a custom aggregation defined on a
+        joined model (e.g. ``rolling_avg(customers.score)``) is recognised
+        and rewritten to colon form.
+
+        BFS, visited-guarded by model name, unbounded depth. Join targets
+        absent from ``referenced_models`` are skipped (best-effort, matches
+        the rest of the bundle). Returns ``None`` when nothing reachable
+        carries any custom aggregation; the contract is "None when empty",
+        not an empty frozenset.
+
+        Scoping is per call: a stage normalises against its own source
+        model, so a stage only sees aggregations reachable from the model
+        it actually queries — not the union across every sibling stage.
+        """
+        names: set[str] = set()
+        visited: set[str] = set()
+        queue: list[SlayerModel] = [start]
+        while queue:
+            current = queue.pop(0)
+            if current.name in visited:
+                continue
+            visited.add(current.name)
+            if current.aggregations:
+                names.update(a.name for a in current.aggregations)
+            for join in current.joins:
+                if join.target_model in visited:
+                    continue
+                nxt = self.get_referenced_model(join.target_model)
+                if nxt is not None:
+                    queue.append(nxt)
+        return frozenset(names) if names else None
+
 
 # Anything accepted as ``SlayerQuery.source_model``.
 SourceSpec = Union[str, SlayerModel, ModelExtension, Dict[str, Any]]

--- a/slayer/memories/resolver.py
+++ b/slayer/memories/resolver.py
@@ -40,6 +40,7 @@ from slayer.core.errors import (
 from slayer.core.models import SlayerModel
 from slayer.core.query import ColumnRef, SlayerQuery, TimeDimension
 from slayer.core.refs import strip_agg_suffix as _strip_agg_suffix
+from slayer.engine.enrichment import _collect_reachable_agg_names
 from slayer.engine.normalization import func_style_agg_to_colon
 from slayer.engine.syntax import (
     AggCall,
@@ -550,9 +551,34 @@ async def extract_entities_from_query(  # NOSONAR(S3776) — straight-line walk 
 
     # 4. measures — parse each formula (Mode-B DSL) and resolve each
     # referenced entity token. Function-style aggregations are rewritten to
-    # colon syntax first (quiet FUNC_STYLE_AGG slack helper), including the
-    # source model's custom aggregations — matching the legacy parse path.
-    custom_agg_names = frozenset(a.name for a in source_model.aggregations)
+    # colon syntax first (quiet FUNC_STYLE_AGG slack helper). DEV-1500 — the
+    # custom-agg name set includes aggregations defined on *joined* models
+    # too, so entity extraction over a formula like
+    # ``rolling_avg(customers.score)`` (where ``rolling_avg`` lives on
+    # ``customers``) still produces the ``customers.score`` token instead of
+    # falling through to the unknown-function branch.
+    async def _resolve_join_target_for_resolver(
+        target_model_name: str, named_queries,  # noqa: ARG001
+    ):
+        try:
+            target = await storage.get_model(
+                target_model_name, data_source=source_model.data_source,
+            )
+        except Exception:  # noqa: BLE001 — best-effort; resolver must not raise
+            return None
+        if target is None:
+            return None
+        return (None, target)
+
+    try:
+        reachable_agg_names = await _collect_reachable_agg_names(
+            model=source_model,
+            resolve_join_target=_resolve_join_target_for_resolver,
+            named_queries={},
+        )
+    except Exception:  # noqa: BLE001 — never let the walk break extraction
+        reachable_agg_names = None
+    custom_agg_names = reachable_agg_names or frozenset()
     for m in query.measures or []:
         if m.formula is None:
             continue

--- a/tests/test_entity_resolution.py
+++ b/tests/test_entity_resolution.py
@@ -646,6 +646,56 @@ class TestExtractEntitiesFromQuery:
         with pytest.raises(EntityResolutionError):
             await extract_entities_from_query(q, storage=storage)
 
+    async def test_funcstyle_joined_custom_agg_extracts_joined_column(
+        self,
+    ) -> None:
+        # DEV-1500: a funcstyle custom aggregation defined on a joined
+        # model (``rolling_avg(customers.score)`` where ``rolling_avg`` lives
+        # on ``customers``) must be recognised by the quiet FUNC_STYLE_AGG
+        # rewrite the resolver uses for entity extraction, so the joined
+        # column (``customers.score``) ends up tagged. The fix walks the
+        # source model's reachable join graph for custom aggregation names.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            s = YAMLStorage(base_dir=tmpdir)
+            await s.save_datasource(
+                DatasourceConfig(name="dev1500", type="postgres", host="x")
+            )
+            await s.save_model(SlayerModel(
+                name="customers",
+                data_source="dev1500",
+                sql_table="customers",
+                columns=[
+                    Column(name="id", sql="id", type=DataType.INT, primary_key=True),
+                    Column(name="score", sql="score", type=DataType.DOUBLE),
+                ],
+                aggregations=[
+                    Aggregation(name="rolling_avg", formula="AVG({value})"),
+                ],
+            ))
+            await s.save_model(SlayerModel(
+                name="orders",
+                data_source="dev1500",
+                sql_table="orders",
+                columns=[
+                    Column(name="id", sql="id", type=DataType.INT, primary_key=True),
+                    Column(name="customer_id", sql="customer_id", type=DataType.INT),
+                ],
+                joins=[
+                    ModelJoin(target_model="customers", join_pairs=[["customer_id", "id"]]),
+                ],
+            ))
+            q = SlayerQuery(
+                source_model="orders",
+                measures=[ModelMeasure(formula="rolling_avg(customers.score)")],
+            )
+            result = await extract_entities_from_query(q, storage=s)
+            # The funcstyle was rewritten to colon form via the joined-agg
+            # walk, so the joined column surfaces as an entity instead of
+            # falling into the unknown-function whole-formula fallback.
+            assert "dev1500.customers.score" in result.canonical_forms, (
+                result.canonical_forms
+            )
+
 
 class TestResolveEntityAmbiguousModel:
     async def test_ambiguous_model_propagates_when_no_priority(

--- a/tests/test_slack_normalization.py
+++ b/tests/test_slack_normalization.py
@@ -14,7 +14,13 @@ import warnings
 import pytest
 
 from slayer.core.enums import DataType
-from slayer.core.models import Column, ModelMeasure, SlayerModel
+from slayer.core.models import (
+    Aggregation,
+    Column,
+    ModelJoin,
+    ModelMeasure,
+    SlayerModel,
+)
 from slayer.core.query import SlayerQuery
 from slayer.core.warnings import SlayerNormalizationWarning
 from slayer.engine.normalization import (
@@ -112,7 +118,6 @@ class TestFuncStyleAgg:
         # A model-level custom aggregation name is recognised by
         # normalize_model — that's where the model's aggregations list
         # is in scope.
-        from slayer.core.models import Aggregation
         m = _orders().model_copy(update={
             "aggregations": [Aggregation(name="custom_sum", formula="SUM({value})")],
             "measures": [ModelMeasure(name="rev_c", formula="custom_sum(revenue)")],
@@ -120,6 +125,53 @@ class TestFuncStyleAgg:
         result = normalize_model(m)
         assert result.model.measures[0].formula == "revenue:custom_sum"
         assert any(w.rule_id == "FUNC_STYLE_AGG" for w in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# DEV-1500 — normalize_model custom_agg_names param (joined-model custom aggs)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeModelCustomAggParam:
+    """``normalize_model(model, custom_agg_names=...)`` lets the caller supply
+    the full reachable aggregation set (source model + joined models) so a
+    funcstyle ``ModelMeasure.formula`` over a joined-model custom aggregation
+    is rewritten to colon form.
+    """
+
+    def test_param_recognises_joined_custom_agg(self):
+        # `rolling_avg` is defined on a JOINED model, not on `orders` itself,
+        # so it only appears in the caller-supplied `custom_agg_names`.
+        m = _orders().model_copy(update={
+            "joins": [ModelJoin(target_model="customers", join_pairs=[["id", "id"]])],
+            "measures": [
+                ModelMeasure(name="ravg", formula="rolling_avg(customers.score)"),
+            ],
+        })
+        result = normalize_model(m, custom_agg_names=frozenset({"rolling_avg"}))
+        assert result.model.measures[0].formula == "customers.score:rolling_avg"
+        assert any(w.rule_id == "FUNC_STYLE_AGG" for w in result.warnings)
+
+    def test_none_param_falls_back_to_models_own_aggs(self):
+        # Explicit None means "caller did not compute the reachable set" —
+        # fall back to the model's own aggregations (backward-compatible).
+        m = _orders().model_copy(update={
+            "aggregations": [Aggregation(name="custom_sum", formula="SUM({value})")],
+            "measures": [ModelMeasure(name="rev_c", formula="custom_sum(revenue)")],
+        })
+        result = normalize_model(m, custom_agg_names=None)
+        assert result.model.measures[0].formula == "revenue:custom_sum"
+
+    def test_empty_frozenset_suppresses_own_agg_fallback(self):
+        # Sharp edge (intentional): an explicit empty frozenset suppresses the
+        # model's-own fallback, so even a local custom agg is NOT recognised.
+        m = _orders().model_copy(update={
+            "aggregations": [Aggregation(name="custom_sum", formula="SUM({value})")],
+            "measures": [ModelMeasure(name="rev_c", formula="custom_sum(revenue)")],
+        })
+        result = normalize_model(m, custom_agg_names=frozenset())
+        assert result.model.measures[0].formula == "custom_sum(revenue)"
+        assert result.warnings == []
 
 
 # ---------------------------------------------------------------------------
@@ -483,3 +535,374 @@ class TestEngineWiring:
             })
             saved = await engine.save_model(m)
             assert saved.measures[0].formula == "revenue:sum"
+
+
+# ---------------------------------------------------------------------------
+# DEV-1500 — joined-model custom aggregations recognised by FUNC_STYLE_AGG
+# ---------------------------------------------------------------------------
+
+
+def _customers_with_rolling_avg() -> SlayerModel:
+    return SlayerModel(
+        name="customers",
+        data_source="prod",
+        sql_table="customers",
+        columns=[
+            Column(name="id", type=DataType.INT, primary_key=True),
+            Column(name="score", type=DataType.DOUBLE),
+        ],
+        aggregations=[Aggregation(name="rolling_avg", formula="AVG({value})")],
+    )
+
+
+def _orders_joining_customers() -> SlayerModel:
+    return _orders().model_copy(update={
+        "joins": [
+            ModelJoin(target_model="customers", join_pairs=[["id", "id"]]),
+        ],
+    })
+
+
+async def _engine_with_prod():
+    """A fresh engine over an in-memory-SQLite YAML store. Returns
+    ``(engine, storage)``; caller owns the TemporaryDirectory lifetime.
+    """
+    import tempfile
+    from pathlib import Path
+
+    from slayer.core.models import DatasourceConfig
+    from slayer.engine.query_engine import SlayerQueryEngine
+    from slayer.storage.yaml_storage import YAMLStorage
+
+    td = tempfile.TemporaryDirectory()
+    storage = YAMLStorage(base_dir=Path(td.name) / "models")
+    await storage.save_datasource(
+        DatasourceConfig(name="prod", type="sqlite", url="sqlite:///:memory:")
+    )
+    return SlayerQueryEngine(storage=storage), storage, td
+
+
+class TestJoinedCustomAggFuncStyle:
+    """End-to-end: the FUNC_STYLE_AGG slack rule recognises a custom
+    aggregation defined on a *joined* model on both the query path
+    (``_normalize_stage``) and the model-save path (``save_model``).
+    """
+
+    async def test_query_path_surfaces_normalized_warning(self):
+        engine, storage, td = await _engine_with_prod()
+        try:
+            await storage.save_model(_customers_with_rolling_avg())
+            await storage.save_model(_orders_joining_customers())
+            q = SlayerQuery(
+                source_model="orders",
+                measures=[{"formula": "rolling_avg(customers.score)"}],
+                dimensions=["status"],
+            )
+            resp = await engine.execute(q, dry_run=True)
+            assert any(
+                w.rule_id == "FUNC_STYLE_AGG"
+                and w.normalized == "customers.score:rolling_avg"
+                for w in resp.warnings
+            ), resp.warnings
+            assert "AVG(" in resp.sql, resp.sql
+        finally:
+            td.cleanup()
+
+    async def test_save_model_rewrites_joined_custom_agg_formula(self):
+        engine, storage, td = await _engine_with_prod()
+        try:
+            # customers MUST be saved first so the save-time storage walk can
+            # discover `rolling_avg` on the joined model.
+            await storage.save_model(_customers_with_rolling_avg())
+            orders = _orders_joining_customers().model_copy(update={
+                "measures": [
+                    ModelMeasure(
+                        name="ravg", formula="rolling_avg(customers.score)"
+                    ),
+                ],
+            })
+            saved = await engine.save_model(orders)
+            assert saved.measures[0].formula == "customers.score:rolling_avg"
+            # And the rewrite is persisted, not just on the returned object.
+            reloaded = await storage.get_model("orders", data_source="prod")
+            assert reloaded.measures[0].formula == "customers.score:rolling_avg"
+        finally:
+            td.cleanup()
+
+    async def test_multistage_named_stage_scoping(self):
+        # A NAMED non-root stage sourced from `orders` (which joins
+        # `customers`) must have its funcstyle joined-agg rewritten — this
+        # exercises the `stage_source_models` branch of `_normalize_stage`
+        # plus the bundle's transitive `referenced_models`.
+        engine, storage, td = await _engine_with_prod()
+        try:
+            await storage.save_model(_customers_with_rolling_avg())
+            await storage.save_model(_orders_joining_customers())
+            stage1 = SlayerQuery(
+                name="stage1",
+                source_model="orders",
+                dimensions=["status"],
+                measures=[
+                    {"formula": "rolling_avg(customers.score)", "name": "ravg"},
+                ],
+            )
+            root = SlayerQuery(
+                source_model="stage1",
+                dimensions=["status"],
+                measures=[{"formula": "ravg:max"}],
+            )
+            resp = await engine.execute([stage1, root], dry_run=True)
+            assert any(
+                w.rule_id == "FUNC_STYLE_AGG"
+                and w.normalized == "customers.score:rolling_avg"
+                for w in resp.warnings
+            ), resp.warnings
+            assert "AVG(" in resp.sql, resp.sql
+        finally:
+            td.cleanup()
+
+    async def test_save_model_skips_missing_join_target_but_finds_others(self):
+        # The model joins TWO targets: one persisted (carrying the agg) and
+        # one absent. The best-effort walk skips the absent target without
+        # error AND still discovers the agg on the persisted joined model
+        # (proving the BFS actually runs end-to-end at save time).
+        engine, storage, td = await _engine_with_prod()
+        try:
+            await storage.save_model(_customers_with_rolling_avg())
+            orders = _orders_joining_customers().model_copy(update={
+                "joins": [
+                    ModelJoin(target_model="customers", join_pairs=[["id", "id"]]),
+                    ModelJoin(target_model="ghost", join_pairs=[["id", "id"]]),
+                ],
+                "measures": [
+                    ModelMeasure(
+                        name="ravg", formula="rolling_avg(customers.score)"
+                    ),
+                ],
+            })
+            saved = await engine.save_model(orders)
+            assert saved.measures[0].formula == "customers.score:rolling_avg"
+        finally:
+            td.cleanup()
+
+    async def test_save_model_swallows_ambiguous_join_lookup(self, monkeypatch):
+        # If the join-target lookup raises (e.g. AmbiguousModelError), the
+        # best-effort walk swallows it and the formula falls through
+        # unrewritten — no crash. A spy on storage.get_model proves the BFS
+        # actually attempted the lookup (so this test fails today, where no
+        # BFS runs, and passes after the fix that swallows the exception).
+        from slayer.core.errors import AmbiguousModelError
+
+        engine, storage, td = await _engine_with_prod()
+        try:
+            await storage.save_model(_customers_with_rolling_avg())
+            orders = _orders_joining_customers().model_copy(update={
+                "measures": [
+                    ModelMeasure(
+                        name="ravg", formula="rolling_avg(customers.score)"
+                    ),
+                ],
+            })
+
+            real_get_model = storage.get_model
+            calls: list[str] = []
+
+            async def _boom(name, data_source=None):
+                calls.append(name)
+                if name == "customers":
+                    raise AmbiguousModelError("customers", ["prod", "other"])
+                return await real_get_model(name, data_source=data_source)
+
+            monkeypatch.setattr(storage, "get_model", _boom)
+            saved = await engine.save_model(orders)
+            # BFS attempted the join-target lookup (proves the walk runs).
+            assert "customers" in calls
+            # Exception was swallowed (no crash) and the funcstyle stayed as-is
+            # because the joined agg could not be discovered.
+            assert saved.measures[0].formula == "rolling_avg(customers.score)"
+        finally:
+            td.cleanup()
+
+    async def test_save_model_rewrites_joined_custom_agg_at_four_hops(self):
+        # Save-time reachable discovery must be unbounded, matching the
+        # query-path 4-hop tracking test. Chain: a -> b -> c -> d -> e,
+        # rolling_avg lives on `e`. A ModelMeasure on `a` referencing
+        # `rolling_avg(b.c.d.e.score)` is rewritten at save time.
+        engine, storage, td = await _engine_with_prod()
+        try:
+            def _chain_model(name, *, joins=None, aggs=None, extra_cols=None):
+                cols = [
+                    Column(name="id", type=DataType.INT, primary_key=True),
+                ] + list(extra_cols or [])
+                return SlayerModel(
+                    name=name,
+                    data_source="prod",
+                    sql_table=name,
+                    columns=cols,
+                    aggregations=[
+                        Aggregation(name=a, formula="AVG({value})")
+                        for a in (aggs or [])
+                    ],
+                    joins=[
+                        ModelJoin(target_model=t, join_pairs=[["id", "id"]])
+                        for t in (joins or [])
+                    ],
+                )
+
+            await storage.save_model(_chain_model(
+                "e", aggs=["rolling_avg"],
+                extra_cols=[Column(name="score", type=DataType.DOUBLE)],
+            ))
+            await storage.save_model(_chain_model("d", joins=["e"]))
+            await storage.save_model(_chain_model("c", joins=["d"]))
+            await storage.save_model(_chain_model("b", joins=["c"]))
+            a = _chain_model("a", joins=["b"]).model_copy(update={
+                "measures": [
+                    ModelMeasure(
+                        name="deep_ravg",
+                        formula="rolling_avg(b.c.d.e.score)",
+                    ),
+                ],
+            })
+            saved = await engine.save_model(a)
+            assert saved.measures[0].formula == "b.c.d.e.score:rolling_avg"
+        finally:
+            td.cleanup()
+
+    async def test_query_path_rewrites_joined_custom_agg_in_filter(self):
+        # Filters in normalize_query are also passed custom_agg_names — a
+        # joined custom agg in a filter must rewrite to colon form and
+        # surface a FUNC_STYLE_AGG warning anchored at `filters[0]`.
+        engine, storage, td = await _engine_with_prod()
+        try:
+            await storage.save_model(_customers_with_rolling_avg())
+            await storage.save_model(_orders_joining_customers())
+            q = SlayerQuery(
+                source_model="orders",
+                measures=[{"formula": "revenue:sum"}],
+                dimensions=["status"],
+                filters=["rolling_avg(customers.score) > 100"],
+            )
+            resp = await engine.execute(q, dry_run=True)
+            assert any(
+                w.rule_id == "FUNC_STYLE_AGG"
+                and w.location == "filters[0]"
+                and "customers.score:rolling_avg" in w.normalized
+                for w in resp.warnings
+            ), resp.warnings
+        finally:
+            td.cleanup()
+
+    async def test_query_path_4hop_joined_custom_agg_warning_form(self):
+        # Companion to the SQL-generator 4-hop tracking test that asserts
+        # `AVG(` only. This pins the slack-layer warning: a 4-hop joined
+        # custom agg in a funcstyle measure surfaces a FUNC_STYLE_AGG
+        # warning whose normalized form is the colon-syntax canonical.
+        engine, storage, td = await _engine_with_prod()
+        try:
+            def _chain_model(name, *, joins=None, aggs=None, extra_cols=None):
+                cols = [
+                    Column(name="id", type=DataType.INT, primary_key=True),
+                ] + list(extra_cols or [])
+                return SlayerModel(
+                    name=name,
+                    data_source="prod",
+                    sql_table=name,
+                    columns=cols,
+                    aggregations=[
+                        Aggregation(name=a, formula="AVG({value})")
+                        for a in (aggs or [])
+                    ],
+                    joins=[
+                        ModelJoin(target_model=t, join_pairs=[["id", "id"]])
+                        for t in (joins or [])
+                    ],
+                )
+
+            await storage.save_model(_chain_model(
+                "e", aggs=["rolling_avg"],
+                extra_cols=[Column(name="score", type=DataType.DOUBLE)],
+            ))
+            await storage.save_model(_chain_model("d", joins=["e"]))
+            await storage.save_model(_chain_model("c", joins=["d"]))
+            await storage.save_model(_chain_model("b", joins=["c"]))
+            await storage.save_model(_chain_model("a", joins=["b"]))
+            q = SlayerQuery(
+                source_model="a",
+                measures=[{"formula": "rolling_avg(b.c.d.e.score)"}],
+            )
+            resp = await engine.execute(q, dry_run=True)
+            assert any(
+                w.rule_id == "FUNC_STYLE_AGG"
+                and w.normalized == "b.c.d.e.score:rolling_avg"
+                for w in resp.warnings
+            ), resp.warnings
+        finally:
+            td.cleanup()
+
+    async def test_multistage_named_stage_scoping_does_not_cross_stages(self):
+        # Negative scoping guard for the engine: a stage whose source model
+        # cannot reach `rolling_avg` must NOT have its funcstyle rewritten,
+        # even when ANOTHER stage's source DOES have `rolling_avg`. Under a
+        # buggy union-of-all-referenced impl, both stages would rewrite. The
+        # scoped impl emits exactly one FUNC_STYLE_AGG warning (for the
+        # reachable stage) and the unreachable stage raises at enrichment.
+        import warnings as _w
+
+        from slayer.core.errors import UnknownFunctionError
+        from slayer.core.warnings import SlayerNormalizationWarning
+
+        engine, storage, td = await _engine_with_prod()
+        try:
+            # widgets has the custom aggregation; no join to gadgets.
+            await storage.save_model(SlayerModel(
+                name="widgets",
+                data_source="prod",
+                sql_table="widgets",
+                columns=[
+                    Column(name="id", type=DataType.INT, primary_key=True),
+                    Column(name="value", type=DataType.DOUBLE),
+                ],
+                aggregations=[
+                    Aggregation(name="rolling_avg", formula="AVG({value})"),
+                ],
+            ))
+            # gadgets has NO aggregation, no join — cannot reach rolling_avg.
+            await storage.save_model(SlayerModel(
+                name="gadgets",
+                data_source="prod",
+                sql_table="gadgets",
+                columns=[
+                    Column(name="id", type=DataType.INT, primary_key=True),
+                    Column(name="qty", type=DataType.DOUBLE),
+                ],
+            ))
+            reachable = SlayerQuery(
+                name="reachable",
+                source_model="widgets",
+                measures=[{"formula": "rolling_avg(value)"}],
+                dimensions=["id"],
+            )
+            unreachable = SlayerQuery(
+                source_model="gadgets",
+                measures=[{"formula": "rolling_avg(qty)"}],
+                dimensions=["id"],
+            )
+
+            with _w.catch_warnings(record=True) as caught:
+                _w.simplefilter("always", SlayerNormalizationWarning)
+                with pytest.raises(UnknownFunctionError):
+                    await engine.execute([reachable, unreachable], dry_run=True)
+
+            payloads = [
+                w.message.payload for w in caught
+                if isinstance(w.message, SlayerNormalizationWarning)
+            ]
+            fs = [p for p in payloads if p.rule_id == "FUNC_STYLE_AGG"]
+            # Exactly one FUNC_STYLE_AGG warning fired — for the reachable
+            # stage only. The unreachable stage's funcstyle was NOT rewritten
+            # (which is why the run later raises UnknownFunctionError).
+            assert len(fs) == 1, fs
+            assert fs[0].normalized == "value:rolling_avg"
+        finally:
+            td.cleanup()

--- a/tests/test_slack_normalization.py
+++ b/tests/test_slack_normalization.py
@@ -563,6 +563,48 @@ def _orders_joining_customers() -> SlayerModel:
     })
 
 
+def _chain_model(
+    name: str,
+    *,
+    joins: list[str] | None = None,
+    aggs: list[str] | None = None,
+    extra_cols: list[Column] | None = None,
+) -> SlayerModel:
+    """Build one node of a linear chain a->b->c->... — used by the 4-hop
+    save and query tests to set up an unbounded BFS scenario.
+    """
+    cols = [
+        Column(name="id", type=DataType.INT, primary_key=True),
+    ] + list(extra_cols or [])
+    return SlayerModel(
+        name=name,
+        data_source="prod",
+        sql_table=name,
+        columns=cols,
+        aggregations=[
+            Aggregation(name=a, formula="AVG({value})")
+            for a in (aggs or [])
+        ],
+        joins=[
+            ModelJoin(target_model=t, join_pairs=[["id", "id"]])
+            for t in (joins or [])
+        ],
+    )
+
+
+async def _save_4hop_chain(storage) -> None:
+    """Save the a->b->c->d->e chain shared by the 4-hop tests; ``e`` carries
+    ``rolling_avg`` and a ``score`` column.
+    """
+    await storage.save_model(_chain_model(
+        "e", aggs=["rolling_avg"],
+        extra_cols=[Column(name="score", type=DataType.DOUBLE)],
+    ))
+    await storage.save_model(_chain_model("d", joins=["e"]))
+    await storage.save_model(_chain_model("c", joins=["d"]))
+    await storage.save_model(_chain_model("b", joins=["c"]))
+
+
 async def _engine_with_prod():
     """A fresh engine over an in-memory-SQLite YAML store. Returns
     ``(engine, storage)``; caller owns the TemporaryDirectory lifetime.
@@ -730,32 +772,7 @@ class TestJoinedCustomAggFuncStyle:
         # `rolling_avg(b.c.d.e.score)` is rewritten at save time.
         engine, storage, td = await _engine_with_prod()
         try:
-            def _chain_model(name, *, joins=None, aggs=None, extra_cols=None):
-                cols = [
-                    Column(name="id", type=DataType.INT, primary_key=True),
-                ] + list(extra_cols or [])
-                return SlayerModel(
-                    name=name,
-                    data_source="prod",
-                    sql_table=name,
-                    columns=cols,
-                    aggregations=[
-                        Aggregation(name=a, formula="AVG({value})")
-                        for a in (aggs or [])
-                    ],
-                    joins=[
-                        ModelJoin(target_model=t, join_pairs=[["id", "id"]])
-                        for t in (joins or [])
-                    ],
-                )
-
-            await storage.save_model(_chain_model(
-                "e", aggs=["rolling_avg"],
-                extra_cols=[Column(name="score", type=DataType.DOUBLE)],
-            ))
-            await storage.save_model(_chain_model("d", joins=["e"]))
-            await storage.save_model(_chain_model("c", joins=["d"]))
-            await storage.save_model(_chain_model("b", joins=["c"]))
+            await _save_4hop_chain(storage)
             a = _chain_model("a", joins=["b"]).model_copy(update={
                 "measures": [
                     ModelMeasure(
@@ -800,32 +817,7 @@ class TestJoinedCustomAggFuncStyle:
         # warning whose normalized form is the colon-syntax canonical.
         engine, storage, td = await _engine_with_prod()
         try:
-            def _chain_model(name, *, joins=None, aggs=None, extra_cols=None):
-                cols = [
-                    Column(name="id", type=DataType.INT, primary_key=True),
-                ] + list(extra_cols or [])
-                return SlayerModel(
-                    name=name,
-                    data_source="prod",
-                    sql_table=name,
-                    columns=cols,
-                    aggregations=[
-                        Aggregation(name=a, formula="AVG({value})")
-                        for a in (aggs or [])
-                    ],
-                    joins=[
-                        ModelJoin(target_model=t, join_pairs=[["id", "id"]])
-                        for t in (joins or [])
-                    ],
-                )
-
-            await storage.save_model(_chain_model(
-                "e", aggs=["rolling_avg"],
-                extra_cols=[Column(name="score", type=DataType.DOUBLE)],
-            ))
-            await storage.save_model(_chain_model("d", joins=["e"]))
-            await storage.save_model(_chain_model("c", joins=["d"]))
-            await storage.save_model(_chain_model("b", joins=["c"]))
+            await _save_4hop_chain(storage)
             await storage.save_model(_chain_model("a", joins=["b"]))
             q = SlayerQuery(
                 source_model="a",

--- a/tests/test_source_bundle.py
+++ b/tests/test_source_bundle.py
@@ -12,7 +12,7 @@ extension point.
 from __future__ import annotations
 
 from slayer.core.enums import DataType
-from slayer.core.models import Column, SlayerModel
+from slayer.core.models import Aggregation, Column, ModelJoin, SlayerModel
 from slayer.core.query import ModelExtension, SlayerQuery
 from slayer.engine.source_bundle import ResolvedSourceBundle
 
@@ -25,6 +25,31 @@ def _model(name: str, ds: str = "prod") -> SlayerModel:
         columns=[
             Column(name="id", type=DataType.INT, primary_key=True),
             Column(name="value", type=DataType.DOUBLE),
+        ],
+    )
+
+
+def _model_with(
+    name: str,
+    *,
+    aggs: list[str] | None = None,
+    joins: list[str] | None = None,
+    ds: str = "prod",
+) -> SlayerModel:
+    return SlayerModel(
+        name=name,
+        data_source=ds,
+        sql_table=name,
+        columns=[
+            Column(name="id", type=DataType.INT, primary_key=True),
+            Column(name="value", type=DataType.DOUBLE),
+        ],
+        aggregations=[
+            Aggregation(name=a, formula="AVG({value})") for a in (aggs or [])
+        ],
+        joins=[
+            ModelJoin(target_model=t, join_pairs=[["id", "id"]])
+            for t in (joins or [])
         ],
     )
 
@@ -137,3 +162,108 @@ class TestAnchorlessReadiness:
         b = ResolvedSourceBundle()
         assert b.source_model is None
         assert b.referenced_models == []
+
+
+# ---------------------------------------------------------------------------
+# DEV-1500 — reachable_aggregation_names (sync join-graph BFS)
+# ---------------------------------------------------------------------------
+
+
+class TestReachableAggregationNames:
+    """Sync mirror of enrichment._collect_reachable_agg_names over a bundle.
+
+    Powers the FUNC_STYLE_AGG slack rewrite so a custom aggregation defined on
+    a *joined* model (``rolling_avg(customers.score)``) is recognised and
+    rewritten to colon form. Scoping is per start model: a stage only sees
+    aggregations reachable from its own source model's join graph.
+    """
+
+    def test_own_aggs_only(self):
+        m = _model_with("orders", aggs=["rolling_avg"])
+        b = ResolvedSourceBundle(source_model=m, referenced_models=[m])
+        assert b.reachable_aggregation_names(start=m) == frozenset({"rolling_avg"})
+
+    def test_no_own_but_joined_has(self):
+        orders = _model_with("orders", joins=["customers"])
+        customers = _model_with("customers", aggs=["rolling_avg"])
+        b = ResolvedSourceBundle(
+            source_model=orders, referenced_models=[orders, customers]
+        )
+        assert b.reachable_aggregation_names(start=orders) == frozenset(
+            {"rolling_avg"}
+        )
+
+    def test_four_hops(self):
+        a = _model_with("a", joins=["b"])
+        b_ = _model_with("b", joins=["c"])
+        c = _model_with("c", joins=["d"])
+        d = _model_with("d", joins=["e"])
+        e = _model_with("e", aggs=["deep_agg"])
+        bundle = ResolvedSourceBundle(
+            source_model=a, referenced_models=[a, b_, c, d, e]
+        )
+        assert bundle.reachable_aggregation_names(start=a) == frozenset(
+            {"deep_agg"}
+        )
+
+    def test_cycle_terminates(self):
+        a = _model_with("a", aggs=["agg_a"], joins=["b"])
+        b_ = _model_with("b", joins=["a"])
+        bundle = ResolvedSourceBundle(
+            source_model=a, referenced_models=[a, b_]
+        )
+        # Must terminate (visited guard) and collect a's own aggregation.
+        assert bundle.reachable_aggregation_names(start=a) == frozenset(
+            {"agg_a"}
+        )
+
+    def test_none_when_no_aggs_anywhere(self):
+        orders = _model_with("orders", joins=["customers"])
+        customers = _model_with("customers")
+        b = ResolvedSourceBundle(
+            source_model=orders, referenced_models=[orders, customers]
+        )
+        assert b.reachable_aggregation_names(start=orders) is None
+
+    def test_scoping_excludes_unreachable_model(self):
+        # Two models that do NOT join each other both live in
+        # referenced_models. A scoped walk from M1 must NOT pick up M2's
+        # aggregation (this pins scoped-per-stage vs union-of-all).
+        m1 = _model_with("m1", aggs=["agg_one"])
+        m2 = _model_with("m2", aggs=["agg_two"])
+        b = ResolvedSourceBundle(
+            source_model=m1, referenced_models=[m1, m2]
+        )
+        assert b.reachable_aggregation_names(start=m1) == frozenset(
+            {"agg_one"}
+        )
+
+    def test_absent_join_target_skipped(self):
+        # Join points at a target not present in referenced_models — the
+        # walk is best-effort and skips it without error, returning the
+        # source model's own aggregations.
+        orders = _model_with("orders", aggs=["rolling_avg"], joins=["missing"])
+        b = ResolvedSourceBundle(source_model=orders, referenced_models=[orders])
+        assert b.reachable_aggregation_names(start=orders) == frozenset(
+            {"rolling_avg"}
+        )
+
+    def test_absent_join_target_with_no_own_aggs_returns_none(self):
+        # Skip-absent + empty-collection: a missing join target must not
+        # synthesise an empty frozenset() — the contract is `None` when
+        # nothing is reachable.
+        orders = _model_with("orders", joins=["missing"])
+        b = ResolvedSourceBundle(source_model=orders, referenced_models=[orders])
+        assert b.reachable_aggregation_names(start=orders) is None
+
+    def test_aggs_from_multiple_hops_unioned(self):
+        orders = _model_with("orders", aggs=["a0"], joins=["customers"])
+        customers = _model_with("customers", aggs=["a1"], joins=["regions"])
+        regions = _model_with("regions", aggs=["a2"])
+        b = ResolvedSourceBundle(
+            source_model=orders,
+            referenced_models=[orders, customers, regions],
+        )
+        assert b.reachable_aggregation_names(start=orders) == frozenset(
+            {"a0", "a1", "a2"}
+        )

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -4139,14 +4139,6 @@ class TestDimensionAggregation:
 class TestCrossModelCustomAggFuncStyle:
     """Function-style syntax with custom aggregations from joined models."""
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "DEV-1500: slack FUNC_STYLE_AGG normalization doesn't recognize "
-            "custom aggregations on joined models, so rolling_avg(customers.score) "
-            "reaches Mode-B unrewritten. Auto-promotes when supported."
-        ),
-    )
     async def test_funcstyle_custom_agg_on_joined_model(self, generator: SQLGenerator) -> None:
         """rolling_avg(customers.score) should rewrite and generate SQL."""
 
@@ -4198,13 +4190,6 @@ class TestReachableAggDiscoveryUnbounded:
     ``custom_agg_names`` and the function-style rewrite failed.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "DEV-1500: slack FUNC_STYLE_AGG normalization doesn't recognize "
-            "custom aggregations on joined models. Auto-promotes when supported."
-        ),
-    )
     async def test_funcstyle_custom_agg_at_four_hops(self, generator: SQLGenerator) -> None:
 
         a = SlayerModel(

--- a/tests/test_validate_models.py
+++ b/tests/test_validate_models.py
@@ -442,6 +442,53 @@ class TestCascadeRules:
         assert isinstance(entry, EditModelDelete)
         assert set(entry.remove.measures) >= {"total_amount", "aov"}
 
+    def test_rule_2_funcstyle_joined_custom_agg_cascades(self) -> None:
+        """DEV-1500: a ``ModelMeasure.formula`` using funcstyle over a custom
+        aggregation defined on a JOINED model (``rolling_avg(customers.score)``
+        where ``rolling_avg`` lives on ``customers``) must extract
+        ``customers.score`` as a ref, so dropping that column cascades the
+        measure away. The cascade now walks the reachable join graph for
+        custom aggregation names instead of using the model's own aggs only.
+        """
+        from slayer.core.models import Aggregation
+
+        orders = _orders_model(
+            joins=[
+                ModelJoin(target_model="customers", join_pairs=[["customer_id", "id"]]),
+            ],
+            measures=[
+                ModelMeasure(formula="rolling_avg(customers.score)", name="ravg"),
+            ],
+        )
+        customers = SlayerModel(
+            name="customers",
+            sql_table="customers",
+            data_source="ds",
+            columns=[
+                Column(name="id", sql="id", type=DataType.DOUBLE, primary_key=True),
+                Column(name="score", sql="score", type=DataType.DOUBLE),
+            ],
+            aggregations=[
+                Aggregation(name="rolling_avg", formula="AVG({value})"),
+            ],
+        )
+        # Live diff: ``customers.score`` was dropped.
+        customers_edit = EditModelDelete(
+            model_name="customers",
+            data_source="ds",
+            remove=RemoveSpec(columns=["score"]),
+        )
+        out = compute_datasource_drops(
+            models=[orders, customers],
+            sql_table_diffs={"customers": (customers_edit, {"score"})},
+            sql_diffs={},
+        )
+        # orders.ravg must cascade because its formula references the
+        # dropped customers.score.
+        orders_entry = _entry_for("orders", out)
+        assert isinstance(orders_entry, EditModelDelete), out
+        assert "ravg" in set(orders_entry.remove.measures), orders_entry
+
     def test_rule_3a_join_local_column_dropped(self) -> None:
         """A ``Join`` whose ``local_column`` (= join_pairs[i][0]) was dropped
         produces a ``drop_join`` on the source model.


### PR DESCRIPTION
## Summary
- The slack `FUNC_STYLE_AGG` normalizer now recognizes custom aggregations defined on **joined** models — `rolling_avg(customers.score)` is rewritten to `customers.score:rolling_avg` instead of reaching the Mode-B parser unrewritten and raising `UnknownFunctionError`.
- Query path: `_normalize_stage` uses a new sync `ResolvedSourceBundle.reachable_aggregation_names(*, start)` (BFS over the pre-resolved bundle; scoped per stage).
- Model-save path: `save_model` does a best-effort async storage BFS via the existing `_collect_reachable_agg_names` (swallows `AmbiguousModelError` and any other lookup error) and passes the reachable set into `normalize_model`, which gains a `custom_agg_names: Optional[frozenset[str]] = None` param mirroring `normalize_query` (None → fallback to model's own aggs; explicit `frozenset()` → suppress fallback).
- The two DEV-1484 Stage-C tracking tests (`test_funcstyle_custom_agg_on_joined_model` and `test_funcstyle_custom_agg_at_four_hops`) have their `xfail(strict=True)` removed and now pass.

Linear: DEV-1500.

## Test plan
- [x] `tests/test_source_bundle.py::TestReachableAggregationNames` (9 unit tests: own-aggs, joined-aggs, 4-hop, cycle, none-when-empty, scoping guard, absent target, absent+no-aggs, multi-hop union).
- [x] `tests/test_slack_normalization.py::TestNormalizeModelCustomAggParam` (3 pure tests: param recognises joined agg, None fallback, empty-frozenset suppression).
- [x] `tests/test_slack_normalization.py::TestJoinedCustomAggFuncStyle` (9 engine tests: query-path warning form, save-path rewrite + persistence, multi-stage named-stage positive, missing-target + own discovery still works, AmbiguousModelError spy + swallow, 4-hop save rewrite, filter-path warning, 4-hop query warning, negative multi-stage scoping).
- [x] `poetry run pytest -m "not integration"` — 3925 passed, 6 skipped, 40 xfailed (pre-existing), no regressions.
- [x] `poetry run ruff check slayer/ tests/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom aggregations defined on joined models are now discoverable and usable in measure formulas
  * Function-style aggregations automatically recognize and rewrite custom aggregations accessible through join paths

* **Bug Fixes**
  * Improved cascade detection for schema changes affecting measures that reference aggregations from joined models
<!-- end of auto-generated comment: release notes by coderabbit.ai -->