### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.7.5"
+version = "0.8.0"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Bumps the package version from 0.7.5 to 0.8.0.

This release is a meaningful feature step: SLayer's Postgres facade now works with Metabase (subquery joins, post-aggregation alias refs in WHERE/HAVING/ORDER BY, CAST projections, per-connection SET state, Sunday-anchored week breakouts, empty-string parameter binding, and a fix for cross-model metrics leaking into catalog introspection), plus T-SQL/MySQL dialect fixes and a sqlglot bump to 30.11.0 — hence the minor-version bump rather than a patch.

The version is read dynamically via importlib.metadata, so only pyproject.toml changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.8.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->