### PR TITLE
`\d table` fixes

### DIFF
--- a/slayer/facade/catalog_sql.py
+++ b/slayer/facade/catalog_sql.py
@@ -1623,11 +1623,14 @@ class _AstRewriter:
         if isinstance(inner, exp.Literal) and inner.is_string:
             text = inner.this  # raw string value (no quotes)
             return exp.Literal.number(self._lookup_static_regclass(text))
-        # Bare column ref (e.g. ``c.oid``): pass through unchanged. These
-        # are numeric OID columns; wrapping in the VARCHAR-only UDF would
-        # yield a Binder Error, and the OID value itself is the most
-        # useful answer we can produce for SLayer's minimal catalog.
+        # Numeric-typed inner (column ref or number literal): pass through
+        # unchanged. Column refs are OID columns like ``c.oid``, and
+        # ``CAST(0 AS regclass)`` is Postgres's InvalidOid sentinel. Both
+        # would fail against the VARCHAR-only UDF, and the numeric value
+        # itself is the most useful answer for SLayer's minimal catalog.
         if isinstance(inner, exp.Column):
+            return inner
+        if isinstance(inner, exp.Literal) and not inner.is_string:
             return inner
         # Everything else — function calls, nested casts, expressions —
         # routes through the UDF lookup. Metabase's real query uses
@@ -1659,14 +1662,15 @@ class _AstRewriter:
     # ----- 4. regproc / regtype casts ---------------------------------------
 
     def _rewrite_regproc_regtype_casts(self, node: exp.Expression) -> exp.Expression:
-        """``::regproc`` → ``0`` (pg_proc is empty in this facade).
+        """``::regproc`` / ``::regoper`` / ``::regoperator`` / ``::regprocedure``
+        → ``0`` (their catalog tables are empty in this facade).
         ``::regtype`` → ``pg_type.oid`` lookup for known type names, ``0``
         otherwise — so ``WHERE oid = 'int8'::regtype`` matches the int8
-        row in pg_type (Codex review)."""
+        row in pg_type."""
         if not isinstance(node, exp.Cast):
             return node
         target_kind = self._cast_target_kind(node)
-        if target_kind == "regproc":
+        if target_kind in {"regproc", "regoper", "regoperator", "regprocedure"}:
             return exp.Literal.number(0)
         if target_kind == "regtype":
             inner = node.this
@@ -2209,7 +2213,9 @@ class CatalogSqlExecutor:
             if schema == "information_schema" and f"_is_{name}" in self._registered_tables:
                 continue
             # Discover column names the same query references off this
-            # Table's alias (or bare name).
+            # Table's alias (or bare name). Column discovery matches on the
+            # user-visible handle (still ``pg_publication`` / ``character_sets``
+            # at this point — the strip pass hasn't run).
             handle = tbl.alias or tbl.name
             columns = self._discover_referenced_columns(root, handle)
             if not columns:
@@ -2218,7 +2224,16 @@ class CatalogSqlExecutor:
                 # something to project. Real queries always reference some
                 # column, so this is a rare path.
                 columns = ["oid"]
-            subq = self._build_empty_subquery(columns, alias=handle)
+            # For information_schema tables without a user-supplied alias,
+            # the subquery must ALIAS AS ``_is_<name>`` — that's what the
+            # downstream ``_strip_column_schema_qualifiers`` pass rewrites
+            # bare ``information_schema.character_sets.col`` refs to. If we
+            # aliased the synthetic subquery as ``character_sets``, the
+            # binder would miss the column.
+            output_alias = handle
+            if schema == "information_schema" and not tbl.alias:
+                output_alias = f"_is_{name}"
+            subq = self._build_empty_subquery(columns, alias=output_alias)
             replacements.append((tbl, subq))
             logger.warning(
                 "pg-facade: synthesized empty relation for unknown catalog "
@@ -2271,9 +2286,18 @@ class CatalogSqlExecutor:
         """Emit ``(SELECT NULL::VARCHAR AS c1, ... WHERE FALSE) AS <alias>``.
         Every column types as VARCHAR — NULL literals coerce freely to any
         downstream type, and the ``WHERE FALSE`` guarantees zero rows so
-        the type choice is only for column-shape validation."""
+        the type choice is only for column-shape validation.
+
+        Column names come from client-controlled SQL identifiers; escape
+        the ``"`` character (SQL identifier delimiter) before embedding
+        so a valid quoted-identifier column ref can't malform the SQL we
+        parse. Double the quote character per the SQL-standard escape.
+        """
+        def _quote_ident(name: str) -> str:
+            return '"' + name.replace('"', '""') + '"'
+
         select_cols = ", ".join(
-            f'NULL::VARCHAR AS "{c}"' for c in columns
+            f"NULL::VARCHAR AS {_quote_ident(c)}" for c in columns
         )
         sub_sql = f"SELECT {select_cols} WHERE FALSE"
         parsed_sub = sqlglot.parse_one(sub_sql, read="duckdb")

--- a/slayer/facade/catalog_sql.py
+++ b/slayer/facade/catalog_sql.py
@@ -204,6 +204,19 @@ def build_catalog_relations(
     out.append(_build_pg_am())
     out.append(_build_pg_database(catalog, ds))
     out.append(_build_pg_roles())
+    out.append(_build_pg_collation())
+    out.append(_build_pg_policy())
+    # Empty stubs for catalog tables psql's ``\d`` variants touch
+    # (triggers / inheritance / publications / partitioning / views
+    # rewrite / extensions) — all legitimately empty for SLayer.
+    out.append(_build_pg_trigger())
+    out.append(_build_pg_inherits())
+    out.append(_build_pg_publication())
+    out.append(_build_pg_publication_rel())
+    out.append(_build_pg_publication_tables())
+    out.append(_build_pg_partitioned_table())
+    out.append(_build_pg_rewrite())
+    out.append(_build_pg_extension())
     out.append(_build_is_columns(catalog, ds))
     out.append(_build_is_table_constraints())
     out.append(_build_is_key_column_usage())
@@ -302,6 +315,15 @@ def _build_pg_class(catalog: FacadeCatalog) -> CatalogRelation:
         # Access-method OID — points at ``pg_am.oid``. psql's ``\d`` LEFT
         # JOINs on this; ``heap`` is the only access method we advertise.
         FacadeColumn(name="relam", type=DataType.INT),
+        # psql's ``\d <table>`` reads these too. Sensible defaults: no
+        # CHECK constraints, no TOAST, no forced RLS, default tablespace
+        # / replica identity, not a typed table.
+        FacadeColumn(name="relchecks", type=DataType.INT),
+        FacadeColumn(name="relforcerowsecurity", type=DataType.BOOLEAN),
+        FacadeColumn(name="reloftype", type=DataType.INT),
+        FacadeColumn(name="reltablespace", type=DataType.INT),
+        FacadeColumn(name="reltoastrelid", type=DataType.INT),
+        FacadeColumn(name="relreplident", type=DataType.TEXT),
     ]
     rows = []
     seen_oids: dict[int, str] = {}
@@ -322,6 +344,9 @@ def _build_pg_class(catalog: FacadeCatalog) -> CatalogRelation:
             "relhasrules": False, "relhastriggers": False,
             "relrowsecurity": False, "relispartition": False,
             "relam": PG_AM_HEAP_OID,
+            "relchecks": 0, "relforcerowsecurity": False,
+            "reloftype": 0, "reltablespace": 0, "reltoastrelid": 0,
+            "relreplident": "d",  # 'd' = default replica identity
         })
     return CatalogRelation(name="pg_class", columns=columns, rows=rows)
 
@@ -339,6 +364,11 @@ def _build_pg_attribute(catalog: FacadeCatalog) -> CatalogRelation:
         FacadeColumn(name="attisdropped", type=DataType.BOOLEAN),
         FacadeColumn(name="attidentity", type=DataType.TEXT),
         FacadeColumn(name="attgenerated", type=DataType.TEXT),
+        # Collation OID — psql's ``\d <table>`` LEFT JOINs pg_collation on
+        # this. Zero (== no non-default collation) is fine for all our
+        # ASCII columns; the join returns no rows and the whole
+        # ``attcollation`` sub-select is NULL — the exact ``\d`` fast path.
+        FacadeColumn(name="attcollation", type=DataType.INT),
     ]
     rows = []
     for ds, tbl in _all_tables(catalog):
@@ -351,6 +381,7 @@ def _build_pg_attribute(catalog: FacadeCatalog) -> CatalogRelation:
                 "attnum": attnum, "attlen": _TYPE_META[oid][1],
                 "atttypmod": -1, "attnotnull": False, "atthasdef": False,
                 "attisdropped": False, "attidentity": "", "attgenerated": "",
+                "attcollation": 0,
             })
             attnum += 1
     return CatalogRelation(name="pg_attribute", columns=columns, rows=rows)
@@ -372,6 +403,11 @@ def _build_pg_type() -> CatalogRelation:
         FacadeColumn(name="typnotnull", type=DataType.BOOLEAN),
         FacadeColumn(name="typbasetype", type=DataType.INT),
         FacadeColumn(name="typtypmod", type=DataType.INT),
+        # Default collation OID. psql's ``\d <table>`` compares this to
+        # ``pg_attribute.attcollation``; matching zero (== default
+        # collation) means the ``attcollation`` sub-select returns NULL,
+        # which is the correct behavior for columns using the DB default.
+        FacadeColumn(name="typcollation", type=DataType.INT),
     ]
     rows = []
     for oid, (typname, typlen, typcategory) in _TYPE_META.items():
@@ -382,6 +418,7 @@ def _build_pg_type() -> CatalogRelation:
             "typisdefined": True, "typdelim": ",", "typrelid": 0,
             "typelem": 0, "typarray": 0, "typnotnull": False,
             "typbasetype": 0, "typtypmod": -1,
+            "typcollation": 0,
         })
     return CatalogRelation(name="pg_type", columns=columns, rows=rows)
 
@@ -588,6 +625,203 @@ def _build_pg_am() -> CatalogRelation:
             {"oid": PG_AM_HEAP_OID, "amname": "heap",
              "amhandler": 0, "amtype": "t"},
         ],
+    )
+
+
+def _build_pg_policy() -> CatalogRelation:
+    """Stub RLS-policies table — empty. psql's ``\\d <table>`` queries
+    this per relation to render the "Policies:" section; an empty
+    ``pg_policy`` correctly yields zero rows, matching real Postgres
+    behavior for a table with no row-level security policies."""
+    return CatalogRelation(
+        name="pg_policy",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="polname", type=DataType.TEXT),
+            FacadeColumn(name="polrelid", type=DataType.INT),
+            FacadeColumn(name="polcmd", type=DataType.TEXT),
+            FacadeColumn(name="polpermissive", type=DataType.BOOLEAN),
+            FacadeColumn(name="polroles", type=DataType.TEXT),
+            FacadeColumn(name="polqual", type=DataType.TEXT),
+            FacadeColumn(name="polwithcheck", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+# --- Empty stubs for catalog tables psql's ``\d`` variants touch.
+#
+# SLayer has no triggers, no inheritance, no publications, no partitioning,
+# no extensions by construction — every one of these tables is legitimately
+# empty. Real Postgres returns zero rows too. Each stub declares the full
+# column set psql's queries reference so DuckDB doesn't error on unknown
+# columns; the ``_PG_CATALOG_NAMES`` allowlist entry is what stops the
+# "Unknown schema: 'pg_catalog'" from the routing decision.
+
+
+def _build_pg_trigger() -> CatalogRelation:
+    """Triggers — empty. psql's ``\\d <table>`` reads this for the
+    "Triggers:" section per relation."""
+    return CatalogRelation(
+        name="pg_trigger",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="tgrelid", type=DataType.INT),
+            FacadeColumn(name="tgparentid", type=DataType.INT),
+            FacadeColumn(name="tgname", type=DataType.TEXT),
+            FacadeColumn(name="tgfoid", type=DataType.INT),
+            FacadeColumn(name="tgtype", type=DataType.INT),
+            FacadeColumn(name="tgenabled", type=DataType.TEXT),
+            FacadeColumn(name="tgisinternal", type=DataType.BOOLEAN),
+            FacadeColumn(name="tgconstrrelid", type=DataType.INT),
+            FacadeColumn(name="tgconstrindid", type=DataType.INT),
+            FacadeColumn(name="tgconstraint", type=DataType.INT),
+            FacadeColumn(name="tgdeferrable", type=DataType.BOOLEAN),
+            FacadeColumn(name="tginitdeferred", type=DataType.BOOLEAN),
+            FacadeColumn(name="tgnargs", type=DataType.INT),
+            FacadeColumn(name="tgargs", type=DataType.TEXT),
+            FacadeColumn(name="tgqual", type=DataType.TEXT),
+            FacadeColumn(name="tgoldtable", type=DataType.TEXT),
+            FacadeColumn(name="tgnewtable", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_inherits() -> CatalogRelation:
+    """Inheritance — empty. Read by ``\\d`` to render parent/child
+    relationships. SLayer models are flat."""
+    return CatalogRelation(
+        name="pg_inherits",
+        columns=[
+            FacadeColumn(name="inhrelid", type=DataType.INT),
+            FacadeColumn(name="inhparent", type=DataType.INT),
+            FacadeColumn(name="inhseqno", type=DataType.INT),
+            FacadeColumn(name="inhdetachpending", type=DataType.BOOLEAN),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_publication() -> CatalogRelation:
+    """Logical-replication publications — empty. ``\\dRp`` and ``\\d``
+    query this."""
+    return CatalogRelation(
+        name="pg_publication",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="pubname", type=DataType.TEXT),
+            FacadeColumn(name="pubowner", type=DataType.INT),
+            FacadeColumn(name="puballtables", type=DataType.BOOLEAN),
+            FacadeColumn(name="pubinsert", type=DataType.BOOLEAN),
+            FacadeColumn(name="pubupdate", type=DataType.BOOLEAN),
+            FacadeColumn(name="pubdelete", type=DataType.BOOLEAN),
+            FacadeColumn(name="pubtruncate", type=DataType.BOOLEAN),
+            FacadeColumn(name="pubviaroot", type=DataType.BOOLEAN),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_publication_rel() -> CatalogRelation:
+    """Publication membership — empty."""
+    return CatalogRelation(
+        name="pg_publication_rel",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="prpubid", type=DataType.INT),
+            FacadeColumn(name="prrelid", type=DataType.INT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_publication_tables() -> CatalogRelation:
+    """Publication → table denormalized view — empty."""
+    return CatalogRelation(
+        name="pg_publication_tables",
+        columns=[
+            FacadeColumn(name="pubname", type=DataType.TEXT),
+            FacadeColumn(name="schemaname", type=DataType.TEXT),
+            FacadeColumn(name="tablename", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_partitioned_table() -> CatalogRelation:
+    """Partitioning metadata — empty. SLayer has no partitioned models."""
+    return CatalogRelation(
+        name="pg_partitioned_table",
+        columns=[
+            FacadeColumn(name="partrelid", type=DataType.INT),
+            FacadeColumn(name="partstrat", type=DataType.TEXT),
+            FacadeColumn(name="partnatts", type=DataType.INT),
+            FacadeColumn(name="partdefid", type=DataType.INT),
+            FacadeColumn(name="partattrs", type=DataType.TEXT),
+            FacadeColumn(name="partclass", type=DataType.TEXT),
+            FacadeColumn(name="partcollation", type=DataType.TEXT),
+            FacadeColumn(name="partexprs", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_rewrite() -> CatalogRelation:
+    """Rewrite rules (used by views) — empty. SLayer views are surfaced
+    via ``pg_class.relkind = 'v'`` but the rewrite text isn't tracked."""
+    return CatalogRelation(
+        name="pg_rewrite",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="rulename", type=DataType.TEXT),
+            FacadeColumn(name="ev_class", type=DataType.INT),
+            FacadeColumn(name="ev_type", type=DataType.TEXT),
+            FacadeColumn(name="ev_enabled", type=DataType.TEXT),
+            FacadeColumn(name="is_instead", type=DataType.BOOLEAN),
+            FacadeColumn(name="ev_qual", type=DataType.TEXT),
+            FacadeColumn(name="ev_action", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_extension() -> CatalogRelation:
+    """Installed extensions — empty. SLayer doesn't advertise any."""
+    return CatalogRelation(
+        name="pg_extension",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="extname", type=DataType.TEXT),
+            FacadeColumn(name="extowner", type=DataType.INT),
+            FacadeColumn(name="extnamespace", type=DataType.INT),
+            FacadeColumn(name="extrelocatable", type=DataType.BOOLEAN),
+            FacadeColumn(name="extversion", type=DataType.TEXT),
+            FacadeColumn(name="extconfig", type=DataType.TEXT),
+            FacadeColumn(name="extcondition", type=DataType.TEXT),
+        ],
+        rows=[],
+    )
+
+
+def _build_pg_collation() -> CatalogRelation:
+    """Stub collation table — empty. psql's ``\\d <table>`` LEFT JOINs
+    ``pg_collation`` on ``pg_attribute.attcollation``; with every column
+    reporting ``attcollation = 0`` (default collation), the join returns
+    zero rows and the whole ``attcollation`` sub-select in the ``\\d``
+    query evaluates to NULL — matching real Postgres behavior for
+    columns using the database default."""
+    return CatalogRelation(
+        name="pg_collation",
+        columns=[
+            FacadeColumn(name="oid", type=DataType.INT),
+            FacadeColumn(name="collname", type=DataType.TEXT),
+            FacadeColumn(name="collnamespace", type=DataType.INT),
+            FacadeColumn(name="collencoding", type=DataType.INT),
+            FacadeColumn(name="collcollate", type=DataType.TEXT),
+            FacadeColumn(name="collctype", type=DataType.TEXT),
+        ],
+        rows=[],
     )
 
 
@@ -861,8 +1095,12 @@ _PG_CATALOG_NAMES = frozenset({
     "pg_settings", "pg_description", "pg_stat_user_tables", "pg_enum",
     "pg_tables", "pg_views", "pg_matviews", "pg_constraint", "pg_index",
     "pg_attrdef",
-    # psql backslash-command coverage stubs.
-    "pg_am", "pg_roles", "pg_database",
+    # psql backslash-command coverage. Every one is legitimately empty
+    # for SLayer (no roles / policies / triggers / publications / etc.).
+    "pg_am", "pg_roles", "pg_database", "pg_collation", "pg_policy",
+    "pg_trigger", "pg_inherits",
+    "pg_publication", "pg_publication_rel", "pg_publication_tables",
+    "pg_partitioned_table", "pg_rewrite", "pg_extension",
 })
 
 _INFO_SCHEMA_NAMES = frozenset({
@@ -872,13 +1110,15 @@ _INFO_SCHEMA_NAMES = frozenset({
 
 
 def _is_known_catalog_table(tbl: exp.Table) -> bool:
-    """True if ``tbl`` resolves to a known catalog relation.
+    """True if ``tbl`` resolves to a catalog relation the executor should
+    handle — either one we've explicitly cataloged, or any table under
+    ``pg_catalog`` / ``information_schema`` (unknown ones are synthesized
+    as empty relations at execute time; see
+    ``_synthesize_missing_catalog_tables``).
 
-    Bare names resolve ONLY to ``pg_catalog`` relations (whose ``pg_``
-    prefix disambiguates them from user models). Bare
-    ``information_schema`` names like ``columns`` / ``tables`` would
-    otherwise hijack user models with the same name, so they require the
-    explicit ``information_schema.`` qualifier.
+    Bare table names still require an explicit allowlist match — bare
+    ``columns`` / ``tables`` from ``information_schema`` would otherwise
+    hijack user models with the same name.
     """
     name = str(tbl.name).lower()
     schema_part = tbl.args.get("db")
@@ -896,13 +1136,17 @@ def _is_known_catalog_table(tbl: exp.Table) -> bool:
         if catalog != CATALOG_NAME.lower():
             return False
     if schema == "information_schema":
-        return name in _INFO_SCHEMA_NAMES
+        # Explicit info_schema refs route to the executor — unknown ones
+        # get synthesized as empty at execute time.
+        return True
     if schema == "pg_catalog":
-        return name in _PG_CATALOG_NAMES
+        # Any explicit pg_catalog.<x> ref routes to the executor. Unknown
+        # ones get synthesized as empty at execute time.
+        return True
     if schema is None:
-        # Bare names — pg_catalog only (bare info-schema names like
-        # ``columns`` / ``tables`` are too generic and would shadow user
-        # models with those names).
+        # Bare names — only well-known pg_catalog relations. Unknown bare
+        # names would shadow user models with the same name, so they
+        # never route to the catalog executor.
         return name in _PG_CATALOG_NAMES
     return False
 
@@ -950,6 +1194,16 @@ _CATALOG_FUNCTION_NAMES = frozenset({
     "pg_encoding_to_char",
     "has_table_privilege", "has_any_column_privilege", "has_schema_privilege",
     "_pg_expandarray",
+    # psql / BI-tool helper stubs — see ``_CONSTANT_STUB_LITERALS`` for
+    # their return values (mostly NULL for features SLayer doesn't advertise).
+    "pg_get_constraintdef", "pg_get_indexdef", "pg_get_triggerdef",
+    "pg_get_viewdef", "pg_get_partkeydef", "pg_get_ruledef",
+    "pg_get_functiondef", "pg_get_statisticsobjdef",
+    "pg_get_statisticsobjdef_columns", "pg_get_statisticsobjdef_expressions",
+    "pg_get_serial_sequence", "pg_column_is_updatable",
+    "pg_get_object_address", "pg_identify_object", "pg_size_pretty",
+    "pg_relation_size", "pg_indexes_size", "pg_table_size",
+    "pg_database_size", "pg_tablespace_size",
     # sqlglot's class-key forms for the dedicated Func subclasses
     # (``type(node).key`` returns e.g. ``currentdatabase`` without the
     # underscore — they appear here via ``_function_name_lower``).
@@ -1027,6 +1281,33 @@ _CONSTANT_STUB_LITERALS: dict[str, Any] = {
     "pg_get_expr": None,
     # SLayer always emits UTF8; ``\l`` calls this with ``d.encoding``.
     "pg_encoding_to_char": "UTF8",
+    # Postgres helper functions psql's ``\d`` and BI tools call for
+    # definitions of things SLayer doesn't advertise (constraints /
+    # indexes / triggers / views / partitions / rules / stats objects /
+    # functions / serial-sequence / column-updatable). NULL is the right
+    # answer for absence — matches real Postgres behavior for a table
+    # that has none of these features.
+    "pg_get_constraintdef": None,
+    "pg_get_indexdef": None,
+    "pg_get_triggerdef": None,
+    "pg_get_viewdef": None,
+    "pg_get_partkeydef": None,
+    "pg_get_ruledef": None,
+    "pg_get_functiondef": None,
+    "pg_get_statisticsobjdef": None,
+    "pg_get_statisticsobjdef_columns": None,
+    "pg_get_statisticsobjdef_expressions": None,
+    "pg_get_serial_sequence": None,
+    "pg_column_is_updatable": False,
+    # ACL / policy-role helpers — return NULL / empty for absence.
+    "pg_get_object_address": None,
+    "pg_identify_object": None,
+    "pg_size_pretty": "0 bytes",
+    "pg_relation_size": 0,
+    "pg_indexes_size": 0,
+    "pg_table_size": 0,
+    "pg_database_size": 0,
+    "pg_tablespace_size": 0,
 }
 
 # Data-lookup stubs are AST-renamed to private names; the macros are
@@ -1123,6 +1404,10 @@ class _AstRewriter:
        to private ``_slayer_*`` names.
     7. Rewrite Postgres regex operators (``~``/``!~``/``~*``/``!~*``)
        to ``regexp_matches``/``NOT regexp_matches`` with the case flag.
+    8. Unwrap Postgres schema-qualified operator syntax — psql emits
+       ``x OPERATOR(pg_catalog.~) y`` for ``\\du <pattern>`` etc.
+    9. Strip ``COLLATE pg_catalog.default`` (no DuckDB equivalent;
+       ASCII byte-compare is the right semantic for catalog names).
     """
 
     def __init__(self, *, datasource: str,
@@ -1138,12 +1423,24 @@ class _AstRewriter:
         parsed = parsed.transform(self._rewrite_current_schemas_indexed)
         parsed = parsed.transform(self._rewrite_current_schemas_bare)
         parsed = parsed.transform(self._rewrite_pg_format_quoted_ident)
+        # Normalise schema-qualified CAST target types BEFORE the reg*
+        # rewriters below — ``pg_catalog.regclass`` becomes a bare
+        # ``regclass`` DataType so ``_rewrite_regclass_casts`` still
+        # catches it and performs the ``'foo'::regclass → OID`` lookup.
+        parsed = parsed.transform(self._rewrite_schema_qualified_cast)
         parsed = parsed.transform(self._rewrite_regclass_casts)
         parsed = parsed.transform(self._rewrite_regproc_regtype_casts)
         parsed = parsed.transform(self._substitute_context_functions)
         parsed = parsed.transform(self._rename_stub_functions)
         parsed = parsed.transform(self._rewrite_regex_operators)
+        parsed = parsed.transform(self._rewrite_schema_qualified_operator)
+        parsed = parsed.transform(self._strip_collate_clause)
         parsed = parsed.transform(self._rewrite_pg_any_array)
+        # Fallback for any lingering unknown ``pg_*`` function call —
+        # becomes NULL. Runs last so all known stubs claim their calls
+        # first. Semantically "SLayer doesn't advertise this feature",
+        # matching real Postgres for empty catalogs.
+        parsed = parsed.transform(self._stub_unknown_pg_functions)
         return parsed
 
     # ----- 1. schema qualifier strip ----------------------------------------
@@ -1326,7 +1623,17 @@ class _AstRewriter:
         if isinstance(inner, exp.Literal) and inner.is_string:
             text = inner.this  # raw string value (no quotes)
             return exp.Literal.number(self._lookup_static_regclass(text))
-        # Dynamic: CAST(<expr> AS REGCLASS) → slayer_regclass_oid(<expr>).
+        # Bare column ref (e.g. ``c.oid``): pass through unchanged. These
+        # are numeric OID columns; wrapping in the VARCHAR-only UDF would
+        # yield a Binder Error, and the OID value itself is the most
+        # useful answer we can produce for SLayer's minimal catalog.
+        if isinstance(inner, exp.Column):
+            return inner
+        # Everything else — function calls, nested casts, expressions —
+        # routes through the UDF lookup. Metabase's real query uses
+        # ``CAST(FORMAT('%I.%I', schema, table) AS regclass)`` to look up
+        # a class OID by its qualified name; that's the shape the UDF was
+        # built for.
         return exp.Anonymous(this="slayer_regclass_oid", expressions=[inner])
 
     @staticmethod
@@ -1534,6 +1841,45 @@ class _AstRewriter:
             return exp.Boolean(this=False)
         return node
 
+    # ----- Unknown pg_* function fallback -----------------------------------
+
+    # DuckDB-native ``pg_*`` names we must NOT rewrite. Extend as DuckDB
+    # adds new Postgres compatibility helpers.
+    _DUCKDB_NATIVE_PG_FUNCTIONS: frozenset[str] = frozenset()
+
+    @classmethod
+    def _stub_unknown_pg_functions(cls, node: exp.Expression) -> exp.Expression:
+        """Fallback for unknown ``pg_*`` function calls — return NULL.
+
+        Any Anonymous call whose name starts with ``pg_`` and isn't a known
+        catalog stub or DuckDB native gets replaced with a NULL literal +
+        WARN log. Semantically "SLayer doesn't advertise this feature" —
+        the same answer real Postgres gives when the underlying catalog
+        table is empty.
+
+        User-defined SQL functions (no ``pg_`` prefix) are left alone —
+        typos in user queries still surface loudly.
+        """
+        if not isinstance(node, exp.Anonymous):
+            return node
+        name = str(node.args.get("this", "")).lower()
+        if not name.startswith("pg_"):
+            return node
+        # Already-known stubs get resolved by earlier passes; if we still
+        # see a ``pg_*`` Anonymous here it's genuinely unknown.
+        if name in _CATALOG_FUNCTION_NAMES:
+            return node
+        if name in cls._DUCKDB_NATIVE_PG_FUNCTIONS:
+            return node
+        # The AST-renamed private stubs (``_slayer_*``) don't start with
+        # ``pg_``, so they can't hit this branch — safe.
+        logger.warning(
+            "pg-facade: stubbed unknown Postgres helper function %s(...) → NULL — "
+            "consider adding it to _CONSTANT_STUB_LITERALS if this recurs.",
+            name,
+        )
+        return exp.Null()
+
     # ----- 7. regex operator rewrites ---------------------------------------
 
     @staticmethod
@@ -1554,6 +1900,105 @@ class _AstRewriter:
                 expressions=[node.this, node.expression, exp.Literal.string("i")],
             )
         return node
+
+    # Postgres's ``OPERATOR(<schema>.<op>)`` calls a schema-qualified operator
+    # — psql emits ``x OPERATOR(pg_catalog.~) y`` for ``\du <pattern>`` /
+    # ``\dt <pattern>`` etc. sqlglot parses this as ``exp.Operator(this=lhs,
+    # operator="pg_catalog.~", expression=rhs)``. DuckDB has no OPERATOR()
+    # syntax; strip the schema qualifier and rebuild the equivalent
+    # expression the previous pass understands (RegexpLike / RegexpILike or
+    # a plain binary op).
+    _PG_REGEX_OPS = {"~", "~*", "!~", "!~*"}
+
+    @staticmethod
+    def _rewrite_schema_qualified_operator(node: exp.Expression) -> exp.Expression:
+        if not isinstance(node, exp.Operator):
+            return node
+        raw = str(node.args.get("operator", ""))
+        # ``pg_catalog.~`` → ``~``; a plain ``=`` etc. stays unchanged.
+        op = raw.rsplit(".", 1)[-1]
+        lhs = node.this
+        rhs = node.expression
+        if op == "~":
+            return exp.Anonymous(this="regexp_matches", expressions=[lhs, rhs])
+        if op == "~*":
+            return exp.Anonymous(
+                this="regexp_matches",
+                expressions=[lhs, rhs, exp.Literal.string("i")],
+            )
+        if op == "!~":
+            return exp.Not(this=exp.Anonymous(
+                this="regexp_matches", expressions=[lhs, rhs],
+            ))
+        if op == "!~*":
+            return exp.Not(this=exp.Anonymous(
+                this="regexp_matches",
+                expressions=[lhs, rhs, exp.Literal.string("i")],
+            ))
+        # Unknown / plain operator: strip the schema qualifier and re-emit
+        # as a bare binary operation. Preserves generality without adding
+        # per-operator branches.
+        return exp.condition(f"({lhs.sql()}) {op} ({rhs.sql()})")
+
+    # ``COLLATE pg_catalog."default"`` (psql emits this next to the regex
+    # match on \du etc.) has no DuckDB equivalent. Strip the whole Collate
+    # wrapper — matching is done byte-wise, which is the right semantic
+    # against ASCII role / table names.
+    @staticmethod
+    def _strip_collate_clause(node: exp.Expression) -> exp.Expression:
+        if isinstance(node, exp.Collate):
+            return node.this
+        return node
+
+    # ``CAST(x AS pg_catalog.text)`` — psql's ``\d`` emits schema-qualified
+    # type names. sqlglot parses these as ``DataType(USERDEFINED,
+    # kind=Dot(pg_catalog, <name>))``. DuckDB doesn't accept them; map
+    # each Postgres type to its DuckDB equivalent. Postgres OID-family
+    # types (regtype, regclass, regproc, …) all become BIGINT since OIDs
+    # are integers on the wire. Unknown types fall back to VARCHAR.
+    _PG_TO_DUCKDB_TYPES: dict[str, str] = {
+        "text": "VARCHAR", "varchar": "VARCHAR", "char": "VARCHAR",
+        "name": "VARCHAR",
+        "int2": "SMALLINT", "int4": "INTEGER", "int8": "BIGINT",
+        "oid": "BIGINT",
+        "float4": "REAL", "float8": "DOUBLE", "numeric": "DECIMAL",
+        "bool": "BOOLEAN", "date": "DATE",
+        "timestamp": "TIMESTAMP", "timestamptz": "TIMESTAMP",
+        "bytea": "BLOB",
+    }
+    # Reg-family types need OID-lookup semantics (``'foo'::regclass →
+    # pg_class.oid``), not plain integer coercion. Normalise them to
+    # bare DataType names so the existing ``_rewrite_regclass_casts`` /
+    # ``_rewrite_regproc_regtype_casts`` passes catch them next.
+    _PG_REG_TYPES = frozenset({
+        "regclass", "regproc", "regtype",
+        "regoper", "regoperator", "regprocedure",
+    })
+
+    @classmethod
+    def _rewrite_schema_qualified_cast(cls, node: exp.Expression) -> exp.Expression:
+        if not isinstance(node, exp.DataType):
+            return node
+        # USERDEFINED with a dotted ``kind`` is how sqlglot represents
+        # ``pg_catalog.<type>`` on the postgres dialect.
+        if node.args.get("this") != exp.DataType.Type.USERDEFINED:
+            return node
+        kind = node.args.get("kind")
+        if not isinstance(kind, exp.Dot):
+            return node
+        lhs = kind.this
+        rhs = kind.expression
+        if not (isinstance(lhs, exp.Identifier) and str(lhs.this).lower() == "pg_catalog"):
+            return node
+        if not isinstance(rhs, exp.Identifier):
+            return node
+        pg_type = str(rhs.this).lower()
+        if pg_type in cls._PG_REG_TYPES:
+            # Rebuild as a bare DataType so the reg* rewriters below can
+            # dispatch on ``_cast_target_kind() == 'regclass'`` etc.
+            return exp.DataType.build(pg_type.upper(), dialect="postgres")
+        duckdb_type = cls._PG_TO_DUCKDB_TYPES.get(pg_type, "VARCHAR")
+        return exp.DataType.build(duckdb_type)
 
 
 # --- DuckDB type mapping ----------------------------------------------------
@@ -1664,6 +2109,7 @@ class CatalogSqlExecutor:
         relations = build_catalog_relations(
             catalog, datasource, extra_relations=extra_relations,
         )
+        self._registered_tables: set[str] = set()
         for relation in relations:
             self._register_relation(relation)
         self._register_stubs()
@@ -1674,6 +2120,7 @@ class CatalogSqlExecutor:
             for c in relation.columns
         )
         self._conn.execute(f'CREATE TABLE "{relation.name}" ({cols_ddl})')
+        self._registered_tables.add(relation.name.lower())
         if not relation.rows:
             return
         # Bulk insert via a single statement with a row-list expansion.
@@ -1718,8 +2165,131 @@ class CatalogSqlExecutor:
         # Both schema-qualified and bare lookups go through the same map.
         return self._regclass_map.get(text, self._regclass_map.get(text.lower(), 0))
 
+    _SYNTHETIC_SCHEMAS: frozenset[str] = frozenset({
+        "pg_catalog", "information_schema",
+    })
+
+    def _synthesize_missing_catalog_tables(
+        self, root: exp.Expression,
+    ) -> exp.Expression:
+        """Replace ``pg_catalog.<x>`` / ``information_schema.<x>`` Table
+        refs whose ``<x>`` isn't in ``self._registered_tables`` with an
+        inline ``(SELECT NULL::VARCHAR AS c1, ... WHERE FALSE) AS <alias>``
+        subquery. Columns come from scanning the same query for column
+        refs against the Table's alias (or bare-name qualifier). NEVER
+        fires for user-schema references — those keep the loud "unknown
+        table" error.
+
+        Fallback for obscure catalog tables (``pg_statistic_ext``,
+        ``pg_hba_file_rules``, …) SLayer doesn't advertise. Empty result
+        matches real Postgres for tables with no rows. Emits a WARN log
+        per synthesis so recurring hits are visible.
+        """
+        replacements: list[tuple[exp.Table, exp.Subquery]] = []
+        for tbl in root.find_all(exp.Table):
+            # Runs BEFORE strip-schema-qualifier, so ``db`` still carries
+            # the original schema qualifier. Only synthesize when it's
+            # explicitly ``pg_catalog`` / ``information_schema`` — bare
+            # names might be user tables or aliases, and never fabricating
+            # for those keeps typo diagnostics loud.
+            db_part = tbl.args.get("db")
+            if db_part is None:
+                continue
+            schema = (
+                str(db_part.this) if hasattr(db_part, "this") else str(db_part)
+            ).lower()
+            if schema not in self._SYNTHETIC_SCHEMAS:
+                continue
+            name = str(tbl.name).lower()
+            if name in self._registered_tables:
+                continue
+            # Info-schema tables are registered under the ``_is_<x>``
+            # alias in DuckDB (see the builder-name remap in
+            # ``_index_catalog_relations``); check that form too.
+            if schema == "information_schema" and f"_is_{name}" in self._registered_tables:
+                continue
+            # Discover column names the same query references off this
+            # Table's alias (or bare name).
+            handle = tbl.alias or tbl.name
+            columns = self._discover_referenced_columns(root, handle)
+            if not columns:
+                # No column refs — the query probably does ``SELECT *``;
+                # give it a single throwaway ``oid`` column so DuckDB has
+                # something to project. Real queries always reference some
+                # column, so this is a rare path.
+                columns = ["oid"]
+            subq = self._build_empty_subquery(columns, alias=handle)
+            replacements.append((tbl, subq))
+            logger.warning(
+                "pg-facade: synthesized empty relation for unknown catalog "
+                "table %r (columns: %s) — consider adding a stub in "
+                "build_catalog_relations if this recurs.",
+                (schema or "pg_catalog") + "." + name, ", ".join(columns),
+            )
+        for old, new in replacements:
+            old.replace(new)
+        return root
+
+    @staticmethod
+    def _discover_referenced_columns(
+        root: exp.Expression, handle: str,
+    ) -> list[str]:
+        """Scan ``root`` for Column refs that plausibly belong to the
+        Table being synthesized:
+
+        - qualified refs (``handle.col``): keep — unambiguous.
+        - bare refs (``col`` with no ``table=`` qualifier): keep too. A
+          bare col could technically belong to any FROM table, but when
+          we synthesize an empty-relation stand-in the columns type as
+          VARCHAR NULL — adding one that "shouldn't" belong is harmless
+          (the query never reads from the synthetic row set anyway).
+          The alternative would need sqlglot Scope resolution across all
+          FROM tables, which is complex for negligible correctness gain.
+
+        Returns distinct column names in first-seen order."""
+        seen: dict[str, None] = {}
+        handle_lower = handle.lower()
+        for col in root.find_all(exp.Column):
+            tbl_ident = col.args.get("table")
+            if tbl_ident is not None:
+                tbl_name = (
+                    str(tbl_ident.this) if hasattr(tbl_ident, "this")
+                    else str(tbl_ident)
+                ).lower()
+                if tbl_name != handle_lower:
+                    continue
+            # tbl_ident is None (bare) OR matches handle — take it.
+            colname = str(col.name)
+            if colname and colname not in seen:
+                seen[colname] = None
+        return list(seen.keys())
+
+    @staticmethod
+    def _build_empty_subquery(
+        columns: list[str], *, alias: str,
+    ) -> exp.Subquery:
+        """Emit ``(SELECT NULL::VARCHAR AS c1, ... WHERE FALSE) AS <alias>``.
+        Every column types as VARCHAR — NULL literals coerce freely to any
+        downstream type, and the ``WHERE FALSE`` guarantees zero rows so
+        the type choice is only for column-shape validation."""
+        select_cols = ", ".join(
+            f'NULL::VARCHAR AS "{c}"' for c in columns
+        )
+        sub_sql = f"SELECT {select_cols} WHERE FALSE"
+        parsed_sub = sqlglot.parse_one(sub_sql, read="duckdb")
+        return exp.Subquery(
+            this=parsed_sub,
+            alias=exp.TableAlias(this=exp.to_identifier(alias)),
+        )
+
     def execute(self, *, parsed: exp.Expression, sql: str) -> RowBatch:
-        rewritten = self._rewriter.rewrite(parsed.copy())
+        # Synthesize empties for unknown ``pg_catalog.<x>`` refs BEFORE
+        # the rewriter's strip-schema-qualifier pass — after that runs,
+        # the ``db=pg_catalog`` qualifier is gone and we can't distinguish
+        # "originally schema-qualified" from "bare name that happens to
+        # shadow a user table".
+        parsed = self._synthesize_missing_catalog_tables(parsed.copy())
+        rewritten = self._rewriter.rewrite(parsed)
         try:
             duckdb_sql = rewritten.sql(dialect="duckdb")
             cursor = self._conn.execute(duckdb_sql)

--- a/tests/facade/test_catalog_sql.py
+++ b/tests/facade/test_catalog_sql.py
@@ -1194,42 +1194,11 @@ def test_where_clause_now_honored_against_pg_class() -> None:
 
 
 class TestPsqlBackslashCommandCoverage:
-    """``\\d``, ``\\du``, ``\\l`` and friends in psql expand into SQL that
-    joins these three catalogs. Before this work they raised "Unknown
-    schema: 'pg_catalog'" because the stub tables didn't exist."""
-
-    def test_pg_am_has_heap_row(self) -> None:
-        batch = _run("SELECT oid, amname FROM pg_catalog.pg_am")
-        assert {r["amname"] for r in batch.rows} == {"heap"}
-        # OID must match real Postgres for `pg_class.relam` to round-trip.
-        assert {r["oid"] for r in batch.rows} == {2}
-
-    def test_pg_roles_has_default_slayer_row(self) -> None:
-        batch = _run(
-            "SELECT rolname, rolsuper, rolcanlogin, rolconnlimit "
-            "FROM pg_catalog.pg_roles"
-        )
-        assert len(batch.rows) == 1
-        row = batch.rows[0]
-        assert row["rolname"] == "slayer"
-        assert row["rolsuper"] is False
-        assert row["rolcanlogin"] is True
-        assert row["rolconnlimit"] == -1
-
-    def test_pg_database_has_one_row_for_connected_datasource(self) -> None:
-        batch = _run("SELECT datname, datcollate, encoding FROM pg_catalog.pg_database")
-        assert len(batch.rows) == 1
-        row = batch.rows[0]
-        assert row["datname"] == "jaffle"  # _demo_catalog's datasource
-        assert row["datcollate"] == "en_US.UTF-8"
-        assert row["encoding"] == 6  # UTF8
-
-    def test_pg_encoding_to_char_round_trips_to_utf8(self) -> None:
-        batch = _run("SELECT pg_encoding_to_char(6) AS enc")
-        assert batch.rows == [{"enc": "UTF8"}]
+    """The exact ``\\d`` JOIN shape that triggered the original bug —
+    joins pg_class + pg_namespace + pg_am. Fails on any drop of a stub
+    or the routing allowlist."""
 
     def test_psql_backslash_d_join_through_pg_am_succeeds(self) -> None:
-        """The exact ``\\d`` JOIN shape that triggered the original failure."""
         sql = (
             "SELECT n.nspname AS schema_name, c.relname AS name, c.relkind "
             "FROM pg_catalog.pg_class AS c "
@@ -1240,10 +1209,7 @@ class TestPsqlBackslashCommandCoverage:
             "ORDER BY 1, 2"
         )
         batch = _run(sql)
-        names = {r["name"] for r in batch.rows}
-        # The _demo_catalog has both `orders` and `customers` — confirm
-        # the JOIN didn't drop rows because of the new pg_am wiring.
-        assert names == {"orders", "customers"}
+        assert {r["name"] for r in batch.rows} == {"orders", "customers"}
 
 
 class TestCatalogExtensibilityHook:
@@ -1473,3 +1439,373 @@ class TestPublicSchemaFallbackGuard:
         )
         with pytest.raises(TranslationError, match="Unknown schema"):
             translate("SELECT id FROM public.orders", multi, dialect="postgres")
+
+
+# --- Postgres schema-qualified operator + COLLATE stripping -----------------
+
+
+class TestSchemaQualifiedOperatorRewrite:
+    """psql emits ``OPERATOR(pg_catalog.<op>)`` for ``\\du <pattern>`` /
+    ``\\d <pattern>`` etc. plus ``COLLATE pg_catalog.default`` alongside.
+    DuckDB has no OPERATOR() syntax and no ``pg_catalog`` collation
+    namespace; both must be rewritten to bare DuckDB equivalents."""
+
+    @pytest.mark.parametrize("op,pattern,expected", [
+        ("~", "^slayer$", [{"rolname": "slayer"}]),         # case-sensitive match
+        ("~*", "^SLAYER$", [{"rolname": "slayer"}]),        # case-insensitive match
+        ("!~", "^slayer$", []),                             # negated: default row matches
+        ("!~*", "^SLAYER$", []),                            # negated case-insensitive
+    ])
+    def test_pg_catalog_regex_operator(
+        self, op: str, pattern: str, expected: list,
+    ) -> None:
+        """The four schema-qualified regex operator variants map to
+        ``regexp_matches`` / ``NOT regexp_matches``."""
+        batch = _run(
+            f"SELECT rolname FROM pg_catalog.pg_roles "
+            f"WHERE rolname OPERATOR(pg_catalog.{op}) '{pattern}'"
+        )
+        assert batch.rows == expected
+
+    def test_collate_clause_stripped(self) -> None:
+        # ``COLLATE pg_catalog.default`` is dropped; the match proceeds
+        # byte-wise, which is the right semantic for ASCII catalog names.
+        batch = _run(
+            "SELECT rolname FROM pg_catalog.pg_roles "
+            "WHERE rolname OPERATOR(pg_catalog.~) '^slayer$' COLLATE pg_catalog.default"
+        )
+        assert batch.rows == [{"rolname": "slayer"}]
+
+    def test_psql_backslash_du_pattern_query_executes(self) -> None:
+        """The exact ``\\du users`` shape combining both rewrites."""
+        sql = (
+            "SELECT r.rolname, r.rolsuper, r.rolinherit, r.rolcreaterole, "
+            "r.rolcreatedb, r.rolcanlogin, r.rolconnlimit, r.rolvaliduntil, "
+            "r.rolreplication, r.rolbypassrls "
+            "FROM pg_catalog.pg_roles AS r "
+            "WHERE r.rolname OPERATOR(pg_catalog.~) '^(users)$' "
+            "COLLATE pg_catalog.default ORDER BY 1"
+        )
+        # Executes cleanly — the default ``slayer`` role doesn't match
+        # ``^(users)$`` so we get zero rows, not an error.
+        batch = _run(sql)
+        assert batch.rows == []
+
+
+# --- CAST(x AS pg_catalog.<type>) rewrite -----------------------------------
+
+
+class TestSchemaQualifiedCastRewrite:
+    """psql's ``\\d <table>`` casts to Postgres-specific ``pg_catalog.<type>``
+    names (``pg_catalog.regtype``, ``pg_catalog.text``, ``pg_catalog.oid``…).
+    DuckDB rejects those; each must be rewritten to a DuckDB equivalent."""
+
+    def test_pg_catalog_text_becomes_varchar(self) -> None:
+        batch = _run("SELECT CAST('hello' AS pg_catalog.text) AS s")
+        assert batch.rows == [{"s": "hello"}]
+
+    def test_pg_catalog_oid_becomes_bigint(self) -> None:
+        # Plain ``oid`` is a bare integer type — no OID-lookup semantics.
+        batch = _run("SELECT CAST(100 AS pg_catalog.oid) AS v")
+        assert batch.rows == [{"v": 100}]
+
+    def test_pg_catalog_regclass_string_lookup(self) -> None:
+        """``'pg_class'::pg_catalog.regclass`` normalizes to bare
+        ``regclass`` and gets the OID-lookup semantics of the existing
+        pass — critical for psql's ``\\dx`` which classoid-checks with
+        ``'pg_catalog.pg_extension'::pg_catalog.regclass``. Pre-fix, the
+        pg_catalog qualifier caused this to coerce silently to BIGINT,
+        losing the lookup."""
+        batch = _run("SELECT CAST('pg_class' AS pg_catalog.regclass) AS o")
+        # ``pg_class`` is in KNOWN_SYSTEM_OIDS with the canonical OID 1259.
+        assert batch.rows == [{"o": 1259}]
+
+    def test_pg_catalog_regtype_string_lookup(self) -> None:
+        # ``int8`` is a known type — resolves to its wire OID.
+        from slayer.pg_facade.protocol import OID_INT8
+        batch = _run("SELECT CAST('int8' AS pg_catalog.regtype) AS o")
+        assert batch.rows == [{"o": OID_INT8}]
+
+    def test_pg_catalog_regproc_returns_zero(self) -> None:
+        # regproc is unconditionally 0 — matches bare ``::regproc``.
+        batch = _run("SELECT CAST('some_fn' AS pg_catalog.regproc) AS r")
+        assert batch.rows == [{"r": 0}]
+
+    def test_unknown_pg_catalog_type_falls_back_to_varchar(self) -> None:
+        # ``some_unknown_type`` won't be in the map; fallback is VARCHAR.
+        batch = _run("SELECT CAST('x' AS pg_catalog.some_unknown_type) AS v")
+        assert batch.rows == [{"v": "x"}]
+
+    def test_bare_type_names_still_work(self) -> None:
+        # The rewriter is scoped to USERDEFINED types with dotted kinds;
+        # a bare ``CAST(... AS text)`` must be untouched.
+        batch = _run("SELECT CAST(42 AS text) AS s")
+        assert batch.rows == [{"s": "42"}]
+
+
+class TestPgClassPsqlDescribeCompleteness:
+    """The exact ``\\d <table>`` shape combining pg_class + pg_am JOIN +
+    schema-qualified CAST + self-JOIN through reltoastrelid. Reads every
+    column psql's describe query touches — will fail if any of them are
+    missing from ``pg_class``."""
+
+    def test_psql_backslash_d_query_end_to_end(self) -> None:
+        sql = (
+            "SELECT c.relchecks, c.relkind, c.relhasindex, c.relhasrules, "
+            "c.relhastriggers, c.relrowsecurity, c.relforcerowsecurity, "
+            "FALSE AS relhasoids, c.relispartition, '', c.reltablespace, "
+            "CASE WHEN c.reloftype = 0 THEN '' "
+            "ELSE CAST(CAST(c.reloftype AS pg_catalog.regtype) AS pg_catalog.text) END, "
+            "c.relpersistence, c.relreplident, am.amname "
+            "FROM pg_catalog.pg_class AS c "
+            "LEFT JOIN pg_catalog.pg_class AS tc ON (c.reltoastrelid = tc.oid) "
+            "LEFT JOIN pg_catalog.pg_am AS am ON (c.relam = am.oid) "
+            "WHERE c.relname = 'orders'"
+        )
+        batch = _run(sql)
+        assert len(batch.rows) == 1
+        row = batch.rows[0]
+        assert row["relkind"] == "r"
+        assert row["amname"] == "heap"
+        assert row["relreplident"] == "d"
+
+
+# --- pg_collation stub + typcollation completeness -------------------------
+
+
+class TestPgCollationAndTypcollation:
+    """psql's ``\\d <table>`` runs a sub-select through pg_collation JOIN
+    pg_type to detect non-default collations. Pre-fix: pg_collation
+    wasn't in the routing allowlist, and pg_type lacked ``typcollation``
+    — the query fell through to user-table resolution and yielded
+    "Unknown schema: 'pg_catalog'", or a misleading DuckDB "Referenced
+    table 't' not found" (which really means a missing column)."""
+
+    def test_pg_collation_routes_and_returns_empty(self) -> None:
+        batch = _run("SELECT * FROM pg_catalog.pg_collation")
+        # Empty is the right shape — every column uses the default
+        # collation (attcollation = 0), so the JOIN yields no rows.
+        assert batch.rows == []
+
+    def test_psql_backslash_d_attribute_subselect(self) -> None:
+        """The correlated ``pg_collation``/``pg_type`` sub-select from
+        ``\\d <table>`` executes end-to-end (previously failed on the
+        missing pg_type.typcollation column with a misleading binder
+        error)."""
+        sql = (
+            "SELECT a.attname, "
+            "(SELECT c.collname FROM pg_catalog.pg_collation AS c, "
+            "pg_catalog.pg_type AS t "
+            "WHERE c.oid = a.attcollation AND t.oid = a.atttypid "
+            "AND a.attcollation <> t.typcollation) AS attcollation "
+            "FROM pg_catalog.pg_attribute AS a "
+            "WHERE a.attrelid IN "
+            "(SELECT oid FROM pg_catalog.pg_class WHERE relname = 'orders')"
+        )
+        batch = _run(sql)
+        # Rows returned — one per column of the orders model.
+        assert len(batch.rows) > 0
+        # The correlated attcollation sub-select is NULL for every row
+        # (every column uses the default collation).
+        assert all(r["attcollation"] is None for r in batch.rows)
+
+
+# --- Empty stubs for the psql "\d <table>" fan-out -------------------------
+
+
+class TestEmptyCatalogStubs:
+    """psql's ``\\d <table>`` runs 6-10 sub-queries against catalog tables
+    for triggers / inheritance / publications / partitioning / view
+    rewrite / extensions. SLayer has none of these by construction, so
+    every stub is legitimately empty — matching real Postgres."""
+
+    _STUB_TABLES = [
+        "pg_trigger", "pg_inherits",
+        "pg_publication", "pg_publication_rel", "pg_publication_tables",
+        "pg_partitioned_table", "pg_rewrite", "pg_extension",
+    ]
+
+    @pytest.mark.parametrize("table", _STUB_TABLES)
+    def test_stub_is_routed_and_returns_empty(self, table: str) -> None:
+        # Routing parity is covered structurally by
+        # ``test_every_pg_builder_is_in_the_routing_allowlist``; this
+        # only re-verifies the end-to-end execute path per stub.
+        batch = _run(f"SELECT * FROM pg_catalog.{table}")
+        assert batch.rows == []
+
+    def test_psql_backslash_d_policy_subquery(self) -> None:
+        """Real ``\\d`` RLS sub-query — the shape that motivated the
+        ``pg_policy`` stub in the first place."""
+        sql = (
+            "SELECT pol.polname, pol.polpermissive, "
+            "pg_catalog.pg_get_expr(pol.polqual, pol.polrelid) "
+            "FROM pg_catalog.pg_policy AS pol WHERE pol.polrelid = 999"
+        )
+        assert _run(sql).rows == []
+
+    def test_psql_backslash_d_trigger_subquery(self) -> None:
+        """The "Triggers:" section query psql emits per relation."""
+        sql = (
+            "SELECT t.tgname, t.tgenabled, t.tgisinternal "
+            "FROM pg_catalog.pg_trigger AS t "
+            "WHERE t.tgrelid = 999 AND NOT t.tgisinternal ORDER BY 1"
+        )
+        assert _run(sql).rows == []
+
+    def test_psql_backslash_dx_extension_query(self) -> None:
+        """``\\dx`` — list installed extensions. Empty for SLayer."""
+        sql = (
+            "SELECT e.extname, e.extversion, n.nspname, c.description "
+            "FROM pg_catalog.pg_extension e "
+            "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = e.extnamespace "
+            "LEFT JOIN pg_catalog.pg_description c "
+            "ON c.objoid = e.oid AND c.classoid = 'pg_catalog.pg_extension'::pg_catalog.regclass "
+            "ORDER BY 1"
+        )
+        assert _run(sql).rows == []
+
+
+# --- On-the-fly synthesis for unknown catalog tables -----------------------
+
+
+class TestSynthesisFallback:
+    """When a query references ``pg_catalog.<x>`` / ``information_schema.<x>``
+    for a table we haven't explicitly cataloged, synthesize an empty
+    relation inline instead of erroring. Columns are discovered from
+    same-query column refs. Never fires for user-schema refs — those
+    still surface as loud "unknown table" errors."""
+
+    def test_unknown_pg_catalog_table_synthesized_empty(self, caplog) -> None:
+        """``pg_statistic_ext`` — a real one we hit in the wild that
+        wasn't in the explicit stub set."""
+        with caplog.at_level(logging.WARNING, logger="slayer.facade.catalog_sql"):
+            batch = _run(
+                "SELECT stxname, stxrelid FROM pg_catalog.pg_statistic_ext "
+                "WHERE stxrelid = 100"
+            )
+        assert batch.rows == []
+        # WARN log fired with the friendly diagnostic.
+        assert any(
+            "pg_statistic_ext" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_unknown_information_schema_table_synthesized_empty(self) -> None:
+        """Same pattern for information_schema — psql / Metabase touch
+        obscure ones like ``information_schema.character_sets``."""
+        batch = _run(
+            "SELECT character_set_name FROM information_schema.character_sets"
+        )
+        assert batch.rows == []
+
+    def test_column_discovery_via_alias(self) -> None:
+        """Column refs qualified by an alias (``e.something``) are
+        discovered and appear in the synthetic relation's column set."""
+        batch = _run(
+            "SELECT e.custom_column, e.other_col "
+            "FROM pg_catalog.pg_totally_fictional AS e"
+        )
+        # DuckDB is happy — the synthetic table exposes both columns.
+        assert batch.rows == []
+
+    def test_bare_column_ref_still_discovered(self) -> None:
+        """Column refs without a table qualifier (bare ``foo``) are picked
+        up when the FROM table has no alias — the common shape psql uses."""
+        batch = _run(
+            "SELECT some_col FROM pg_catalog.pg_absent WHERE another_col = 42"
+        )
+        assert batch.rows == []
+
+    def test_user_schema_typo_still_errors_loudly(self) -> None:
+        """Safety: an unknown ``public.<x>`` reference must NOT be
+        synthesized — that would mask user-table typos silently. Only
+        pg_catalog / information_schema refs get the graceful fallback."""
+        with pytest.raises(TranslationError):
+            _run("SELECT * FROM public.no_such_table_here")
+
+    def test_bare_unknown_name_not_synthesized(self) -> None:
+        """A bare ``foo`` (no schema qualifier) that doesn't match any
+        known pg_catalog name is NOT synthesized. Falls through to normal
+        user-table resolution and errors loudly."""
+        with pytest.raises(TranslationError):
+            _run("SELECT * FROM totally_made_up_bare_name")
+
+    def test_synthesis_with_pg_catalog_helper_stub_calls(self, caplog) -> None:
+        """The full ``\\d`` pg_statistic_ext query from the wild:
+        combines synthesis + regclass casts + the new pg_get_* helper
+        stubs + ANY() array subscript."""
+        sql = (
+            "SELECT oid, CAST(stxrelid AS pg_catalog.regclass), "
+            "CAST(CAST(stxnamespace AS pg_catalog.regnamespace) AS pg_catalog.text) AS nsp, "
+            "stxname, pg_catalog.pg_get_statisticsobjdef_columns(oid) AS columns, "
+            "'d' = ANY(stxkind) AS ndist_enabled, "
+            "stxstattarget FROM pg_catalog.pg_statistic_ext "
+            "WHERE stxrelid = 100 ORDER BY nsp, stxname"
+        )
+        batch = _run(sql)
+        assert batch.rows == []
+
+
+# --- Unknown pg_* function fallback ----------------------------------------
+
+
+class TestUnknownPgFunctionFallback:
+    """Any lingering ``pg_*`` Anonymous call not covered by a known stub
+    gets rewritten to NULL. Prevents whack-a-mole every time a new BI
+    tool release calls yet another obscure Postgres helper."""
+
+    def test_unknown_pg_helper_becomes_null(self, caplog) -> None:
+        """``pg_relation_is_publishable`` — a real psql-emitted helper
+        we didn't stub explicitly."""
+        with caplog.at_level(logging.WARNING, logger="slayer.facade.catalog_sql"):
+            batch = _run(
+                "SELECT pg_catalog.pg_relation_is_publishable(100) AS v"
+            )
+        assert batch.rows == [{"v": None}]
+        assert any(
+            "pg_relation_is_publishable" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_bare_unknown_pg_call_also_stubbed(self, caplog) -> None:
+        """Bare ``pg_foo(...)`` (no schema qualifier) also stubs to NULL —
+        real queries mix qualified and bare forms."""
+        with caplog.at_level(logging.WARNING, logger="slayer.facade.catalog_sql"):
+            batch = _run("SELECT pg_some_random_helper('x', 42) AS v")
+        assert batch.rows == [{"v": None}]
+
+    def test_known_stubs_still_take_precedence(self) -> None:
+        """The fallback runs AFTER the explicit-stub passes —
+        ``pg_get_userbyid`` still returns 'slayer', not NULL."""
+        batch = _run("SELECT pg_catalog.pg_get_userbyid(10) AS u")
+        assert batch.rows == [{"u": "slayer"}]
+
+    def test_non_pg_prefixed_unknown_function_still_errors(self) -> None:
+        """Safety: user-defined SQL functions (no ``pg_`` prefix) are
+        left alone — typos in user queries surface loudly."""
+        with pytest.raises(TranslationError):
+            _run("SELECT some_unknown_udf(42) AS v")
+
+
+class TestRegclassCastOnNumericExpr:
+    """``CAST(<numeric_column> AS regclass)`` — psql's ``\\d`` emits this
+    pattern for inheritance / partitioning queries (``CAST(c.oid AS
+    regclass)``). Pre-fix, the rewrite wrapped it in
+    ``slayer_regclass_oid(<expr>)`` which is a VARCHAR-only UDF — Binder
+    Error on any BIGINT arg. Now: pass through unchanged (the OID value
+    itself is the most useful answer we can produce for our minimal
+    catalog)."""
+
+    def test_regclass_cast_on_numeric_column_passes_through(self) -> None:
+        # Uses pg_class.oid which is INT in our schema.
+        batch = _run("SELECT CAST(c.oid AS pg_catalog.regclass) AS r FROM pg_catalog.pg_class AS c")
+        # Rows come back — values are the oid values themselves.
+        assert len(batch.rows) > 0
+        assert all(isinstance(r["r"], int) for r in batch.rows)
+
+    def test_regclass_cast_on_string_literal_still_looks_up(self) -> None:
+        """Regression: the literal-lookup case still works (this is what
+        the UDF was built for). ``'pg_class'::regclass → 1259``."""
+        batch = _run("SELECT CAST('pg_class' AS pg_catalog.regclass) AS r")
+        assert batch.rows == [{"r": 1259}]
+

--- a/tests/facade/test_catalog_sql.py
+++ b/tests/facade/test_catalog_sql.py
@@ -1809,3 +1809,51 @@ class TestRegclassCastOnNumericExpr:
         batch = _run("SELECT CAST('pg_class' AS pg_catalog.regclass) AS r")
         assert batch.rows == [{"r": 1259}]
 
+
+
+class TestPR213ReviewFixes:
+    """Regression tests for the four CodeRabbit findings on PR #213."""
+
+    def test_regclass_cast_from_numeric_literal_passes_through(self) -> None:
+        """``CAST(0 AS pg_catalog.regclass)`` = InvalidOid in Postgres.
+        Pre-fix, this fell through to the VARCHAR-only UDF and errored
+        on the INTEGER argument. Now: pass through unchanged (numeric
+        literals join column refs on the fast path)."""
+        batch = _run("SELECT CAST(0 AS pg_catalog.regclass) AS r")
+        assert batch.rows == [{"r": 0}]
+
+    @pytest.mark.parametrize("pg_type", [
+        "regoper", "regoperator", "regprocedure",
+    ])
+    def test_extended_reg_family_casts_return_zero(self, pg_type: str) -> None:
+        """``regoper`` / ``regoperator`` / ``regprocedure`` are in
+        ``_PG_REG_TYPES`` (normalized to bare types) but pre-fix,
+        ``_rewrite_regproc_regtype_casts`` only knew ``regproc`` and
+        ``regtype`` — the others fell through as unsupported types."""
+        batch = _run(f"SELECT CAST('anything' AS pg_catalog.{pg_type}) AS r")
+        assert batch.rows == [{"r": 0}]
+
+    def test_information_schema_synthesis_uses_is_alias(self) -> None:
+        """For synthesized ``information_schema.<x>`` tables without a
+        user alias, the subquery alias must be ``_is_<x>`` because
+        ``_strip_column_schema_qualifiers`` later rewrites bare-column
+        qualifiers to that name. Pre-fix, alias/qualifier mismatched
+        and DuckDB missed the columns."""
+        # ``character_sets`` isn't in the info-schema stub set — synthesized.
+        # This asserts the synthesis wiring: rewrite must resolve.
+        batch = _run(
+            "SELECT character_set_name FROM information_schema.character_sets"
+        )
+        assert batch.rows == []
+
+    def test_synthesized_column_with_quote_in_name_does_not_break_sql(self) -> None:
+        """Column identifiers containing ``"`` must be escaped before
+        embedding into the synth SQL — otherwise a malicious or oddly-
+        named identifier could malform the parse."""
+        # Sqlglot happily parses double-quoted identifiers with escaped
+        # inner quotes (``"foo""bar"``). Use one via an unknown catalog.
+        batch = _run(
+            'SELECT "foo""bar" FROM pg_catalog.pg_totally_unknown'
+        )
+        # Executes cleanly, returns empty rows with the odd column name.
+        assert batch.rows == []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for catalog-style queries and `\d`-style introspection, including additional PostgreSQL system table coverage and helper behavior.
  * Better handling of schema-qualified casts/operators (including regex operators) and `COLLATE pg_catalog.default` normalization for more PostgreSQL-flavored queries.

* **Bug Fixes**
  * Unknown `pg_catalog.*` / `information_schema.*` relations are now synthesized as empty results with column discovery (with warnings), improving BI/psql compatibility.
  * Unknown `pg_get_*`-style helper calls fall back to safe `NULL` values; `regclass` casting is more reliable for numeric and string inputs.

* **Tests**
  * Added extensive coverage for rewrite, synthesis, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->