### PR TITLE
Handle read-only Postgres facade tx

### DIFF
--- a/slayer/facade/translator.py
+++ b/slayer/facade/translator.py
@@ -2273,12 +2273,19 @@ def _unwrap_probe(
 # (``BEGIN READ ONLY``, ``START TRANSACTION ISOLATION LEVEL …``). The facade is
 # read-only, so every variant is a no-op that just opens a transaction; we
 # recognise them BEFORE the parse to avoid the parse error entirely.
+#
+# The characteristic run uses a POSSESSIVE quantifier (``[^;]*+``) so the
+# engine can't backtrack into it when the trailing ``;?\s*$`` fails to match.
+# The prior ``(?:\s+[^;]*?)?\s*;?\s*$`` form had ``\s`` matched by both the
+# lazy inner class and the trailing ``\s*``, so a crafted long whitespace run
+# before a mid-string ``;`` drove O(n²) backtracking on the asyncio loop —
+# stalling every connection (SonarCloud ReDoS finding, PR #221).
 _TX_START_RE = re.compile(
-    r"^\s*START\s+TRANSACTION\b(?:\s+[^;]*?)?\s*;?\s*$",
+    r"^\s*START\s+TRANSACTION\b[^;]*+;?\s*$",
     re.IGNORECASE | re.DOTALL,
 )
 _TX_BEGIN_RE = re.compile(
-    r"^\s*BEGIN\b(?:\s+(?:WORK|TRANSACTION))?(?:\s+[^;]*?)?\s*;?\s*$",
+    r"^\s*BEGIN\b(?:\s+(?:WORK|TRANSACTION))?[^;]*+;?\s*$",
     re.IGNORECASE | re.DOTALL,
 )
 

--- a/slayer/facade/translator.py
+++ b/slayer/facade/translator.py
@@ -2268,6 +2268,36 @@ def _unwrap_probe(
     return ProbeResult(batch=probe)
 
 
+# Transaction-open statements. sqlglot's postgres dialect parses bare ``BEGIN``
+# / ``START TRANSACTION`` but REJECTS the characteristic forms Metabase emits
+# (``BEGIN READ ONLY``, ``START TRANSACTION ISOLATION LEVEL …``). The facade is
+# read-only, so every variant is a no-op that just opens a transaction; we
+# recognise them BEFORE the parse to avoid the parse error entirely.
+_TX_START_RE = re.compile(
+    r"^\s*START\s+TRANSACTION\b(?:\s+[^;]*?)?\s*;?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+_TX_BEGIN_RE = re.compile(
+    r"^\s*BEGIN\b(?:\s+(?:WORK|TRANSACTION))?(?:\s+[^;]*?)?\s*;?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _classify_transaction_open(sql: str) -> NoOpResult | None:
+    """Recognise ``BEGIN`` / ``START TRANSACTION`` (with optional
+    characteristics like ``READ ONLY`` / ``ISOLATION LEVEL …``) pre-parse.
+
+    Returns a ``NoOpResult`` opening a transaction, or ``None`` when the
+    statement isn't a transaction-open. ``COMMIT`` / ``ROLLBACK`` / ``END``
+    parse fine on their own and are handled by ``_classify_noop_root``.
+    """
+    if _TX_START_RE.match(sql):
+        return NoOpResult(command_tag="START TRANSACTION")
+    if _TX_BEGIN_RE.match(sql):
+        return NoOpResult(command_tag="BEGIN")
+    return None
+
+
 def translate(
     sql: str,
     catalog: FacadeCatalog,
@@ -2298,6 +2328,13 @@ def translate(
 
     Raises ``TranslationError`` on user-visible failures.
     """
+    # Step 0 — transaction-open shim (before parse): sqlglot rejects the
+    # characteristic forms (``BEGIN READ ONLY`` etc.) that BI tools wrap reads
+    # in, so recognise them here rather than letting the parse fail.
+    tx_open = _classify_transaction_open(sql)
+    if tx_open is not None:
+        return tx_open
+
     token = _IN_FACADE_PARSE.set(True)
     try:
         parsed = _parse_with_keyword_alias_fallback(sql, dialect=dialect)

--- a/slayer/pg_facade/connection.py
+++ b/slayer/pg_facade/connection.py
@@ -69,6 +69,24 @@ logger = logging.getLogger(__name__)
 _BACKEND_PID = 1
 _BACKEND_SECRET = 0
 _PARAM_PLACEHOLDER = re.compile(r"\$(\d+)")
+
+# Strips characteristics off a statement-initial ``BEGIN`` / ``START
+# TRANSACTION`` (``READ ONLY``, ``ISOLATION LEVEL …``, ``DEFERRABLE`` …) so the
+# sqlglot-based simple-query splitter — which rejects those forms — can still
+# parse the statement list. Anchored to statement start (^ or after ``;``) so a
+# ``begin`` column reference elsewhere is never touched. The stripped statement
+# stays a plain transaction-open, handled as a no-op downstream (DEV-1594).
+_TX_OPEN_STRIP_RE = re.compile(
+    r"(?P<lead>^|;)(?P<ws>\s*)"
+    r"(?P<verb>BEGIN(?:\s+WORK|\s+TRANSACTION)?|START\s+TRANSACTION)\b[^;]*",
+    re.IGNORECASE,
+)
+
+
+def _strip_tx_open_characteristics(sql: str) -> str:
+    return _TX_OPEN_STRIP_RE.sub(
+        lambda m: f"{m.group('lead')}{m.group('ws')}{m.group('verb')}", sql
+    )
 # The default schema the facade advertises (matches pg_namespace /
 # current_schema). Datasources without an explicit ``postgres_schema`` land here.
 PUBLIC_SCHEMA = "public"
@@ -490,12 +508,24 @@ class PgConnection:
         try:
             statements = [s for s in sqlglot.parse(sql, dialect="postgres") if s is not None]
         except sqlglot.errors.ParseError as exc:
-            await self._send_error(
-                code=proto.SQLSTATE_SYNTAX_ERROR, message=f"SQL parse error: {exc}",
-            )
-            self._fail_tx()
-            await self._send_ready()
-            return
+            # BI tools (Metabase) wrap reads in ``BEGIN READ ONLY`` etc., which
+            # sqlglot can't parse. Strip the transaction characteristics and
+            # retry once before surfacing a syntax error.
+            stripped = _strip_tx_open_characteristics(sql)
+            try:
+                statements = [
+                    s for s in sqlglot.parse(stripped, dialect="postgres") if s is not None
+                ] if stripped != sql else None
+            except sqlglot.errors.ParseError:
+                statements = None
+            if statements is None:
+                logger.warning("pg facade: cannot parse simple query %r: %s", sql, exc)
+                await self._send_error(
+                    code=proto.SQLSTATE_SYNTAX_ERROR, message=f"SQL parse error: {exc}",
+                )
+                self._fail_tx()
+                await self._send_ready()
+                return
         if not statements:
             self._writer.write(proto.encode_empty_query_response())
             await self._send_ready()
@@ -663,10 +693,12 @@ class PgConnection:
         try:
             try:
                 result = self._translate(describe_sql)
-            except TranslationError:
+            except TranslationError as exc:
                 # Describe must not raise to the wire here; the subsequent
                 # Execute surfaces the error. Report NoData so the client
-                # can proceed.
+                # can proceed. Log it (debug) so the silent Describe path is
+                # still greppable when a client swallows the later error.
+                logger.debug("pg facade: cannot describe %r: %s", describe_sql, exc)
                 self._writer.write(proto.encode_no_data())
                 return
         finally:

--- a/tests/facade/test_translator.py
+++ b/tests/facade/test_translator.py
@@ -147,6 +147,29 @@ def test_transaction_open_shim_does_not_over_match() -> None:
     assert _classify_transaction_open("BEGINNER") is None
     assert _classify_transaction_open("SELECT * FROM begin_events") is None
     assert _classify_transaction_open("COMMIT") is None
+    # A ``BEGIN`` followed by a second statement is NOT a transaction-open.
+    assert _classify_transaction_open("BEGIN; SELECT 1") is None
+    assert _classify_transaction_open("START TRANSACTION READ ONLY; SELECT 1") is None
+
+
+def test_transaction_open_regex_is_linear_on_pathological_input() -> None:
+    """ReDoS guard (PR #221): the tx-open regexes previously backtracked
+    O(n²) on a long whitespace run before a mid-string ``;`` — a crafted
+    client string could stall the asyncio loop. The possessive quantifier
+    makes matching linear; assert a large pathological input classifies
+    fast (well under a timeout the old regex would have blown)."""
+    import time
+
+    from slayer.facade.translator import _classify_transaction_open
+
+    evil = "BEGIN" + " " * 200_000 + ";" + "x" * 5
+    start = time.perf_counter()
+    result = _classify_transaction_open(evil)
+    elapsed = time.perf_counter() - start
+    assert result is None  # not a valid single tx-open (junk after ;)
+    # Linear matching finishes in milliseconds; the old O(n²) form took
+    # tens of seconds at this size. Generous bound to avoid CI flakiness.
+    assert elapsed < 1.0, f"tx-open regex too slow ({elapsed:.2f}s) — ReDoS regression"
 
 
 def test_command_fallback_warning_suppressed_during_translate(dialect, caplog) -> None:

--- a/tests/facade/test_translator.py
+++ b/tests/facade/test_translator.py
@@ -112,6 +112,12 @@ def test_info_schema_returns_info_schema_result(dialect) -> None:
     [
         ("BEGIN", "BEGIN"),
         ("START TRANSACTION", "START TRANSACTION"),
+        # Characteristic forms sqlglot can't parse — BI tools (Metabase) wrap
+        # reads in these; the facade recognises them pre-parse (DEV-1594).
+        ("BEGIN READ ONLY", "BEGIN"),
+        ("BEGIN TRANSACTION READ ONLY", "BEGIN"),
+        ("START TRANSACTION READ ONLY", "START TRANSACTION"),
+        ("START TRANSACTION ISOLATION LEVEL SERIALIZABLE", "START TRANSACTION"),
         ("COMMIT", "COMMIT"),
         ("ROLLBACK", "ROLLBACK"),
         ("SET timezone = 'UTC'", "SET"),
@@ -132,6 +138,15 @@ def test_show_statement_is_noop_with_tag(dialect) -> None:
     result = translate(sql="SHOW search_path", catalog=_catalog(), dialect=dialect)
     assert isinstance(result, NoOpResult)
     assert result.command_tag == "SHOW"
+
+
+def test_transaction_open_shim_does_not_over_match() -> None:
+    from slayer.facade.translator import _classify_transaction_open
+
+    # Not transaction-opens: a word merely starting with "begin", and real SQL.
+    assert _classify_transaction_open("BEGINNER") is None
+    assert _classify_transaction_open("SELECT * FROM begin_events") is None
+    assert _classify_transaction_open("COMMIT") is None
 
 
 def test_command_fallback_warning_suppressed_during_translate(dialect, caplog) -> None:

--- a/tests/pg_facade/test_connection.py
+++ b/tests/pg_facade/test_connection.py
@@ -377,6 +377,24 @@ async def test_multi_statement_begin_select_commit_tx_cycle() -> None:
     assert statuses[-1] == proto.TX_IDLE
 
 
+async def test_begin_read_only_tx_cycle() -> None:
+    # Metabase wraps reads in BEGIN READ ONLY; sqlglot can't parse that, so the
+    # facade recognises it pre-parse (DEV-1594). Whole cycle must succeed.
+    inp = (
+        _startup(user="u", database="jaffle")
+        + _query("BEGIN READ ONLY; SELECT 1; COMMIT;")
+        + _terminate()
+    )
+    writer = await _run(inp)
+    msgs = _messages(writer.buffer)
+    assert not any(t == "E" for t, _ in msgs)  # no error
+    tags = [b for t, b in msgs if t == "C"]
+    assert any(b.startswith(b"BEGIN") for b in tags)
+    assert any(b.startswith(b"SELECT 1") for b in tags)
+    assert any(b.startswith(b"COMMIT") for b in tags)
+    assert _ready_statuses(msgs)[-1] == proto.TX_IDLE
+
+
 async def test_error_in_transaction_then_blocked_until_end() -> None:
     inp = (
         _startup(user="u", database="jaffle")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of `BEGIN` / `START TRANSACTION` statements with variants like `READ ONLY` and isolation/deferrable options.
  * Reduced simple-query parsing failures by retrying transaction statements in a simplified form; invalid SQL still returns syntax errors.
  * Kept SQL description behavior consistent when translation fails, returning no data cleanly.
* **Tests**
  * Added regression tests for transaction no-op classification (including non-matches and semicolon cases).
  * Added a timing guard to prevent regex backtracking issues.
  * Added an end-to-end read-only transaction cycle test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->