### PR TITLE
Refresh Postgres facade schema

### DIFF
--- a/slayer/pg_facade/connection.py
+++ b/slayer/pg_facade/connection.py
@@ -459,6 +459,11 @@ class PgConnection:
         single ``graph_fingerprint`` read per window. Backends that don't
         implement a real fingerprint report a constant, so they never rebuild
         and behave exactly as before.
+
+        Best-effort: a transient storage failure during the fingerprint read
+        or the rebuild must not propagate out of ``_run_statement`` and tear
+        down the client connection. On failure we keep the existing (possibly
+        stale) catalog and retry on the next TTL window.
         """
         if self._catalog_ttl_seconds is None or self._catalog is None:
             return
@@ -467,11 +472,23 @@ class PgConnection:
         now = time.monotonic()
         if now - self._catalog_checked_at < self._catalog_ttl_seconds:
             return
+        # Stamp the check time up front so a failing refresh retries no sooner
+        # than the next window rather than hammering storage every statement.
         self._catalog_checked_at = now
-        fingerprint = await self._read_fingerprint()
-        if fingerprint is not None and fingerprint == self._catalog_fingerprint:
+        try:
+            fingerprint = await self._read_fingerprint()
+            if fingerprint is not None and fingerprint == self._catalog_fingerprint:
+                return
+            # Build into a local and swap only on success, so a failed rebuild
+            # never leaves the connection with a half-built or ``None`` catalog.
+            catalog = await self._build_catalog()
+        except Exception:  # noqa: BLE001 — refresh is best-effort, keep old catalog
+            logger.warning(
+                "pg facade: catalog refresh failed; keeping current catalog",
+                exc_info=True,
+            )
             return
-        self._catalog = await self._build_catalog()
+        self._catalog = catalog
         self._catalog_fingerprint = fingerprint
         # Derived from the catalog; drop it so it rebuilds against the new one.
         self._column_type_index = None

--- a/slayer/pg_facade/connection.py
+++ b/slayer/pg_facade/connection.py
@@ -482,7 +482,8 @@ class PgConnection:
             # Build into a local and swap only on success, so a failed rebuild
             # never leaves the connection with a half-built or ``None`` catalog.
             catalog = await self._build_catalog()
-        except Exception:  # noqa: BLE001 — refresh is best-effort, keep old catalog
+        # Refresh is best-effort: keep the old catalog on any storage failure.
+        except Exception:  # noqa: BLE001
             logger.warning(
                 "pg facade: catalog refresh failed; keeping current catalog",
                 exc_info=True,
@@ -715,6 +716,12 @@ class PgConnection:
         )
 
     async def _handle_describe(self, msg: proto.DescribeMessage) -> None:
+        # Refresh here too, not just at Execute: Describe advertises the
+        # RowDescription, and it stamps the TTL check so the following Execute
+        # stays in the same window and won't shift the catalog underneath it —
+        # otherwise a mid-window edit could make the rows disagree with the
+        # already-sent RowDescription.
+        await self._maybe_refresh_catalog()
         if msg.kind == "S":
             stmt = self._statements.get(msg.name)
             if stmt is None:

--- a/slayer/pg_facade/connection.py
+++ b/slayer/pg_facade/connection.py
@@ -18,6 +18,7 @@ import asyncio
 import logging
 import re
 import struct
+import time
 from collections.abc import Awaitable, Callable, Iterable
 
 import sqlglot
@@ -165,6 +166,7 @@ class PgConnection:
         engine_factory: "EngineFactory | None" = None,
         tls_ctx=None,
         catalog_extra_relations=None,
+        catalog_ttl_seconds: float | None = None,
     ) -> None:
         self._reader = reader
         self._writer = writer
@@ -201,6 +203,14 @@ class PgConnection:
         # datasource — execution routes per query (see ``QueryResult.data_source``).
         self._database: str = DEFAULT_DATABASE
         self._catalog: FacadeCatalog | None = None
+        # On-demand catalog refresh: when a TTL is set, an idle connection
+        # re-checks storage at most once per window and rebuilds the catalog
+        # only if the cheap ``graph_fingerprint`` actually moved (see
+        # ``_maybe_refresh_catalog``). ``None`` keeps the catalog static for
+        # the connection's lifetime (the historical behavior).
+        self._catalog_ttl_seconds: float | None = catalog_ttl_seconds
+        self._catalog_checked_at: float = 0.0
+        self._catalog_fingerprint: str | None = None
         self._statements: dict[str, _PreparedStatement] = {}
         self._portals: dict[str, _Portal] = {}
         # Lazily-built (schema, table, column) -> DataType lookup, used by the
@@ -233,6 +243,8 @@ class PgConnection:
                 return
             await self._resolve_scope(startup.parameters.get("database"))
             self._catalog = await self._build_catalog()
+            self._catalog_checked_at = time.monotonic()
+            self._catalog_fingerprint = await self._read_fingerprint()
             await self._send_startup_complete()
             await self._main_loop()
         except _Done:
@@ -421,6 +433,48 @@ class PgConnection:
             datasource_priority=priority,
             default_schema=PUBLIC_SCHEMA,
         )
+
+    async def _read_fingerprint(self) -> str | None:
+        """Cheap storage staleness token, or ``None`` when unavailable.
+
+        Only consulted when a catalog TTL is configured. ``OSError`` (e.g. a
+        file backend caught mid-write) is treated as "unknown" so the next
+        check forces a rebuild, matching the search-graph convention.
+        """
+        if self._catalog_ttl_seconds is None:
+            return None
+        try:
+            return await self._storage.graph_fingerprint()
+        except OSError:
+            return None
+
+    async def _maybe_refresh_catalog(self) -> None:
+        """On-demand, TTL-throttled, change-gated catalog rebuild.
+
+        Called at statement entry. Rebuilds the per-connection catalog only
+        when (a) a TTL is configured, (b) the connection is idle — never
+        mid-transaction, to avoid a catalog shift inside a txn, (c) the TTL
+        window has elapsed since the last check, and (d) the storage
+        fingerprint has actually changed. When nothing changed the cost is a
+        single ``graph_fingerprint`` read per window. Backends that don't
+        implement a real fingerprint report a constant, so they never rebuild
+        and behave exactly as before.
+        """
+        if self._catalog_ttl_seconds is None or self._catalog is None:
+            return
+        if self._tx_state != proto.TX_IDLE:
+            return
+        now = time.monotonic()
+        if now - self._catalog_checked_at < self._catalog_ttl_seconds:
+            return
+        self._catalog_checked_at = now
+        fingerprint = await self._read_fingerprint()
+        if fingerprint is not None and fingerprint == self._catalog_fingerprint:
+            return
+        self._catalog = await self._build_catalog()
+        self._catalog_fingerprint = fingerprint
+        # Derived from the catalog; drop it so it rebuilds against the new one.
+        self._column_type_index = None
 
     async def _send_startup_complete(self) -> None:
         for name, value in parameter_status_defaults():
@@ -805,6 +859,10 @@ class PgConnection:
         self, sql: str, *, result_formats: list[int] | None, send_row_description: bool,
     ) -> bool:
         """Translate + respond. Returns False if an error was sent."""
+        # Refresh the catalog before translating so an idle connection picks
+        # up model/schema edits within the TTL window (no-op when disabled or
+        # mid-transaction).
+        await self._maybe_refresh_catalog()
         try:
             result = self._translate(sql)
         except TranslationError as exc:

--- a/slayer/pg_facade/server.py
+++ b/slayer/pg_facade/server.py
@@ -35,6 +35,7 @@ async def serve(
     engine_factory: EngineFactory | None = None,
     tls_ctx: ssl.SSLContext | None = None,
     catalog_extra_relations=None,
+    catalog_ttl_seconds: float | None = None,
 ) -> None:
     """Bind and serve forever. Validates the bind/token combination first.
 
@@ -65,6 +66,7 @@ async def serve(
             storage_provider=storage_provider, engine_factory=engine_factory,
             tls_ctx=tls_ctx,
             catalog_extra_relations=catalog_extra_relations,
+            catalog_ttl_seconds=catalog_ttl_seconds,
         )
         try:
             await conn.run()

--- a/slayer/pg_facade/server.py
+++ b/slayer/pg_facade/server.py
@@ -49,6 +49,13 @@ async def serve(
     (e.g. Storyline) use this to project real per-tenant data into
     ``pg_roles`` / ``pg_database`` / add new tables. Override is by table
     name; new tables are appended.
+
+    ``catalog_ttl_seconds``: catalog freshness for each connection. ``None``
+    (default) keeps the historical behavior — the catalog is built once at
+    connect and stays static for the connection's lifetime. A float enables
+    TTL-gated, on-demand refresh: an idle connection re-checks the storage
+    fingerprint at most once per window and rebuilds only when it changed, so
+    long-lived BI sessions pick up model/schema edits without reconnecting.
     """
     # A custom authenticator that prompts for a password counts as auth, so the
     # non-loopback-requires-a-secret rule is satisfied even without a token.

--- a/tests/pg_facade/test_connection.py
+++ b/tests/pg_facade/test_connection.py
@@ -2440,3 +2440,97 @@ async def test_static_storage_aclose_not_called_when_scope_swap_did_not_run() ->
     assert static_aclosed["called"] is False, (
         "static storage's aclose must not be called when scope-swap never ran"
     )
+
+
+# --- on-demand catalog refresh (TTL) ----------------------------------------
+
+
+class _RefreshableStorage(_FakeStorage):
+    """Fake storage whose content and fingerprint can be mutated mid-test."""
+
+    def __init__(self, models_by_ds, *, fingerprint: str) -> None:
+        super().__init__(models_by_ds)
+        self.fingerprint = fingerprint
+
+    async def graph_fingerprint(self) -> str:  # NOSONAR(S7503) — async to satisfy the awaited interface
+        return self.fingerprint
+
+
+def _refresh_conn(storage) -> PgConnection:
+    # ttl 0.0 => the window is always "elapsed", so every call re-checks the
+    # cheap fingerprint (the change-gate is what decides whether to rebuild).
+    conn = PgConnection(
+        asyncio.StreamReader(), _FakeWriter(),
+        engine=_FakeEngine([]), storage=storage,
+        catalog_ttl_seconds=0.0,
+    )
+    conn._storage = storage
+    return conn
+
+
+async def _seed_catalog(conn: PgConnection, storage) -> None:
+    conn._catalog = await conn._build_catalog()
+    conn._catalog_fingerprint = storage.fingerprint
+    conn._catalog_checked_at = 0.0
+
+
+async def test_refresh_rebuilds_catalog_when_fingerprint_changes() -> None:
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    # A model edit that also bumps the storage fingerprint.
+    storage._models_by_ds["jaffle"][0].description = "edited"
+    storage.fingerprint = "v2"
+
+    await conn._maybe_refresh_catalog()
+
+    assert conn._catalog is not before  # rebuilt
+    assert conn._catalog_fingerprint == "v2"
+    assert conn._column_type_index is None  # derived index dropped
+
+
+async def test_refresh_skips_when_fingerprint_unchanged() -> None:
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    # Content changes but the fingerprint doesn't -> the cheap check
+    # short-circuits and we never pay for a rebuild.
+    storage._models_by_ds["jaffle"].append(_orders_model())
+
+    await conn._maybe_refresh_catalog()
+
+    assert conn._catalog is before  # NOT rebuilt
+
+
+async def test_refresh_skips_mid_transaction() -> None:
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    storage.fingerprint = "v2"  # changed, but...
+    conn._tx_state = proto.TX_IN_TRANSACTION  # ...we're inside a transaction
+
+    await conn._maybe_refresh_catalog()
+
+    assert conn._catalog is before  # never shift the catalog mid-transaction
+
+
+async def test_refresh_disabled_by_default_never_rebuilds() -> None:
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = PgConnection(
+        asyncio.StreamReader(), _FakeWriter(),
+        engine=_FakeEngine([]), storage=storage,
+    )  # no catalog_ttl_seconds -> static catalog (historical behavior)
+    conn._storage = storage
+    conn._catalog = await conn._build_catalog()
+    before = conn._catalog
+    storage.fingerprint = "v2"
+
+    await conn._maybe_refresh_catalog()
+
+    assert conn._catalog is before

--- a/tests/pg_facade/test_connection.py
+++ b/tests/pg_facade/test_connection.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import struct
+import time
 import types
 
 import pytest
@@ -2571,3 +2572,53 @@ async def test_refresh_swallows_build_error_and_keeps_catalog() -> None:
     assert conn._catalog is before  # half-built/None never swapped in
     # Fingerprint not advanced -> the next TTL window retries the rebuild.
     assert conn._catalog_fingerprint == "v1"
+
+
+async def test_describe_triggers_catalog_refresh() -> None:
+    # Regression: Describe advertises the RowDescription, so it must refresh
+    # too — not only Execute — or a mid-window edit could make the later
+    # Execute's rows disagree with the already-sent RowDescription.
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)  # ttl 0.0 -> always re-checks
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    storage._models_by_ds["jaffle"][0].description = "edited"
+    storage.fingerprint = "v2"
+
+    # Missing statement still exercises the refresh at the top of _handle_describe.
+    await conn._handle_describe(proto.DescribeMessage(kind="S", name="nope"))
+
+    assert conn._catalog is not before  # refreshed at Describe
+    assert conn._catalog_fingerprint == "v2"
+
+
+async def test_describe_pins_execute_to_same_catalog_within_window() -> None:
+    ttl = 30.0  # realistic window (NOT 0)
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = PgConnection(
+        asyncio.StreamReader(), _FakeWriter(),
+        engine=_FakeEngine([]), storage=storage,
+        catalog_ttl_seconds=ttl,
+    )
+    conn._storage = storage
+    conn._catalog = await conn._build_catalog()
+    conn._catalog_fingerprint = "v1"
+    # Last checked more than the TTL ago, relative to the live monotonic clock,
+    # so the first check treats the window as expired regardless of process
+    # uptime. (A literal 0.0 would fail on a young process where monotonic() < ttl.)
+    conn._catalog_checked_at = time.monotonic() - (ttl + 1.0)
+
+    # Edit lands before Describe -> Describe rebuilds to the v2 snapshot.
+    storage.fingerprint = "v2"
+    await conn._handle_describe(proto.DescribeMessage(kind="S", name="nope"))
+    pinned = conn._catalog
+    assert conn._catalog_fingerprint == "v2"
+
+    # A further edit lands, but Execute (via _maybe_refresh_catalog) is inside
+    # the same TTL window Describe just stamped, so it must NOT shift the
+    # catalog underneath the RowDescription Describe advertised.
+    storage.fingerprint = "v3"
+    await conn._maybe_refresh_catalog()
+    assert conn._catalog is pinned
+    assert conn._catalog_fingerprint == "v2"

--- a/tests/pg_facade/test_connection.py
+++ b/tests/pg_facade/test_connection.py
@@ -2534,3 +2534,40 @@ async def test_refresh_disabled_by_default_never_rebuilds() -> None:
     await conn._maybe_refresh_catalog()
 
     assert conn._catalog is before
+
+
+async def test_refresh_swallows_fingerprint_error_and_keeps_catalog() -> None:
+    class _BoomFingerprint(_RefreshableStorage):
+        async def graph_fingerprint(self) -> str:
+            raise RuntimeError("storage unreachable")  # not an OSError
+
+    storage = _BoomFingerprint({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    # Best-effort: the error must be swallowed, not propagate to _run_statement.
+    await conn._maybe_refresh_catalog()
+
+    assert conn._catalog is before  # current catalog retained
+
+
+async def test_refresh_swallows_build_error_and_keeps_catalog() -> None:
+    storage = _RefreshableStorage({"jaffle": [_orders_model()]}, fingerprint="v1")
+    conn = _refresh_conn(storage)
+    await _seed_catalog(conn, storage)
+    before = conn._catalog
+
+    # Fingerprint moves (forces a rebuild attempt), but the rebuild itself fails.
+    storage.fingerprint = "v2"
+
+    async def _boom():
+        raise RuntimeError("rebuild failed")
+
+    conn._build_catalog = _boom  # type: ignore[assignment]
+
+    await conn._maybe_refresh_catalog()  # must not raise
+
+    assert conn._catalog is before  # half-built/None never swapped in
+    # Fingerprint not advanced -> the next TTL window retries the rebuild.
+    assert conn._catalog_fingerprint == "v1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `catalog_ttl_seconds` to enable on-demand, TTL-throttled catalog refresh for the PostgreSQL facade (per connection via `serve(...)`).
  * Refresh is idle-only, checks a storage “fingerprint”, and rebuilds the catalog when it changes; refresh failures are handled best-effort without breaking existing catalog usage.
  * `Describe` requests now participate in the same refresh behavior to keep `RowDescription` consistent with subsequent execution.
* **Tests**
  * Expanded coverage for TTL gating, fingerprint-change detection, active-transaction skipping, and error resilience, including `Describe`/`Execute` interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->