### PR TITLE
DEV-1593: fix false ColumnCycleError on quoted self-identity columns

### DIFF
--- a/slayer/engine/column_expansion.py
+++ b/slayer/engine/column_expansion.py
@@ -35,7 +35,15 @@ def _is_trivial_base(*, column: Column) -> bool:
     """
     if column.sql is None:
         return True
-    return column.sql.strip() == column.name
+    sql = column.sql.strip()
+    # A double-quoted self-identity (``"legalEntityType"`` for a column named
+    # ``legalEntityType``) is still a bare base reference — required to point
+    # at a mixed-case physical column on case-folding dialects. Strip the
+    # surrounding identifier quotes before comparing so it is not mistaken
+    # for a derived expression (which would self-recurse into a false cycle).
+    if len(sql) >= 2 and sql[0] == '"' and sql[-1] == '"':
+        sql = sql[1:-1].replace('""', '"')
+    return sql == column.name
 
 
 def _root_scope_column_ids(*, parsed: exp.Expression) -> Set[int]:

--- a/tests/test_column_dependency.py
+++ b/tests/test_column_dependency.py
@@ -206,6 +206,26 @@ async def test_save_model_accepts_base_columns_only(tmp_path) -> None:
     await storage.save_model(model)
 
 
+async def test_save_model_accepts_quoted_self_identity_column(tmp_path) -> None:
+    """A column whose sql is the double-quoted form of its own name is a base
+    reference, not a derived expression — required to reach a mixed-case
+    physical column on case-folding dialects (Prisma-style camelCase). It must
+    NOT be mistaken for a single-step self-cycle."""
+    storage = _yaml_storage(tmp_path)
+    model = SlayerModel(
+        name="merchant",
+        data_source="ds",
+        sql_table="merchant",
+        columns=[
+            Column(name="legalEntityType", sql='"legalEntityType"', type=DataType.TEXT),
+        ],
+    )
+    await storage.save_model(model)
+    reloaded = await storage.get_model("merchant", data_source="ds")
+    assert reloaded is not None
+    assert {c.name for c in reloaded.columns} == {"legalEntityType"}
+
+
 # ---------------------------------------------------------------------------
 # 2. Cross-model cycles (within a single data_source).
 # ---------------------------------------------------------------------------

--- a/tests/test_cross_model_derived_columns.py
+++ b/tests/test_cross_model_derived_columns.py
@@ -104,6 +104,30 @@ async def test_cross_model_dim_derived_column_via_query(tmp_path) -> None:
     assert "B.foo_raw / 100.0" in _norm(sql), f"Expected qualified B.foo_raw, got:\n{sql}"
 
 
+async def test_quoted_self_identity_column_emits_quoted_and_no_cycle(tmp_path) -> None:
+    """A column whose sql is the double-quoted form of its own name
+    (``"legalEntityType"`` for a mixed-case physical column) is a base
+    reference, not a derived one. It must resolve without a false
+    ColumnCycleError and emit the quoted identifier so case-folding dialects
+    reach the right physical column."""
+    engine, storage = _engine_with_storage(tmp_path)
+    model = SlayerModel(
+        name="merchant",
+        data_source="test",
+        sql_table="merchant",
+        columns=[
+            Column(name="legalEntityType", sql='"legalEntityType"', type=DataType.TEXT),
+        ],
+    )
+    await storage.save_model(model)
+    query = SlayerQuery(
+        source_model="merchant",
+        dimensions=[ColumnRef(name="legalEntityType")],
+    )
+    sql = await _gen_sql(engine, query, model)
+    assert '"legalEntityType"' in sql, f"Expected quoted identifier preserved, got:\n{sql}"
+
+
 # ---------------------------------------------------------------------------
 # 2. The original DEV-1333 bug: A.Column.sql references B's derived column.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix false ColumnCycleError on quoted self-identity columns (camelCase schemas)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of self-referencing column expressions when they are wrapped in double quotes.
  * Quoted self-identity columns are now treated as base/reference columns, preventing incorrect derivation behavior and avoiding cycle-related issues.
* **Tests**
  * Added coverage to verify quoted self-identity columns load correctly from saved models and preserve quoted identifiers when generating SQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->