### PR TITLE
Bump version to 0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.9.2"
+version = "0.9.3"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Bumps the package version from 0.9.2 to 0.9.3.

Covers the change merged to main since the 0.9.2 tag: an optional root_hint on recommend_root_model that forces an intended query root (honored when it reaches every requested item, otherwise falls back to the automatic pick with a warning), surfaced on MCP, REST, CLI (--root-hint), and SlayerClient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **0.9.3**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->