### PR TITLE
BigQuery JSON creds from string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.8.2"
+version = "0.8.3"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -747,7 +747,7 @@ class DatasourceConfig(BaseModel):
     # so the connection authenticates against that service account directly.
     # When unset, BigQuery falls back to Application Default Credentials
     # (``GOOGLE_APPLICATION_CREDENTIALS`` env var or attached compute identity).
-    credentials_json: Optional[str] = None
+    credentials_json: Optional[str] = Field(default=None, repr=False)
 
     @model_validator(mode="before")
     @classmethod

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -741,6 +741,13 @@ class DatasourceConfig(BaseModel):
     connection_name: Optional[str] = None
     warehouse: Optional[str] = None
     role: Optional[str] = None
+    # BigQuery-specific. Other dialects ignore it. The contents of a Google
+    # service-account key file as a JSON string. When set, the BigQuery dialect
+    # constructs the SQLAlchemy engine with ``credentials_info=json.loads(...)``
+    # so the connection authenticates against that service account directly.
+    # When unset, BigQuery falls back to Application Default Credentials
+    # (``GOOGLE_APPLICATION_CREDENTIALS`` env var or attached compute identity).
+    credentials_json: Optional[str] = None
 
     @model_validator(mode="before")
     @classmethod

--- a/slayer/sql/dialects/bigquery.py
+++ b/slayer/sql/dialects/bigquery.py
@@ -25,14 +25,19 @@ differs.
 
 from __future__ import annotations
 
+import json
 import re
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
+import sqlalchemy as sa
 from sqlglot import exp
 
 from slayer.core.enums import TimeGranularity
 from slayer.sql.dialects._alias_mangle import decode_alias, encode_alias
 from slayer.sql.dialects.base import SqlDialect
+
+if TYPE_CHECKING:
+    from slayer.core.models import DatasourceConfig
 
 
 # ---------------------------------------------------------------------------
@@ -136,3 +141,35 @@ class BigqueryDialect(SqlDialect):
         consumers see SLayer's universal dotted alias shape regardless of
         whether the query ran against BigQuery or another dialect."""
         return [{decode_alias(k): v for k, v in row.items()} for row in rows]
+
+    def build_engine(
+        self,
+        datasource: "DatasourceConfig",
+        *,
+        connection_string: str,
+    ) -> Optional["sa.Engine"]:
+        """Construct the SQLAlchemy engine with inline service-account JSON
+        when ``DatasourceConfig.credentials_json`` is set.
+
+        ``sqlalchemy-bigquery`` accepts a ``credentials_info`` kwarg on
+        ``create_engine`` — a dict matching the service-account key file's
+        shape. Parse the JSON string into a dict and pass it through; the
+        BigQuery client builds credentials from it directly, no temp file
+        needed. When ``credentials_json`` is unset, return ``None`` so
+        ``engine_factory`` falls back to the default ``create_engine`` and
+        the BigQuery client picks up Application Default Credentials.
+        """
+        credentials_json = datasource.credentials_json
+        if not credentials_json:
+            return None
+        try:
+            credentials_info = json.loads(credentials_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Datasource '{datasource.name}': credentials_json is not valid JSON: {exc}"
+            ) from exc
+        return sa.create_engine(
+            connection_string,
+            credentials_info=credentials_info,
+            pool_pre_ping=True,
+        )

--- a/slayer/sql/dialects/bigquery.py
+++ b/slayer/sql/dialects/bigquery.py
@@ -168,6 +168,10 @@ class BigqueryDialect(SqlDialect):
             raise ValueError(
                 f"Datasource '{datasource.name}': credentials_json is not valid JSON: {exc}"
             ) from exc
+        if not isinstance(credentials_info, dict):
+            raise ValueError(
+                f"Datasource '{datasource.name}': credentials_json must be a JSON object"
+            )
         return sa.create_engine(
             connection_string,
             credentials_info=credentials_info,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -651,3 +651,16 @@ def test_build_engine_with_invalid_credentials_json_raises() -> None:
     dialect = BigqueryDialect()
     with pytest.raises(ValueError, match="credentials_json is not valid JSON"):
         dialect.build_engine(ds, connection_string="bigquery://my-project")
+
+
+@pytest.mark.parametrize("payload", ["[]", "null", '"key"', "42"])
+def test_build_engine_with_non_object_credentials_json_raises(payload: str) -> None:
+    """Valid JSON that isn't an object (list/null/string/number) is rejected
+    rather than passed to ``create_engine`` as a bogus ``credentials_info``."""
+    ds = DatasourceConfig(
+        name="bq", type="bigquery", database="my-project",
+        credentials_json=payload,
+    )
+    dialect = BigqueryDialect()
+    with pytest.raises(ValueError, match="credentials_json must be a JSON object"):
+        dialect.build_engine(ds, connection_string="bigquery://my-project")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -589,3 +589,65 @@ class TestEngineDecodeIntegration:
             assert "orders.status" in resp.columns
         finally:
             tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# build_engine — inline service-account JSON
+# ---------------------------------------------------------------------------
+
+
+def test_build_engine_without_credentials_json_returns_none() -> None:
+    """No ``credentials_json`` → return ``None`` so engine_factory falls
+    back to the default ``create_engine`` (which reads ADC)."""
+    ds = DatasourceConfig(name="bq", type="bigquery", database="my-project")
+    dialect = BigqueryDialect()
+    assert dialect.build_engine(ds, connection_string="bigquery://my-project") is None
+
+
+def test_build_engine_with_credentials_json_passes_info_to_create_engine() -> None:
+    """``credentials_json`` → ``create_engine(..., credentials_info=<dict>)``."""
+    import json as _json
+
+    sa_info = {
+        "type": "service_account",
+        "project_id": "my-project",
+        "private_key_id": "abc",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n",
+        "client_email": "svc@my-project.iam.gserviceaccount.com",
+        "client_id": "123",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    }
+    ds = DatasourceConfig(
+        name="bq",
+        type="bigquery",
+        database="my-project",
+        credentials_json=_json.dumps(sa_info),
+    )
+    dialect = BigqueryDialect()
+    captured: dict = {}
+
+    def fake_create_engine(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return object()  # opaque sentinel; we only check call args
+
+    with patch("slayer.sql.dialects.bigquery.sa.create_engine", side_effect=fake_create_engine):
+        engine = dialect.build_engine(ds, connection_string="bigquery://my-project")
+
+    assert engine is not None
+    assert captured["url"] == "bigquery://my-project"
+    assert captured["kwargs"]["credentials_info"] == sa_info
+    assert captured["kwargs"]["pool_pre_ping"] is True
+
+
+def test_build_engine_with_invalid_credentials_json_raises() -> None:
+    """Garbage in ``credentials_json`` raises a clear error rather than
+    leaking a low-level ``JSONDecodeError`` traceback."""
+    ds = DatasourceConfig(
+        name="bq", type="bigquery", database="my-project",
+        credentials_json="this is not JSON",
+    )
+    dialect = BigqueryDialect()
+    with pytest.raises(ValueError, match="credentials_json is not valid JSON"):
+        dialect.build_engine(ds, connection_string="bigquery://my-project")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BigQuery connections can now accept optional inline service-account credentials JSON.
  * When not provided, BigQuery uses existing default authentication.
* **Bug Fixes**
  * Added validation for the inline credentials JSON with clearer errors for invalid JSON or non-object values.
* **Tests**
  * Expanded unit tests covering missing, valid, and invalid credentials JSON, including verification of arguments sent during engine creation.
* **Chores**
  * Updated package version to 0.8.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->