### PR TITLE
Bump version to 0.9.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.9.4"
+version = "0.9.5"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Micro-PR: bump package version `0.9.4` → `0.9.5` in `pyproject.toml`.

Covers the commits merged since the `v0.9.4` tag — RLS join constraints (DEV-1627), instruct agents to call `help()` first (DEV-1652), and per-task MCP query-engine teardown (DEV-1656).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app/package version to **0.9.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->