### PR TITLE
DEV-1492: preserve transform kwargs in filter normalization

### DIFF
--- a/slayer/engine/syntax.py
+++ b/slayer/engine/syntax.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 import ast
 import re
 from decimal import Decimal
-from typing import Any, Dict, Iterator, List, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -166,6 +166,24 @@ _COLON_AGG_RE = re.compile(
     # No (args) consumption — Python's AST handles that.
 )
 
+_FILTER_KEYWORDS = frozenset({"and", "or", "not", "in", "is"})
+_SCAN_TOKEN_RE = re.compile(
+    r"(?P<ws>\s+)"
+    r"|(?P<string>'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\")"
+    r"|(?P<ident>[A-Za-z_]\w*)"
+    r"|(?P<number>\d+(?:\.\d*)?|\.\d+)"
+    r"|(?P<op_eq2>==|<=|>=|!=)"
+    r"|(?P<op_eq>=)"
+    r"|(?P<lparen>\()"
+    r"|(?P<rparen>\))"
+    r"|(?P<lbrack>\[)"
+    r"|(?P<rbrack>\])"
+    r"|(?P<comma>,)"
+    r"|(?P<other>.)",
+    re.DOTALL,
+)
+
+
 _BIN_OP_MAP: Dict[type, str] = {
     ast.Add: "+", ast.Sub: "-", ast.Mult: "*", ast.Div: "/",
     ast.Mod: "%", ast.Pow: "**", ast.FloorDiv: "//",
@@ -279,7 +297,6 @@ def _normalize_sql_filter_operators(text: str) -> str:
         part = re.sub(r"\bNULL\b", "None", part, flags=re.IGNORECASE)
         for kw in ("IS", "NOT", "AND", "OR", "IN"):
             part = re.sub(rf"\b{kw}\b", kw.lower(), part, flags=re.IGNORECASE)
-        part = re.sub(r"(?<![<>=!])=(?!=)", "==", part)
         part = part.replace("<>", "!=")
         # SQL ``||`` concat → Python ``|`` (BitOr), reinterpreted as a
         # ``concat(...)`` ScalarCall in ``_convert``. ``|`` binds tighter
@@ -289,7 +306,127 @@ def _normalize_sql_filter_operators(text: str) -> str:
         result.append(part)
         if i < len(literals):
             result.append(literals[i])
-    return "".join(result)
+    # DEV-1492: the `=` → `==` rewrite runs on the rejoined string with a
+    # call-paren-aware scanner that leaves keyword-argument `=` alone
+    # inside non-scalar calls (transforms / parametric aggregations). Run
+    # last so the scanner sees lowercased keywords and the post-`<>` /
+    # post-`||` text — only its own pass can touch literal-spanning
+    # paren context correctly.
+    return _rewrite_comparison_equals("".join(result))
+
+
+def _rewrite_comparison_equals(text: str) -> str:
+    """Rewrite SQL-style ``=`` to Python ``==`` except where Python would
+    treat the ``=`` as a keyword argument inside a non-scalar call.
+
+    Per the architecture (``docs/architecture/parsing.md`` — scalars
+    reject kwargs, only ``AggCall`` / ``TransformCall`` carry kwargs),
+    a lone ``=`` is preserved (kwarg) iff:
+
+    1. the innermost open paren is a CALL paren (the preceding
+       significant token is a bare identifier, ``)``, or ``]``;
+       otherwise GROUPING). Lowercase Python keywords
+       (``and`` / ``or`` / ``not`` / ``in`` / ``is``) do not classify
+       a following ``(`` as a call paren — they introduce a grouping
+       paren (``not(...)``, ``x in (...)``).
+    2. the callee of that innermost call is NOT in
+       :data:`SCALAR_FUNCTIONS` — scalars never accept kwargs, so a
+       ``=`` inside them is the user's SQL comparison
+       (``coalesce(status = 'paid', False)``).
+    3. the ``=`` is immediately preceded (skipping whitespace) by an
+       identifier preceded (skipping whitespace) by the call's ``(``
+       or by a ``,`` at that paren depth — Python's
+       keyword-argument grammar.
+
+    Compound operators (``==``, ``<=``, ``>=``, ``!=``) are emitted
+    verbatim by the tokenizer so their ``=`` is never touched. String
+    literals are tokenized as a unit (Python single/double-quoted with
+    backslash escapes) and pass through without perturbing the paren
+    stack or the previous-significant-token history.
+    """
+    out: List[str] = []
+    # Each frame: (is_call, callee). ``callee`` is the identifier text
+    # preceding the call's ``(``, or ``None`` (e.g. a callable expression
+    # like ``f()(x=1)`` where the prior token is ``)``).
+    stack: List[Tuple[bool, Optional[str]]] = []
+    # Trailing window of the last 2 significant tokens (oldest-first).
+    # Categories: NAME (bare identifier), KW (lowercase Python keyword),
+    # LPAREN, COMMA, OTHER (everything else; string literals don't enter
+    # the history).
+    hist: List[Tuple[str, str]] = []
+
+    def _push(kind: str, text: str) -> None:
+        hist.append((kind, text))
+        if len(hist) > 2:
+            del hist[0]
+
+    for m in _SCAN_TOKEN_RE.finditer(text):
+        if m.group("ws") is not None:
+            out.append(m.group(0))
+            continue
+        if m.group("string") is not None:
+            out.append(m.group(0))
+            continue
+        ident = m.group("ident")
+        if ident is not None:
+            out.append(ident)
+            _push("KW" if ident in _FILTER_KEYWORDS else "NAME", ident)
+            continue
+        if m.group("number") is not None:
+            out.append(m.group(0))
+            _push("OTHER", m.group(0))
+            continue
+        if m.group("op_eq2") is not None:
+            out.append(m.group(0))
+            _push("OTHER", m.group(0))
+            continue
+        if m.group("op_eq") is not None:
+            prev_kind = hist[-1][0] if hist else None
+            prev_prev_kind = hist[-2][0] if len(hist) >= 2 else None
+            top = stack[-1] if stack else None
+            is_kwarg = (
+                top is not None
+                and top[0]  # call paren
+                and (top[1] is None or top[1] not in SCALAR_FUNCTIONS)
+                and prev_kind == "NAME"
+                and prev_prev_kind in ("LPAREN", "COMMA")
+            )
+            out.append("=" if is_kwarg else "==")
+            _push("OTHER", "=")
+            continue
+        if m.group("lparen") is not None:
+            prev_kind = hist[-1][0] if hist else None
+            prev_text = hist[-1][1] if hist else ""
+            is_call = prev_kind == "NAME" or prev_text in (")", "]")
+            callee = hist[-1][1] if (is_call and prev_kind == "NAME") else None
+            stack.append((is_call, callee))
+            out.append("(")
+            _push("LPAREN", "(")
+            continue
+        if m.group("rparen") is not None:
+            if stack:
+                stack.pop()
+            out.append(")")
+            _push("OTHER", ")")
+            continue
+        if m.group("lbrack") is not None:
+            out.append("[")
+            _push("OTHER", "[")
+            continue
+        if m.group("rbrack") is not None:
+            out.append("]")
+            _push("OTHER", "]")
+            continue
+        if m.group("comma") is not None:
+            out.append(",")
+            _push("COMMA", ",")
+            continue
+        # Any other single char (``:``, ``.``, ``+``, ``-``, ``*``, ``/``,
+        # ``%``, ``<``, ``>``, ``!``, ``|``, ``{``, ``}``, ...).
+        out.append(m.group(0))
+        _push("OTHER", m.group(0))
+
+    return "".join(out)
 
 
 # ---------------------------------------------------------------------------

--- a/slayer/engine/syntax.py
+++ b/slayer/engine/syntax.py
@@ -325,11 +325,23 @@ def _classify_paren(
     / ``]``). Lowercase keywords (``and`` / ``or`` / ``not`` / ``in``
     / ``is``) do NOT make the next ``(`` a call paren — that's why
     ``not(...)`` and ``x in (...)`` carry grouping parens.
+
+    DEV-1492 iteration 3: a colon-aggregation context
+    (``revenue:first(...)``) makes the call a parametric aggregation
+    regardless of the callee name. ``first`` and ``last`` sit in both
+    :data:`ALL_TRANSFORMS` and the built-in aggregation set
+    (``_AMBIGUOUS_AGG_TRANSFORMS`` in ``slayer/core/formula.py``);
+    after a ``:`` they are always aggregations, never transforms.
+    Drop the callee to ``None`` so :func:`_is_kwarg_equals` takes the
+    aggregation/unknown branch (kwargs preserved after ``(`` or
+    ``,``).
     """
     prev_kind = hist[-1][0] if hist else None
     prev_text = hist[-1][1] if hist else ""
     is_call = prev_kind == "NAME" or prev_text in (")", "]")
     callee = hist[-1][1] if (is_call and prev_kind == "NAME") else None
+    if callee is not None and len(hist) >= 2 and hist[-2] == ("OTHER", ":"):
+        callee = None
     return is_call, callee
 
 

--- a/slayer/engine/syntax.py
+++ b/slayer/engine/syntax.py
@@ -339,18 +339,32 @@ def _is_kwarg_equals(
 ) -> bool:
     """Whether a lone ``=`` is a Python keyword-argument separator.
 
-    True iff the innermost open paren is a call paren whose callee is
-    NOT a scalar (scalars never accept kwargs), and the ``=`` matches
-    Python's ``IDENT preceded by ( or ,`` keyword-argument grammar.
+    Three callee classes get different treatment (DEV-1492 iteration 2):
+
+    * **Scalar** (``callee in SCALAR_FUNCTIONS``) — never a kwarg;
+      scalars reject keyword args by design.
+    * **Transform** (``callee in ALL_TRANSFORMS``) — the first
+      positional is always the value to transform, so a kwarg can
+      only appear AFTER a ``,``. This preserves the documented
+      predicate-input form (``consecutive_periods(status = 'paid')``
+      where the SQL ``=`` is part of the predicate, not a kwarg).
+    * **Aggregation or unknown** — kwarg can be the first arg
+      (``weighted_avg(weight=qty)``, ``percentile(p=0.5)``), so the
+      ``=`` may follow either ``(`` or ``,``.
     """
     top = stack[-1] if stack else None
     if top is None or not top[0]:
         return False
-    if top[1] is not None and top[1] in SCALAR_FUNCTIONS:
+    callee = top[1]
+    if callee is not None and callee in SCALAR_FUNCTIONS:
         return False
     prev_kind = hist[-1][0] if hist else None
+    if prev_kind != "NAME":
+        return False
     prev_prev_kind = hist[-2][0] if len(hist) >= 2 else None
-    return prev_kind == "NAME" and prev_prev_kind in ("LPAREN", "COMMA")
+    if callee is not None and callee in ALL_TRANSFORMS:
+        return prev_prev_kind == "COMMA"
+    return prev_prev_kind in ("LPAREN", "COMMA")
 
 
 def _push_hist(hist: List[Tuple[str, str]], kind: str, text: str) -> None:

--- a/slayer/engine/syntax.py
+++ b/slayer/engine/syntax.py
@@ -315,6 +315,145 @@ def _normalize_sql_filter_operators(text: str) -> str:
     return _rewrite_comparison_equals("".join(result))
 
 
+def _classify_paren(
+    hist: List[Tuple[str, str]],
+) -> Tuple[bool, Optional[str]]:
+    """Classify an open ``(`` as a CALL or GROUPING paren.
+
+    A ``(`` is a call paren when the previous significant token is a
+    bare identifier (callable name) or a callable-suffix token (``)``
+    / ``]``). Lowercase keywords (``and`` / ``or`` / ``not`` / ``in``
+    / ``is``) do NOT make the next ``(`` a call paren — that's why
+    ``not(...)`` and ``x in (...)`` carry grouping parens.
+    """
+    prev_kind = hist[-1][0] if hist else None
+    prev_text = hist[-1][1] if hist else ""
+    is_call = prev_kind == "NAME" or prev_text in (")", "]")
+    callee = hist[-1][1] if (is_call and prev_kind == "NAME") else None
+    return is_call, callee
+
+
+def _is_kwarg_equals(
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> bool:
+    """Whether a lone ``=`` is a Python keyword-argument separator.
+
+    True iff the innermost open paren is a call paren whose callee is
+    NOT a scalar (scalars never accept kwargs), and the ``=`` matches
+    Python's ``IDENT preceded by ( or ,`` keyword-argument grammar.
+    """
+    top = stack[-1] if stack else None
+    if top is None or not top[0]:
+        return False
+    if top[1] is not None and top[1] in SCALAR_FUNCTIONS:
+        return False
+    prev_kind = hist[-1][0] if hist else None
+    prev_prev_kind = hist[-2][0] if len(hist) >= 2 else None
+    return prev_kind == "NAME" and prev_prev_kind in ("LPAREN", "COMMA")
+
+
+def _push_hist(hist: List[Tuple[str, str]], kind: str, text: str) -> None:
+    """Append ``(kind, text)`` and trim ``hist`` to the last 2 entries."""
+    hist.append((kind, text))
+    if len(hist) > 2:
+        del hist[0]
+
+
+def _handle_pass_through(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    """Whitespace and string literals: emit verbatim, don't touch hist."""
+    out.append(m.group(0))
+
+
+def _handle_ident(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    ident = m.group(0)
+    out.append(ident)
+    _push_hist(hist, "KW" if ident in _FILTER_KEYWORDS else "NAME", ident)
+
+
+def _handle_other(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    """Numbers, compound ops (``==``/``<=``/``>=``/``!=``), brackets, and
+    any single char not otherwise classified (``:``, ``.``, ``+``, ``-``,
+    ``*``, ``/``, ``%``, ``<``, ``>``, ``!``, ``|``, ``{``, ``}``, ...)."""
+    text = m.group(0)
+    out.append(text)
+    _push_hist(hist, "OTHER", text)
+
+
+def _handle_comma(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    out.append(",")
+    _push_hist(hist, "COMMA", ",")
+
+
+def _handle_lparen(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    stack.append(_classify_paren(hist))
+    out.append("(")
+    _push_hist(hist, "LPAREN", "(")
+
+
+def _handle_rparen(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    if stack:
+        stack.pop()
+    out.append(")")
+    _push_hist(hist, "OTHER", ")")
+
+
+def _handle_op_eq(
+    m: "re.Match[str]",
+    out: List[str],
+    stack: List[Tuple[bool, Optional[str]]],
+    hist: List[Tuple[str, str]],
+) -> None:
+    out.append("=" if _is_kwarg_equals(stack, hist) else "==")
+    _push_hist(hist, "OTHER", "=")
+
+
+_HANDLERS: Dict[str, Any] = {
+    "ws": _handle_pass_through,
+    "string": _handle_pass_through,
+    "ident": _handle_ident,
+    "number": _handle_other,
+    "op_eq2": _handle_other,
+    "op_eq": _handle_op_eq,
+    "lparen": _handle_lparen,
+    "rparen": _handle_rparen,
+    "lbrack": _handle_other,
+    "rbrack": _handle_other,
+    "comma": _handle_comma,
+    "other": _handle_other,
+}
+
+
 def _rewrite_comparison_equals(text: str) -> str:
     """Rewrite SQL-style ``=`` to Python ``==`` except where Python would
     treat the ``=`` as a keyword argument inside a non-scalar call.
@@ -323,26 +462,27 @@ def _rewrite_comparison_equals(text: str) -> str:
     reject kwargs, only ``AggCall`` / ``TransformCall`` carry kwargs),
     a lone ``=`` is preserved (kwarg) iff:
 
-    1. the innermost open paren is a CALL paren (the preceding
-       significant token is a bare identifier, ``)``, or ``]``;
-       otherwise GROUPING). Lowercase Python keywords
-       (``and`` / ``or`` / ``not`` / ``in`` / ``is``) do not classify
-       a following ``(`` as a call paren — they introduce a grouping
-       paren (``not(...)``, ``x in (...)``).
+    1. the innermost open paren is a CALL paren (see
+       :func:`_classify_paren`),
     2. the callee of that innermost call is NOT in
        :data:`SCALAR_FUNCTIONS` — scalars never accept kwargs, so a
        ``=`` inside them is the user's SQL comparison
-       (``coalesce(status = 'paid', False)``).
+       (``coalesce(status = 'paid', False)``),
     3. the ``=`` is immediately preceded (skipping whitespace) by an
        identifier preceded (skipping whitespace) by the call's ``(``
-       or by a ``,`` at that paren depth — Python's
-       keyword-argument grammar.
+       or by a ``,`` at that paren depth — Python's keyword-argument
+       grammar (see :func:`_is_kwarg_equals`).
 
     Compound operators (``==``, ``<=``, ``>=``, ``!=``) are emitted
     verbatim by the tokenizer so their ``=`` is never touched. String
     literals are tokenized as a unit (Python single/double-quoted with
     backslash escapes) and pass through without perturbing the paren
     stack or the previous-significant-token history.
+
+    Token-class dispatch goes through :data:`_HANDLERS` keyed by the
+    regex's ``lastgroup`` (each token-class group is named and the
+    arms are mutually exclusive, so ``lastgroup`` is exactly the
+    matched arm).
     """
     out: List[str] = []
     # Each frame: (is_call, callee). ``callee`` is the identifier text
@@ -354,78 +494,8 @@ def _rewrite_comparison_equals(text: str) -> str:
     # LPAREN, COMMA, OTHER (everything else; string literals don't enter
     # the history).
     hist: List[Tuple[str, str]] = []
-
-    def _push(kind: str, text: str) -> None:
-        hist.append((kind, text))
-        if len(hist) > 2:
-            del hist[0]
-
     for m in _SCAN_TOKEN_RE.finditer(text):
-        if m.group("ws") is not None:
-            out.append(m.group(0))
-            continue
-        if m.group("string") is not None:
-            out.append(m.group(0))
-            continue
-        ident = m.group("ident")
-        if ident is not None:
-            out.append(ident)
-            _push("KW" if ident in _FILTER_KEYWORDS else "NAME", ident)
-            continue
-        if m.group("number") is not None:
-            out.append(m.group(0))
-            _push("OTHER", m.group(0))
-            continue
-        if m.group("op_eq2") is not None:
-            out.append(m.group(0))
-            _push("OTHER", m.group(0))
-            continue
-        if m.group("op_eq") is not None:
-            prev_kind = hist[-1][0] if hist else None
-            prev_prev_kind = hist[-2][0] if len(hist) >= 2 else None
-            top = stack[-1] if stack else None
-            is_kwarg = (
-                top is not None
-                and top[0]  # call paren
-                and (top[1] is None or top[1] not in SCALAR_FUNCTIONS)
-                and prev_kind == "NAME"
-                and prev_prev_kind in ("LPAREN", "COMMA")
-            )
-            out.append("=" if is_kwarg else "==")
-            _push("OTHER", "=")
-            continue
-        if m.group("lparen") is not None:
-            prev_kind = hist[-1][0] if hist else None
-            prev_text = hist[-1][1] if hist else ""
-            is_call = prev_kind == "NAME" or prev_text in (")", "]")
-            callee = hist[-1][1] if (is_call and prev_kind == "NAME") else None
-            stack.append((is_call, callee))
-            out.append("(")
-            _push("LPAREN", "(")
-            continue
-        if m.group("rparen") is not None:
-            if stack:
-                stack.pop()
-            out.append(")")
-            _push("OTHER", ")")
-            continue
-        if m.group("lbrack") is not None:
-            out.append("[")
-            _push("OTHER", "[")
-            continue
-        if m.group("rbrack") is not None:
-            out.append("]")
-            _push("OTHER", "]")
-            continue
-        if m.group("comma") is not None:
-            out.append(",")
-            _push("COMMA", ",")
-            continue
-        # Any other single char (``:``, ``.``, ``+``, ``-``, ``*``, ``/``,
-        # ``%``, ``<``, ``>``, ``!``, ``|``, ``{``, ``}``, ...).
-        out.append(m.group(0))
-        _push("OTHER", m.group(0))
-
+        _HANDLERS[m.lastgroup](m, out, stack, hist)
     return "".join(out)
 
 

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1631,6 +1631,69 @@ class TestRankFamilyTransforms:
             f"<= 5 predicate should live in the outer wrapper, got:\n{sql}"
         )
 
+    async def test_ntile_with_n_kwarg_in_filter(
+        self, generator: SQLGenerator, orders_model: SlayerModel
+    ) -> None:
+        """DEV-1492: ``ntile(<measure>, n=4) <= 1`` end-to-end.
+
+        Mirrors ``test_dense_rank_in_filter_top_5_distinct``. The fix to
+        ``parse_filter_expr`` (DEV-1492) preserves the ``n=4`` kwarg through
+        operator normalization, so the filter parses as a TransformCall with
+        kwargs and the planner extracts it as a hidden field. The window
+        function must materialise inside the inner SELECT and the comparison
+        must live in the outer ``_filtered`` wrapper.
+        """
+        query = SlayerQuery(
+            source_model="orders",
+            dimensions=[ColumnRef(name="customer_id")],
+            measures=[ModelMeasure(formula="revenue:sum")],
+            filters=["ntile(revenue:sum, n=4) <= 1"],
+        )
+        sql = await _generate(generator, query, orders_model)
+        assert "_filtered" in sql, f"expected post-filter wrapper, got:\n{sql}"
+        inner_sql, outer_sql = sql.split("_filtered", 1)
+        assert "NTILE(4)" in inner_sql, (
+            f"NTILE(4) should be materialised in the inner SELECT, got:\n{sql}"
+        )
+        assert "NTILE(" not in outer_sql, (
+            f"NTILE should not appear in the outer wrapper, got:\n{sql}"
+        )
+        assert "<= 1" in _norm(outer_sql), (
+            f"<= 1 predicate should live in the outer wrapper, got:\n{sql}"
+        )
+
+    async def test_rank_with_partition_by_kwarg_in_filter(
+        self, generator: SQLGenerator, orders_model: SlayerModel
+    ) -> None:
+        """DEV-1492: ``rank(<measure>, partition_by=<col>) <= 1`` end-to-end.
+
+        Same fix path as ntile-with-n: ``partition_by=status`` must survive
+        operator normalization so the planner sees it as a kwarg, binds it to
+        a column ref, and emits ``RANK() OVER (PARTITION BY ...)`` in the
+        inner SELECT. The ``<= 1`` predicate must land in the outer
+        ``_filtered`` wrapper.
+        """
+        query = SlayerQuery(
+            source_model="orders",
+            dimensions=[ColumnRef(name="status"), ColumnRef(name="customer_id")],
+            measures=[ModelMeasure(formula="revenue:sum")],
+            filters=["rank(revenue:sum, partition_by=status) <= 1"],
+        )
+        sql = await _generate(generator, query, orders_model)
+        assert "_filtered" in sql, f"expected post-filter wrapper, got:\n{sql}"
+        inner_sql, outer_sql = sql.split("_filtered", 1)
+        assert (
+            'RANK() OVER (PARTITION BY "orders.status" '
+            'ORDER BY "orders.revenue_sum" DESC)'
+            in _norm(inner_sql)
+        ), f"PARTITION BY status should appear in the inner SELECT, got:\n{sql}"
+        assert "RANK()" not in outer_sql, (
+            f"RANK should not appear in the outer wrapper, got:\n{sql}"
+        )
+        assert "<= 1" in _norm(outer_sql), (
+            f"<= 1 predicate should live in the outer wrapper, got:\n{sql}"
+        )
+
     async def test_rank_partition_by_time_dimension(
         self, generator: SQLGenerator, orders_model: SlayerModel
     ) -> None:

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -686,6 +686,28 @@ class TestFilterOperatorNormalization:
         assert right.left == Ref(name="status")
         assert right.right == Literal(value="),=")
 
+    def test_transform_bare_ref_equality_predicate_preserved(self):
+        # DEV-1492 iteration 2 (Codex review): consecutive_periods(predicate)
+        # is documented to take a boolean predicate (formulas.md:140,163,170).
+        # A bare-ref SQL equality (`status = 'paid'`) as the first positional
+        # arg of a transform must NOT be misread as a kwarg — transforms only
+        # accept kwargs AFTER the value (i.e. after the first `,`). The colon-
+        # agg form (`revenue:sum > 0`) already worked because the `:` token
+        # breaks the LPAREN/IDENT pattern; the bare-ref form is the gap.
+        result = parse_filter_expr("consecutive_periods(status = 'paid') >= 2")
+        assert isinstance(result, Cmp)
+        assert result.op == ">="
+        assert isinstance(result.left, TransformCall)
+        assert result.left.op == "consecutive_periods"
+        assert result.left.args == ()
+        assert result.left.kwargs == ()
+        inner = result.left.input
+        assert isinstance(inner, Cmp)
+        assert inner.op == "=="
+        assert inner.left == Ref(name="status")
+        assert inner.right == Literal(value="paid")
+        assert result.right == Literal(value=Decimal(2))
+
     def test_comparison_inside_ifnull_scalar_call_preserved(self):
         # DEV-1492 (Codex review): the SCALAR_FUNCTIONS narrowing must
         # apply to every scalar in the allowlist, not just `coalesce`.

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -500,21 +500,202 @@ class TestFilterOperatorNormalization:
         assert result.left.args == (Ref(name="status"), Ref(name="status"))
         assert result.right == Literal(value="foo")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "DEV-1492: parse_filter_expr's SQL '='->'==' rewrite mangles a "
-            "transform kwarg inside call parens (n=4 -> n==4), so the kwarg "
-            "lands as a positional Cmp arg instead of kwargs. Auto-promotes "
-            "to PASS when DEV-1492 is fixed."
-        ),
-    )
     def test_transform_kwarg_preserved_in_filter(self):
-        # ntile(revenue:sum, n=4) <= 1 — the n=4 kwarg must survive the
-        # filter operator-normalization, not be rewritten to ``n == 4``.
+        # DEV-1492: ntile(revenue:sum, n=4) <= 1 — the n=4 kwarg must
+        # survive the SQL operator-normalization (the previous '=' -> '=='
+        # rewrite mangled kwargs inside call parens).
         result = parse_filter_expr("ntile(revenue:sum, n=4) <= 1")
         assert isinstance(result, Cmp)
         assert isinstance(result.left, TransformCall)
         assert result.left.op == "ntile"
         assert result.left.args == ()
         assert result.left.kwargs == (("n", Literal(value=Decimal(4))),)
+
+    def test_rank_partition_by_kwarg_preserved_in_filter(self):
+        # DEV-1492: rank(revenue:sum, partition_by=region) <= 1 — kwarg
+        # survives the operator rewrite; binder turns partition_by into a
+        # column ref (covered by SQL-gen tests).
+        result = parse_filter_expr("rank(revenue:sum, partition_by=region) <= 1")
+        assert isinstance(result, Cmp)
+        assert result.op == "<="
+        assert isinstance(result.left, TransformCall)
+        assert result.left.op == "rank"
+        assert result.left.args == ()
+        assert result.left.kwargs == (("partition_by", Ref(name="region")),)
+        assert result.right == Literal(value=Decimal(1))
+
+    def test_rank_partition_by_list_kwarg_preserved_in_filter(self):
+        # DEV-1492: list-form partition_by kwarg survives. _convert_kwarg_value
+        # converts the list to a tuple of Refs.
+        result = parse_filter_expr(
+            "rank(revenue:sum, partition_by=[region, channel]) <= 1"
+        )
+        assert isinstance(result, Cmp)
+        assert isinstance(result.left, TransformCall)
+        assert result.left.op == "rank"
+        assert result.left.kwargs == (
+            ("partition_by", (Ref(name="region"), Ref(name="channel"))),
+        )
+
+    def test_grouping_paren_equality_still_rewritten(self):
+        # DEV-1492 regression guard: a `=` inside a *grouping* paren (not a
+        # call) must still be rewritten to `==`. The kwarg-preservation rule
+        # keys off CALL-paren classification, not bare paren depth.
+        result = parse_filter_expr("(status = 'x' or amount = 5)")
+        assert isinstance(result, BoolOp)
+        assert result.op == "or"
+        assert len(result.operands) == 2
+        left, right = result.operands
+        assert isinstance(left, Cmp) and left.op == "=="
+        assert left.left == Ref(name="status") and left.right == Literal(value="x")
+        assert isinstance(right, Cmp) and right.op == "=="
+        assert right.left == Ref(name="amount")
+        assert right.right == Literal(value=Decimal(5))
+
+    def test_mixed_transform_kwarg_and_top_level_equality(self):
+        # DEV-1492: a transform kwarg `=` inside a call and a SQL equality
+        # `=` at top level must be classified independently in the same
+        # expression. Proves the scanner is selective, not global.
+        result = parse_filter_expr(
+            "ntile(revenue:sum, n=4) <= 1 and status = 'paid'"
+        )
+        assert isinstance(result, BoolOp)
+        assert result.op == "and"
+        assert len(result.operands) == 2
+        left, right = result.operands
+        assert isinstance(left, Cmp) and left.op == "<="
+        assert isinstance(left.left, TransformCall)
+        assert left.left.op == "ntile"
+        assert left.left.kwargs == (("n", Literal(value=Decimal(4))),)
+        assert isinstance(right, Cmp) and right.op == "=="
+        assert right.left == Ref(name="status")
+        assert right.right == Literal(value="paid")
+
+    def test_equality_inside_string_literal_untouched(self):
+        # DEV-1492 literal-awareness: the `=` inside the string literal
+        # `'a=b'` must not be touched by the scanner; only the outer SQL
+        # equality is rewritten.
+        result = parse_filter_expr("status = 'a=b'")
+        assert isinstance(result, Cmp)
+        assert result.op == "=="
+        assert result.left == Ref(name="status")
+        assert result.right == Literal(value="a=b")
+
+    def test_comparison_inside_scalar_call_preserved(self):
+        # DEV-1492: the SCALAR_FUNCTIONS narrowing keeps the historical
+        # behavior of `coalesce(status = 'paid', False)` — the `=` inside
+        # a scalar call is a SQL comparison, not a kwarg (scalars reject
+        # kwargs per architecture). Without the narrowing, the kwarg-
+        # preservation rule would re-read `status='paid'` as a kwarg and
+        # the binder would reject it.
+        result = parse_filter_expr("coalesce(status = 'paid', False)")
+        assert isinstance(result, ScalarCall)
+        assert result.name == "coalesce"
+        assert len(result.args) == 2
+        first, second = result.args
+        assert isinstance(first, Cmp)
+        assert first.op == "=="
+        assert first.left == Ref(name="status")
+        assert first.right == Literal(value="paid")
+        assert second == Literal(value=False)
+
+    def test_colon_agg_kwarg_preserved_in_filter(self):
+        # DEV-1492: parametric aggregation kwarg (e.g. percentile(p=...))
+        # is the same failure mode as transform kwargs — the colon-agg
+        # callee `percentile` is not a SCALAR_FUNCTION, so the scanner
+        # preserves `p=0.5` as a kwarg on the AggCall.
+        result = parse_filter_expr("revenue:percentile(p=0.5) > 100")
+        assert isinstance(result, Cmp)
+        assert result.op == ">"
+        assert isinstance(result.left, AggCall)
+        assert result.left.source == Ref(name="revenue")
+        assert result.left.agg == "percentile"
+        assert result.left.args == ()
+        assert result.left.kwargs == (
+            ("p", Literal(value=Decimal("0.5"))),
+        )
+        assert result.right == Literal(value=Decimal(100))
+
+    def test_transform_kwarg_with_whitespace_around_equals_preserved(self):
+        # DEV-1492 (Codex review): the scanner skips whitespace when
+        # checking the `IDENT = value` shape, so a spaced kwarg still
+        # parses as a kwarg, not a positional comparison.
+        result = parse_filter_expr("ntile(revenue:sum, n = 4) <= 1")
+        assert isinstance(result, Cmp)
+        assert isinstance(result.left, TransformCall)
+        assert result.left.op == "ntile"
+        assert result.left.args == ()
+        assert result.left.kwargs == (("n", Literal(value=Decimal(4))),)
+
+    def test_not_paren_is_grouping_not_call(self):
+        # DEV-1492 (Codex review): the lowercased keyword `not` is not an
+        # identifier, so the `(` after it must classify as GROUPING (not
+        # CALL). The `=` inside is therefore a SQL comparison and gets
+        # rewritten to `==`. Python's `not(x)` is UnaryOp(Not, x), not a
+        # function call.
+        result = parse_filter_expr("not(status = 'paid')")
+        assert isinstance(result, UnaryOp)
+        assert result.op == "not"
+        assert isinstance(result.operand, Cmp)
+        assert result.operand.op == "=="
+        assert result.operand.left == Ref(name="status")
+        assert result.operand.right == Literal(value="paid")
+
+    def test_nested_scalar_in_transform_with_kwarg(self):
+        # DEV-1492 (Codex review): innermost-paren tracking across nested
+        # calls. Outer transform `rank` has a kwarg `partition_by=region`
+        # which must be preserved; inner scalar `coalesce(status = 'paid',
+        # 0)` has a `=` which must be rewritten (SCALAR_FUNCTIONS
+        # narrowing). Exercises the per-frame (kind, callee) stack.
+        result = parse_filter_expr(
+            "rank(coalesce(status = 'paid', 0), partition_by=region) <= 1"
+        )
+        assert isinstance(result, Cmp)
+        assert result.op == "<="
+        assert isinstance(result.left, TransformCall)
+        assert result.left.op == "rank"
+        # Transform kwarg preserved.
+        assert result.left.kwargs == (("partition_by", Ref(name="region")),)
+        # Transform input is the inner coalesce ScalarCall with a Cmp arg.
+        inner = result.left.input
+        assert isinstance(inner, ScalarCall)
+        assert inner.name == "coalesce"
+        assert len(inner.args) == 2
+        cmp_arg, zero = inner.args
+        assert isinstance(cmp_arg, Cmp) and cmp_arg.op == "=="
+        assert cmp_arg.left == Ref(name="status")
+        assert cmp_arg.right == Literal(value="paid")
+        assert zero == Literal(value=Decimal(0))
+
+    def test_string_literal_with_parens_commas_equals_does_not_corrupt_stack(self):
+        # DEV-1492 (Codex review): a string literal containing `)`, `,`,
+        # and `=` must not perturb the scanner's paren-kind stack or
+        # previous-token tracking. Both the kwarg `n=4` and the top-level
+        # `status = '),='` must be classified correctly.
+        result = parse_filter_expr(
+            "ntile(revenue:sum, n=4) <= 1 and status = '),='"
+        )
+        assert isinstance(result, BoolOp)
+        assert result.op == "and"
+        left, right = result.operands
+        assert isinstance(left, Cmp) and left.op == "<="
+        assert isinstance(left.left, TransformCall)
+        assert left.left.op == "ntile"
+        assert left.left.kwargs == (("n", Literal(value=Decimal(4))),)
+        assert isinstance(right, Cmp) and right.op == "=="
+        assert right.left == Ref(name="status")
+        assert right.right == Literal(value="),=")
+
+    def test_comparison_inside_ifnull_scalar_call_preserved(self):
+        # DEV-1492 (Codex review): the SCALAR_FUNCTIONS narrowing must
+        # apply to every scalar in the allowlist, not just `coalesce`.
+        # `ifnull` (also a null-handling scalar) gets the same treatment.
+        result = parse_filter_expr("ifnull(status = 'paid', False)")
+        assert isinstance(result, ScalarCall)
+        assert result.name == "ifnull"
+        assert len(result.args) == 2
+        first, second = result.args
+        assert isinstance(first, Cmp) and first.op == "=="
+        assert first.left == Ref(name="status")
+        assert first.right == Literal(value="paid")
+        assert second == Literal(value=False)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -686,6 +686,25 @@ class TestFilterOperatorNormalization:
         assert right.left == Ref(name="status")
         assert right.right == Literal(value="),=")
 
+    def test_colon_agg_with_ambiguous_name_preserves_kwarg_in_filter(self):
+        # DEV-1492 iteration 3 (Codex review): `first` and `last` are in
+        # both ALL_TRANSFORMS (FIRST_VALUE window) and BUILTIN_AGGREGATIONS
+        # (per-group first/last). The colon makes them aggregation calls,
+        # so a kwarg after `(` must be preserved — the transform-only
+        # COMMA-after-IDENT rule does NOT apply when the call sits after
+        # a `:`. Built-in `first`/`last` take the order column positionally
+        # today, but custom aggregations overriding these names can declare
+        # any kwarg shape; this pins the architectural rule.
+        result = parse_filter_expr("revenue:first(order=created_at) > 0")
+        assert isinstance(result, Cmp)
+        assert result.op == ">"
+        assert isinstance(result.left, AggCall)
+        assert result.left.source == Ref(name="revenue")
+        assert result.left.agg == "first"
+        assert result.left.args == ()
+        assert result.left.kwargs == (("order", Ref(name="created_at")),)
+        assert result.right == Literal(value=Decimal(0))
+
     def test_transform_bare_ref_equality_predicate_preserved(self):
         # DEV-1492 iteration 2 (Codex review): consecutive_periods(predicate)
         # is documented to take a boolean predicate (formulas.md:140,163,170).


### PR DESCRIPTION
## Summary
- `parse_filter_expr`'s blanket `=`→`==` rewrite mangled keyword arguments inside transform / parametric-aggregation calls, so `ntile(<m>, n=4) <= 1`, `rank(<m>, partition_by=<col>) <= N`, and `revenue:percentile(p=0.5) > 100` were rejected at the binder ("Transform 'X' accepts exactly one positional argument"). The documented top-N-in-filter patterns were broken end-to-end whenever a kwarg was present.
- Replace the per-part `=`→`==` regex with a literal-aware, paren-kind-tracking single scan that preserves `=` as a kwarg iff the innermost open paren is a CALL paren whose callee is not in `SCALAR_FUNCTIONS`, and the `=` matches Python's `IDENT preceded by ( or ,` kwarg grammar. Lowercase keywords (`and`/`or`/`not`/`in`/`is`) do not classify a following `(` as a call paren.
- The `SCALAR_FUNCTIONS` narrowing mirrors the architecture's existing no-kwargs-on-scalars rule (`docs/architecture/parsing.md`), so `coalesce(status = 'paid', False)` still normalizes to a `ScalarCall` with a `Cmp` arg as before — confirmed by a regression test.

Linear: [DEV-1492](https://linear.app/motley-ai/issue/DEV-1492/parse-filter-expr-mangles-transform-kwargs-in-filters-ntilex-n4-1)

## Test plan
- [x] `tests/test_syntax.py::TestFilterOperatorNormalization` — un-xfail tracking test + 12 new parse-level cases: `rank(..., partition_by=region)`, list form `partition_by=[a,b]`, grouping-paren guard, mixed transform-kwarg + top-level equality, literal-awareness `status = 'a=b'`, scalar-comparison preserved (`coalesce`/`ifnull`), colon-agg kwarg `revenue:percentile(p=0.5) > 100`, spaced kwarg `n = 4`, `not(...)` grouping classification, nested scalar-in-transform stacking, string literal containing `)`/`,`/`=`.
- [x] `tests/test_sql_generator.py::TestRankFamilyTransforms` — 2 end-to-end emission tests pinning `NTILE(4)` and `RANK() OVER (PARTITION BY ...)` to the inner SELECT and the `<= 1` predicate to the `_filtered` outer wrapper.
- [x] Full non-integration suite: `3917 passed, 6 skipped, 41 xfailed, 0 failed` (3m22s).
- [x] `ruff check slayer/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter-expression parsing: `=` is now reliably converted to `==` where appropriate while preserving function keyword arguments and respecting grouping vs. call parentheses; string literals and compound operators remain unchanged.

* **Tests**
  * Expanded regression and unit tests covering nested calls, kwarg preservation, grouping vs. call behavior, scalar-function arguments, and string-literal edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->