### PR TITLE
Bump version to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.7.1"
+version = "0.7.2"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.7.2 covering the SQLite ingestion type-probe fix and the new `distinct_dimension_values` raw-row flag landed since 0.7.1.

## Test plan
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.7.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->