### PR TITLE
Bump version to 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.9.1"
+version = "0.9.2"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Bumps the package version from 0.9.1 to 0.9.2.

Covers the changes merged to main since the 0.9.1 tag: the multi-schema Postgres facade (datasources map to Postgres schemas, more psql commands, per-connection storage_provider seam), the new recommend_root_model tool, the strengthened dbt MetricFlow importer with count_distinct_approx, and the inspect sample-value back-fill fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)