### PR TITLE
Fix datasource credential URL encoding

### DIFF
--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -24,6 +24,10 @@ type: postgres
 connection_string: postgresql://user:pass@host:5432/dbname
 ```
 
+When configuring individual connection fields, enter credentials exactly as issued. SLayer URL-encodes
+reserved characters when building the connection string. When supplying `connection_string` directly,
+encode reserved characters yourself.
+
 ## Environment Variables
 
 Use `${VAR_NAME}` references for credentials — resolved at read time from the process environment:

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -846,17 +846,14 @@ class DatasourceConfig(BaseModel):
             "clickhouse": "clickhouse+http",
         }
         driver = driver_map.get(self.type, self.type)
-        auth = ""
-        if self.username:
-            auth = self.username
-            if self.password:
-                auth += f":{self.password}"
-            auth += "@"
-        host_port = self.host or "localhost"
-        if self.port:
-            host_port += f":{self.port}"
-        db = self.database or ""
-        return f"{driver}://{auth}{host_port}/{db}"
+        return _SA_URL.create(
+            driver,
+            username=self.username or None,
+            password=self.password or None,
+            host=self.host or "localhost",
+            port=self.port,
+            database=self.database or "",
+        ).render_as_string(hide_password=False)
 
     def resolve_env_vars(self) -> "DatasourceConfig":
         data = self.model_dump()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import datetime
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy.engine import make_url
 
 from slayer.core.enums import DataType, TimeGranularity
 from slayer.core.models import Aggregation, Column, DatasourceConfig, ModelMeasure, SlayerModel
@@ -1042,6 +1043,31 @@ class TestDatasourceConfig:
         )
         cs = ds.get_connection_string()
         assert cs == "postgresql://user:pass@localhost:5432/mydb"
+
+    @pytest.mark.parametrize("datasource_type", ["postgres", "mysql", "clickhouse"])
+    def test_connection_string_encodes_reserved_password_characters(
+        self,
+        datasource_type: str,
+    ) -> None:
+        ds = DatasourceConfig(
+            name="test",
+            type=datasource_type,
+            host="db.example",
+            port=5432,
+            database="analytics",
+            username="user",
+            password="p@ss/w:rd",  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+        )
+
+        url = make_url(ds.get_connection_string())
+
+        assert (url.username, url.password, url.host, url.port, url.database) == (
+            "user",
+            "p@ss/w:rd",
+            "db.example",
+            5432,
+            "analytics",
+        )
 
     def test_explicit_connection_string(self) -> None:
         ds = DatasourceConfig(


### PR DESCRIPTION
## Summary

- build component-based datasource URLs with SQLAlchemy's structured `URL.create()` API
- add regression coverage for reserved password characters in PostgreSQL, MySQL, and ClickHouse URLs
- document credential encoding behavior for component fields and explicit connection strings

## Why

The generic datasource path interpolated credentials directly into a URL string. Password characters such as `@`, `/`, and `:` were then parsed as URL delimiters, corrupting the password, host, port, and database before SQLAlchemy attempted a connection.

This reuses the same SQLAlchemy URL construction approach already used by the SQL Server-specific path.

Fixes #240

## Validation

- `.venv/bin/pytest tests/test_models.py::TestDatasourceConfig -q` — 14 passed
- `.venv/bin/ruff check slayer/ tests/` — passed
- `.venv/bin/pytest tests/ -q -m "not integration" --timeout=120` — 6,468 passed, 5 skipped, 595 deselected, and 3 expected failures; one unrelated existing failure remains on macOS's case-insensitive filesystem: `tests/test_memory_string_ids.py::TestUserSuppliedId::test_case_sensitive_ids[yaml]`
- `git diff --check` — passed

The repository's pinned `ruff format --check` currently requests whole-file formatting changes in the untouched upstream versions of both modified Python files. Those unrelated formatting changes are intentionally excluded from this focused fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved datasource connection-string generation to correctly handle passwords containing reserved characters across supported database dialects.
  - Preserved connection credentials and settings accurately when constructing connection strings.

- **Documentation**
  - Clarified that individual credential fields are encoded automatically.
  - Added guidance to URL-encode reserved characters when supplying a complete `connection_string` directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->