### PR TITLE
Heal shorthand `order` items in SlayerQuery; harden direction validation (DEV-1575)

### DIFF
--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -97,6 +97,8 @@ A time dimension with a required granularity and an optional date range. Support
 
 ## OrderItem
 
+A sort specification: `column` is the short alias (`status`, `revenue_sum`, `*:count`), `direction` is `asc` or `desc`.
+
 ```json
 {"column": "*:count", "direction": "desc"}
 ```

--- a/slayer/core/query.py
+++ b/slayer/core/query.py
@@ -197,6 +197,24 @@ def _coerce_order_column(v: Any) -> Any:
     return v
 
 
+# DEV-1575: the accepted ORDER BY direction vocabulary (case-insensitive),
+# mapping every synonym to the canonical lowercase form the SQL generator
+# compares against (``direction == "asc"``). Single source of truth shared by
+# the shorthand-healing detector (``_process_order_item``) and the
+# ``OrderItem.direction`` normalizing validator.
+_DIRECTION_NORMALIZE = {
+    "asc": "asc",
+    "ascending": "asc",
+    "desc": "desc",
+    "descending": "desc",
+}
+
+
+def _is_direction(value: Any) -> bool:
+    """True if ``value`` is a recognized direction word (case/whitespace-insensitive)."""
+    return isinstance(value, str) and value.strip().lower() in _DIRECTION_NORMALIZE
+
+
 class TimeDimension(BaseModel):
     dimension: Annotated[ColumnRef, BeforeValidator(_coerce_column_ref)]
     granularity: TimeGranularity
@@ -205,6 +223,11 @@ class TimeDimension(BaseModel):
 
 
 class OrderItem(BaseModel):
+    # DEV-1575: reject stray keys so a mixed canonical+shorthand item
+    # (e.g. ``{"column": "x", "b": "asc"}``) raises loudly instead of silently
+    # dropping the extra key.
+    model_config = ConfigDict(extra="forbid")
+
     column: Annotated[ColumnRef, BeforeValidator(_coerce_order_column)]
     direction: str = "asc"
     raw_formula: Optional[str] = None
@@ -221,6 +244,24 @@ class OrderItem(BaseModel):
                 if ":" in rewritten or _FUNCSTYLE_CALL_PATTERN.match(rewritten):
                     data = {**data, "raw_formula": rewritten}
         return data
+
+    @field_validator("direction")
+    @classmethod
+    def _normalize_direction(cls, v: str) -> str:
+        """DEV-1575: normalize direction to canonical ``asc``/``desc`` (case- and
+        whitespace-insensitive, accepting ``ascending``/``descending`` synonyms),
+        rejecting anything else.
+
+        The SQL generator compares ``direction == "asc"`` strictly, so a
+        non-normalized value (``"ASC"``, ``"ascending"``) would silently emit
+        DESC. Normalizing here fixes that for both healed and canonical items.
+        """
+        if _is_direction(v):
+            return _DIRECTION_NORMALIZE[v.strip().lower()]
+        raise ValueError(
+            "order direction must be one of asc/desc/ascending/descending "
+            f"(case-insensitive), got {v!r}"
+        )
 
 
 def _coerce_measures(v: Any) -> Any:
@@ -239,6 +280,56 @@ def _coerce_dimensions(v: Any) -> Any:
     if not isinstance(v, (list, tuple)):
         raise TypeError(f"'dimensions' must be a list, got {type(v).__name__}")
     return [{"name": item} if isinstance(item, str) else item for item in v]
+
+
+def _process_order_item(item: Any) -> list:
+    """DEV-1575: heal a single ``order`` entry, returning the list of canonical
+    items it expands to.
+
+    LLM agents frequently write a shorthand dict mapping column → direction
+    instead of the canonical ``{"column", "direction"}`` shape. A dict with no
+    ``column``/``direction`` key whose values are *all* direction words is
+    treated as shorthand and expanded — one canonical item per key, preserving
+    insertion order (so a single-key dict yields one item and a multi-key dict
+    yields several). Everything else passes through unchanged: canonical dicts
+    (their stray keys are policed by ``OrderItem``'s ``extra="forbid"``) and
+    malformed input (rejected by ``OrderItem`` validation).
+    """
+    if not isinstance(item, dict):
+        return [item]
+    # A dict carrying a reserved key is canonical-intended; never reinterpret it
+    # as shorthand. extra="forbid" on OrderItem rejects any stray keys.
+    if "column" in item or "direction" in item:
+        return [item]
+    if (
+        item
+        and all(isinstance(k, str) for k in item)
+        and all(_is_direction(val) for val in item.values())
+    ):
+        return [{"column": k, "direction": val} for k, val in item.items()]
+    return [item]
+
+
+def _coerce_order(v: Any) -> Any:
+    """DEV-1575: heal shorthand ``order`` items before ``OrderItem`` validation.
+
+    Accepts the canonical ``list``/``tuple`` of items, healing each shorthand
+    dict (see ``_process_order_item``). A bare single item passed without the
+    enclosing list (a ``dict`` or an ``OrderItem``) is wrapped into a
+    one-element list; any other non-list input raises (mirrors the
+    ``_coerce_measures``/``_coerce_dimensions`` convention).
+    """
+    if v is None:
+        return v
+    if not isinstance(v, (list, tuple)):
+        if isinstance(v, (dict, OrderItem)):
+            v = [v]
+        else:
+            raise TypeError(f"'order' must be a list, got {type(v).__name__}")
+    result: list = []
+    for item in v:
+        result.extend(_process_order_item(item))
+    return result
 
 
 class ModelExtension(BaseModel):
@@ -334,7 +425,7 @@ class SlayerQuery(BaseModel):
     main_time_dimension: Optional[str] = None  # Explicit time dimension for transforms (overrides auto-detection)
     filters: Optional[List[str]] = None
     variables: Optional[Dict[str, Any]] = None  # Variable values for filter substitution
-    order: Optional[List[OrderItem]] = None
+    order: Annotated[Optional[List[OrderItem]], BeforeValidator(_coerce_order)] = None
     limit: Optional[int] = None
     offset: Optional[int] = None
     whole_periods_only: bool = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 import datetime
 
 import pytest
+from pydantic import ValidationError
 
 from slayer.core.enums import DataType, TimeGranularity
 from slayer.core.models import Aggregation, Column, DatasourceConfig, ModelMeasure, SlayerModel
@@ -96,6 +97,244 @@ class TestOrderItem:
         item = OrderItem(column="status", direction="asc")
         assert item.column.name == "status"
         assert item.raw_formula is None
+
+
+class TestOrderShorthandHealing:
+    """DEV-1575: heal LLM-shorthand ``order`` items and harden direction validation.
+
+    Shorthand ``{col: "desc"}`` (single- or multi-key) heals to canonical
+    ``{"column": col, "direction": "desc"}``; direction is normalized
+    (case-insensitive, ``asc``/``desc``/``ascending``/``descending``, whitespace
+    trimmed) and anything else is rejected; ``OrderItem`` forbids extra keys.
+    """
+
+    # --- single-key shorthand ---
+
+    def test_shorthand_desc(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"avg_processing_time_days": "desc"}])
+        assert len(q.order) == 1
+        assert q.order[0].column.name == "avg_processing_time_days"
+        assert q.order[0].direction == "desc"
+
+    def test_shorthand_asc(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"status": "asc"}])
+        assert q.order[0].column.name == "status"
+        assert q.order[0].direction == "asc"
+
+    def test_shorthand_equals_canonical(self) -> None:
+        shorthand = SlayerQuery(source_model="orders", order=[{"status": "desc"}])
+        canonical = SlayerQuery(
+            source_model="orders", order=[{"column": "status", "direction": "desc"}]
+        )
+        assert shorthand.order == canonical.order
+
+    # --- direction vocabulary: case-insensitive, synonyms, whitespace ---
+
+    def test_shorthand_uppercase_normalized(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"status": "DESC"}])
+        assert q.order[0].direction == "desc"
+
+    def test_shorthand_descending_synonym(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"status": "DESCENDING"}])
+        assert q.order[0].direction == "desc"
+
+    def test_shorthand_ascending_synonym_mixed_case(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"status": "Ascending"}])
+        assert q.order[0].direction == "asc"
+
+    def test_shorthand_whitespace_trimmed(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"status": " Asc "}])
+        assert q.order[0].direction == "asc"
+
+    # --- formula key composes with existing normalization ---
+
+    def test_shorthand_formula_key(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"revenue:sum": "desc"}])
+        assert q.order[0].column.name == "revenue_sum"
+        assert q.order[0].raw_formula == "revenue:sum"
+        assert q.order[0].direction == "desc"
+
+    def test_shorthand_formula_key_equals_canonical(self) -> None:
+        shorthand = SlayerQuery(source_model="orders", order=[{"revenue:sum": "desc"}])
+        canonical = SlayerQuery(
+            source_model="orders", order=[{"column": "revenue:sum", "direction": "desc"}]
+        )
+        assert shorthand.order == canonical.order
+
+    # --- multi-key expansion (one dict -> N OrderItems, insertion order) ---
+
+    def test_multikey_expands_in_order(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"a": "desc", "b": "asc"}])
+        assert [(o.column.name, o.direction) for o in q.order] == [("a", "desc"), ("b", "asc")]
+
+    def test_multikey_synonyms_and_case(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"a": "ASCENDING", "b": "Desc"}])
+        assert [(o.column.name, o.direction) for o in q.order] == [("a", "asc"), ("b", "desc")]
+
+    def test_multikey_partial_non_direction_raises(self) -> None:
+        # Not every value is a direction -> not shorthand -> canonical validation rejects.
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"a": "desc", "b": "downward"}])
+
+    # --- bare single item passed without the enclosing list gets wrapped ---
+
+    def test_bare_dict_shorthand_wrapped(self) -> None:
+        q = SlayerQuery(source_model="orders", order={"status": "desc"})
+        assert len(q.order) == 1
+        assert q.order[0].column.name == "status"
+        assert q.order[0].direction == "desc"
+
+    def test_bare_canonical_dict_wrapped(self) -> None:
+        q = SlayerQuery(source_model="orders", order={"column": "status", "direction": "asc"})
+        assert len(q.order) == 1
+        assert q.order[0].column.name == "status"
+        assert q.order[0].direction == "asc"
+
+    def test_bare_multikey_dict_wrapped(self) -> None:
+        q = SlayerQuery(source_model="orders", order={"a": "desc", "b": "asc"})
+        assert [(o.column.name, o.direction) for o in q.order] == [("a", "desc"), ("b", "asc")]
+
+    def test_bare_orderitem_wrapped(self) -> None:
+        item = OrderItem(column="status", direction="desc")
+        q = SlayerQuery(source_model="orders", order=item)
+        assert len(q.order) == 1
+        assert q.order[0].column.name == "status"
+        assert q.order[0].direction == "desc"
+
+    # --- canonical preserved; latent uppercase-direction bug fixed ---
+
+    def test_canonical_unchanged(self) -> None:
+        q = SlayerQuery(source_model="orders", order=[{"column": "status", "direction": "desc"}])
+        assert q.order[0].column.name == "status"
+        assert q.order[0].direction == "desc"
+
+    def test_canonical_uppercase_direction_normalized(self) -> None:
+        # Pre-existing latent bug: SQL generator compares ``direction == "asc"`` strictly,
+        # so a stored "ASCENDING"/"ASC" used to silently emit DESC. Now normalized.
+        q = SlayerQuery(
+            source_model="orders", order=[{"column": "status", "direction": "ASCENDING"}]
+        )
+        assert q.order[0].direction == "asc"
+
+    def test_canonical_column_named_like_direction_word(self) -> None:
+        # Single reserved 'column' key whose value happens to be a direction word
+        # stays canonical (order by a column literally named "desc").
+        q = SlayerQuery(source_model="orders", order=[{"column": "desc"}])
+        assert q.order[0].column.name == "desc"
+        assert q.order[0].direction == "asc"
+
+    # --- rejections: malformed / ambiguous never silently mangled ---
+
+    def test_invalid_direction_value_shorthand_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"col": "downward"}])
+
+    def test_invalid_direction_value_canonical_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"column": "status", "direction": "sideways"}])
+
+    def test_mixed_canonical_and_stray_direction_key_raises(self) -> None:
+        # extra='forbid' rejects the stray 'b' rather than silently dropping it.
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"column": "status", "b": "asc"}])
+
+    def test_mixed_canonical_and_stray_nondirection_key_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"column": "status", "b": "downward"}])
+
+    def test_direction_only_key_raises(self) -> None:
+        # {"direction": "desc"} is a malformed canonical item (no column), not shorthand.
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{"direction": "desc"}])
+
+    def test_empty_dict_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{}])
+
+    def test_nested_list_item_raises(self) -> None:
+        # No list-of-lists support.
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[["a", "desc"]])
+
+    def test_non_wrappable_scalar_string_raises(self) -> None:
+        with pytest.raises(Exception, match="must be a list"):
+            SlayerQuery(source_model="orders", order="status")
+
+    def test_non_wrappable_int_raises(self) -> None:
+        with pytest.raises(Exception, match="must be a list"):
+            SlayerQuery(source_model="orders", order=42)
+
+    # --- mixed list: shorthand + canonical + multi-key together ---
+
+    def test_mixed_shorthand_canonical_multikey_list(self) -> None:
+        q = SlayerQuery(
+            source_model="orders",
+            order=[
+                {"a": "desc"},
+                {"column": "b", "direction": "asc"},
+                {"c": "asc", "d": "desc"},
+            ],
+        )
+        assert [(o.column.name, o.direction) for o in q.order] == [
+            ("a", "desc"),
+            ("b", "asc"),
+            ("c", "asc"),
+            ("d", "desc"),
+        ]
+
+    # --- None / tuple / non-string keys / passthrough ---
+
+    def test_order_none_stays_none(self) -> None:
+        q = SlayerQuery(source_model="orders", order=None)
+        assert q.order is None
+
+    def test_tuple_input_accepted(self) -> None:
+        q = SlayerQuery(
+            source_model="orders",
+            order=({"a": "desc"}, {"column": "b", "direction": "asc"}),
+        )
+        assert [(o.column.name, o.direction) for o in q.order] == [("a", "desc"), ("b", "asc")]
+
+    def test_non_string_key_not_healed_raises(self) -> None:
+        # A non-string key means the dict is not treated as shorthand; it falls
+        # through to OrderItem validation, which rejects it (no column).
+        with pytest.raises(ValidationError):
+            SlayerQuery(source_model="orders", order=[{1: "desc"}])
+
+    def test_multikey_formula_keys_preserve_raw_formula(self) -> None:
+        q = SlayerQuery(
+            source_model="orders", order=[{"revenue:sum": "desc", "amount:max": "asc"}]
+        )
+        assert len(q.order) == 2
+        assert q.order[0].column.name == "revenue_sum"
+        assert q.order[0].raw_formula == "revenue:sum"
+        assert q.order[0].direction == "desc"
+        assert q.order[1].column.name == "amount_max"
+        assert q.order[1].raw_formula == "amount:max"
+        assert q.order[1].direction == "asc"
+
+    def test_list_orderitem_passthrough(self) -> None:
+        item = OrderItem(column="revenue:sum", direction="desc")
+        q = SlayerQuery(source_model="orders", order=[item])
+        assert len(q.order) == 1
+        assert q.order[0].column.name == "revenue_sum"
+        assert q.order[0].direction == "desc"
+
+    # --- OrderItem-level direction validation + extra=forbid ---
+
+    def test_orderitem_direction_synonym_normalized(self) -> None:
+        assert OrderItem(column="status", direction="DESCENDING").direction == "desc"
+
+    def test_orderitem_direction_default_asc(self) -> None:
+        assert OrderItem(column="status").direction == "asc"
+
+    def test_orderitem_invalid_direction_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            OrderItem(column="status", direction="sideways")
+
+    def test_orderitem_extra_key_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            OrderItem(column="status", direction="asc", bogus="x")
 
 
 class TestSlayerModel:

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -232,6 +232,35 @@ class TestBasicQueries:
         assert "ORDER BY" in sql
         assert "DESC" in sql
 
+    async def test_order_by_shorthand_descending_reaches_sql(
+        self, generator: SQLGenerator, orders_model: SlayerModel
+    ) -> None:
+        # DEV-1575: shorthand {col: "descending"} heals + normalizes and emits DESC.
+        query = SlayerQuery(
+            source_model="orders",
+            measures=[ModelMeasure(formula="*:count")],
+            dimensions=[ColumnRef(name="status")],
+            order=[{"status": "descending"}],
+        )
+        sql = await _generate(generator, query, orders_model)
+        assert "ORDER BY" in sql
+        assert "DESC" in sql.upper()
+
+    async def test_order_by_ascending_synonym_not_descending(
+        self, generator: SQLGenerator, orders_model: SlayerModel
+    ) -> None:
+        # DEV-1575 regression: a canonical "ASCENDING" must normalize to asc so the
+        # generator's strict ``direction == "asc"`` check does NOT fall through to DESC.
+        query = SlayerQuery(
+            source_model="orders",
+            measures=[ModelMeasure(formula="*:count")],
+            dimensions=[ColumnRef(name="status")],
+            order=[{"column": "status", "direction": "ASCENDING"}],
+        )
+        sql = await _generate(generator, query, orders_model)
+        assert "ORDER BY" in sql
+        assert "DESC" not in sql.upper()
+
 
 class TestTimeDimensions:
     async def test_time_dimension_with_granularity(self, generator: SQLGenerator, orders_model: SlayerModel) -> None:


### PR DESCRIPTION
## What

Heals the most common SlayerQuery DSL mistake LLM agents make: writing `order` items as a shorthand dict mapping column → direction instead of the canonical `{"column", "direction"}` shape. In the bird-agents rejection analysis this `order_shape` mistake was **~46% of all SlayerQuery DSL validation rejections** (183/399) — pure friction (a wasted retry turn), the cheapest large ergonomics win.

Healing is silent, consistent with the existing `_coerce_measures` / `_coerce_dimensions` input coercions.

## Changes (`slayer/core/query.py`)

- **`_coerce_order`** `BeforeValidator` on `SlayerQuery.order`:
  - single-key shorthand `{"avg_time": "desc"}` → `{"column": "avg_time", "direction": "desc"}`
  - multi-key dict expands to one sort per key, in insertion order (`{"region": "asc", "revenue_sum": "desc"}` → two items)
  - a bare single item passed without the enclosing list (`order={"status": "desc"}`) is wrapped
  - formula keys compose for free (`{"revenue:sum": "desc"}` normalizes column + captures `raw_formula`)
- **`OrderItem` hardening**:
  - `extra="forbid"` — a mixed canonical+shorthand item (`{"column": "x", "b": "asc"}`) raises loudly instead of silently dropping the stray key
  - `direction` field-validator normalizes to canonical `asc`/`desc` (case- and whitespace-insensitive, accepting `ascending`/`descending`) and rejects anything else. This also **fixes a latent bug**: the SQL generator compares `direction == "asc"` strictly, so a non-lowercase direction (`"ASC"`, `"ascending"`) previously emitted `DESC` silently.

Malformed / ambiguous input (non-direction values, empty dicts, nested lists, non-wrappable scalars) still raises rather than being mangled.

## Tests

- `tests/test_models.py::TestOrderShorthandHealing` — 38 cases covering single/multi-key shorthand, bare-item wrapping, formula keys, direction vocabulary (case/whitespace/synonyms), canonical pass-through, the latent-bug fix, and every rejection path.
- `tests/test_sql_generator.py` — 2 regressions asserting healed/synonym directions reach generated SQL correctly.

Full unit suite: **5142 passed, 4 skipped**; `ruff` clean.

## Docs

`docs/concepts/queries.md` documents only the single canonical `OrderItem` format — the shorthand is healed silently by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order direction now accepts synonyms (`ascending`/`descending`) normalized to canonical `asc`/`desc` format.
  * Improved shorthand syntax support for order specifications.

* **Bug Fixes**
  * Enhanced validation and normalization of order inputs for consistency.

* **Documentation**
  * Clarified `OrderItem` documentation with examples of accepted column aliases and direction values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->