### PR TITLE
Instruct agents to call help() before any other SLayer tool (DEV-1652)

### DIFF
--- a/slayer/mcp/server.py
+++ b/slayer/mcp/server.py
@@ -272,8 +272,8 @@ def create_mcp_server(  # NOSONAR(S3776) — FastMCP tool-registration factory; 
         instructions=(
             "SLayer is a semantic layer for querying databases. "
             "Instead of writing SQL, describe what data you want using models, measures, dimensions, and filters. "
-            "Call help() for an overview of SLayer concepts, and help(topic='...') for deep dives on specific topics. "
-            "Typical workflow: list_datasources → models_summary → inspect → query. "
+            "Before calling any other SLayer tool, call help() first for an overview of SLayer concepts, then help(topic='...') for deep dives on specific topics. "
+            "Typical workflow: help → search → inspect → query. "
             "To connect a new database: create_datasource → describe_datasource (verify + list tables) → ingest_datasource_models → models_summary."
         ),
     )


### PR DESCRIPTION
## What

Strengthen the SLayer MCP server `instructions` (sent to the client at the initialize handshake) so agents are told to call `help()` before touching any other SLayer tool.

- Lead directive now mandates `help()` first: *"Before calling any other SLayer tool, call help() first for an overview of SLayer concepts, then help(topic='...') for deep dives on specific topics."*
- Typical workflow updated to `help → search → inspect → query`.

## Why

Previously the instructions only softly mentioned `help()` alongside a workflow that started with `list_datasources`, so agents had no clear signal to orient themselves via `help()` before querying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the onboarding guidance shown to users, recommending `help()` as the first step before using other tools.
  * Refined the typical workflow to encourage a new sequence for exploring and querying data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->