### PR TITLE
Fix datasource passwords with reserved characters (union of #241 + #242)

### DIFF
--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -26,7 +26,8 @@ connection_string: postgresql://user:pass@host:5432/dbname
 
 When configuring individual connection fields, enter credentials exactly as issued. SLayer URL-encodes
 reserved characters when building the connection string. When supplying `connection_string` directly,
-encode reserved characters yourself.
+percent-encode reserved characters within credential components yourself; do not encode the URL's
+structural delimiters.
 
 ## Environment Variables
 

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -24,6 +24,10 @@ type: postgres
 connection_string: postgresql://user:pass@host:5432/dbname
 ```
 
+When configuring individual connection fields, enter credentials exactly as issued. SLayer URL-encodes
+reserved characters when building the connection string. When supplying `connection_string` directly,
+encode reserved characters yourself.
+
 ## Environment Variables
 
 Use `${VAR_NAME}` references for credentials — resolved at read time from the process environment:

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 _MULTIDOT_COLUMN_RE = re.compile(r'\b([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*){2,})\b')
 _STRING_LITERAL_RE = re.compile(r"'[^']*'")
 
+# A host field of the form ``<host>:<numeric-port>`` with no separate port.
+# The leading class excludes ``:`` and ``[`` so bare IPv6 (``::1``) and
+# already-bracketed IPv6 (``[::1]``) never match — only a single-colon,
+# numeric-tail host does. See ``DatasourceConfig.get_connection_string``.
+_HOST_EMBEDDED_PORT_RE = re.compile(r"^([^:\[]+):(\d+)$")
+
 
 class _SubstringRule:
     """Single source of truth for a forbidden substring inside a name.
@@ -853,12 +859,20 @@ class DatasourceConfig(BaseModel):
         # delimiters. ``username``/``password`` treat values as raw
         # credentials; ``host or "localhost"`` preserves the pre-fix
         # default. Mirrors ``_get_tsql_connection_string``.
+        host, port = self.host or "localhost", self.port
+        # Backward-compat with the pre-fix string branch: a caller could put
+        # ``host:port`` in the host field and leave ``port`` unset. Split it
+        # so ``URL.create`` doesn't bracket the colon as an IPv6 host.
+        if port is None:
+            embedded = _HOST_EMBEDDED_PORT_RE.match(host)
+            if embedded:
+                host, port = embedded.group(1), int(embedded.group(2))
         return _SA_URL.create(
             driver,
             username=self.username or None,
             password=self.password or None,
-            host=self.host or "localhost",
-            port=self.port,
+            host=host,
+            port=port,
             database=self.database or "",
         ).render_as_string(hide_password=False)
 

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -860,12 +860,14 @@ class DatasourceConfig(BaseModel):
         }
         driver = driver_map.get(self.type, self.type)
         # Build the URL with SQLAlchemy's structured builder (issue #240)
-        # rather than manual string concatenation, so credentials/host/
-        # database containing reserved URL characters (``@``, ``/``, ``:``,
-        # ...) are percent-encoded instead of being misparsed as URL
-        # delimiters. ``username``/``password`` treat values as raw
-        # credentials; ``host or "localhost"`` preserves the pre-fix
-        # default. Mirrors ``_get_tsql_connection_string``.
+        # rather than manual string concatenation, so credentials containing
+        # reserved URL characters (``@``, ``/``, ``:``, ...) are
+        # percent-encoded in the userinfo section instead of being misparsed
+        # as URL delimiters. ``username``/``password`` are treated as raw
+        # credentials; ``host or "localhost"`` preserves the pre-fix default.
+        # (SQLAlchemy renders the database path unencoded, matching the
+        # pre-fix behavior — a ``?`` in a database name is not our concern.)
+        # Mirrors ``_get_tsql_connection_string``.
         host, port = self.host or "localhost", self.port
         # Backward-compat with the pre-fix string branch, which tolerated the
         # port (and IPv6 brackets) living in the host field. ``URL.create``

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -895,7 +895,7 @@ class DatasourceConfig(BaseModel):
                 )
             port = int(embedded_port)
         return _SA_URL.create(
-            driver,
+            drivername=driver,
             username=self.username or None,
             password=self.password or None,
             host=host,

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -27,10 +27,17 @@ logger = logging.getLogger(__name__)
 _MULTIDOT_COLUMN_RE = re.compile(r'\b([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*){2,})\b')
 _STRING_LITERAL_RE = re.compile(r"'[^']*'")
 
-# A host field of the form ``<host>:<numeric-port>`` with no separate port.
-# The leading class excludes ``:`` and ``[`` so bare IPv6 (``::1``) and
-# already-bracketed IPv6 (``[::1]``) never match — only a single-colon,
-# numeric-tail host does. See ``DatasourceConfig.get_connection_string``.
+# Host-field normalization for the generic connection URL. ``URL.create``
+# wants a raw host (IPv6 without brackets) plus a separate port, but the
+# pre-fix string branch tolerated the port being embedded in the host
+# field. These two patterns split it back out. See
+# ``DatasourceConfig.get_connection_string``.
+#
+# ``[<ipv6>]`` or ``[<ipv6>]:<port>`` — bracketed IPv6, optional port.
+_BRACKETED_HOST_RE = re.compile(r"^\[(.+)\](?::(\d+))?$")
+# ``<host>:<numeric-port>`` — the leading class excludes ``:`` and ``[`` so
+# bare IPv6 (``::1``) and bracketed IPv6 never match here; only a
+# single-colon, numeric-tail host does.
 _HOST_EMBEDDED_PORT_RE = re.compile(r"^([^:\[]+):(\d+)$")
 
 
@@ -860,10 +867,20 @@ class DatasourceConfig(BaseModel):
         # credentials; ``host or "localhost"`` preserves the pre-fix
         # default. Mirrors ``_get_tsql_connection_string``.
         host, port = self.host or "localhost", self.port
-        # Backward-compat with the pre-fix string branch: a caller could put
-        # ``host:port`` in the host field and leave ``port`` unset. Split it
-        # so ``URL.create`` doesn't bracket the colon as an IPv6 host.
-        if port is None:
+        # Backward-compat with the pre-fix string branch, which tolerated the
+        # port (and IPv6 brackets) living in the host field. ``URL.create``
+        # wants a raw host + separate port, so normalize:
+        #   [::1] / [::1]:5432  -> strip brackets, lift embedded port
+        #   db.example:5432     -> split single-colon numeric port
+        # A bare IPv6 host (``::1``) is left as-is — ``URL.create`` brackets
+        # it correctly. An explicit ``port`` field always wins over an
+        # embedded one.
+        bracketed = _BRACKETED_HOST_RE.match(host)
+        if bracketed:
+            host = bracketed.group(1)
+            if port is None and bracketed.group(2):
+                port = int(bracketed.group(2))
+        elif port is None:
             embedded = _HOST_EMBEDDED_PORT_RE.match(host)
             if embedded:
                 host, port = embedded.group(1), int(embedded.group(2))

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -846,17 +846,21 @@ class DatasourceConfig(BaseModel):
             "clickhouse": "clickhouse+http",
         }
         driver = driver_map.get(self.type, self.type)
-        auth = ""
-        if self.username:
-            auth = self.username
-            if self.password:
-                auth += f":{self.password}"
-            auth += "@"
-        host_port = self.host or "localhost"
-        if self.port:
-            host_port += f":{self.port}"
-        db = self.database or ""
-        return f"{driver}://{auth}{host_port}/{db}"
+        # Build the URL with SQLAlchemy's structured builder (issue #240)
+        # rather than manual string concatenation, so credentials/host/
+        # database containing reserved URL characters (``@``, ``/``, ``:``,
+        # ...) are percent-encoded instead of being misparsed as URL
+        # delimiters. ``username``/``password`` treat values as raw
+        # credentials; ``host or "localhost"`` preserves the pre-fix
+        # default. Mirrors ``_get_tsql_connection_string``.
+        return _SA_URL.create(
+            driver,
+            username=self.username or None,
+            password=self.password or None,
+            host=self.host or "localhost",
+            port=self.port,
+            database=self.database or "",
+        ).render_as_string(hide_password=False)
 
     def resolve_env_vars(self) -> "DatasourceConfig":
         data = self.model_dump()

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -875,17 +875,25 @@ class DatasourceConfig(BaseModel):
         #   [::1] / [::1]:5432  -> strip brackets, lift embedded port
         #   db.example:5432     -> split single-colon numeric port
         # A bare IPv6 host (``::1``) is left as-is — ``URL.create`` brackets
-        # it correctly. An explicit ``port`` field always wins over an
-        # embedded one.
+        # it correctly. If the host embeds a port AND the ``port`` field is
+        # also set, that is contradictory config — raise rather than guess.
+        embedded_port: str | None = None
         bracketed = _BRACKETED_HOST_RE.match(host)
         if bracketed:
             host = bracketed.group(1)
-            if port is None and bracketed.group(2):
-                port = int(bracketed.group(2))
-        elif port is None:
+            embedded_port = bracketed.group(2)
+        else:
             embedded = _HOST_EMBEDDED_PORT_RE.match(host)
             if embedded:
-                host, port = embedded.group(1), int(embedded.group(2))
+                host, embedded_port = embedded.group(1), embedded.group(2)
+        if embedded_port is not None:
+            if port is not None:
+                raise ValueError(
+                    f"Datasource '{self.name}': port is set both in the host "
+                    f"field ({self.host!r}) and in the 'port' field ({port}); "
+                    f"specify it in only one place."
+                )
+            port = int(embedded_port)
         return _SA_URL.create(
             driver,
             username=self.username or None,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import datetime
 
 import pytest
 from pydantic import ValidationError
+from sqlalchemy.engine import make_url
 
 from slayer.core.enums import DataType, TimeGranularity
 from slayer.core.models import Aggregation, Column, DatasourceConfig, ModelMeasure, SlayerModel
@@ -1128,6 +1129,97 @@ class TestDatasourceConfig:
         assert "%40" in cs, "the '@' in password must appear as %40"
         assert "sqlserver" in cs
         assert "slayer_demo" in cs
+
+    # Issue #240: the generic (non-tsql) connection-string branch must not
+    # corrupt credentials whose password contains reserved URL characters.
+    # The password below exercises every generic-branch delimiter: '@'
+    # (userinfo/host), ':' (userinfo/port), '/' (path), '#' (fragment),
+    # '?' (query), and a space.
+    _RESERVED_PASSWORD = "p@ss/w:rd#q?x y"  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+
+    @pytest.mark.parametrize(
+        ("ds_type", "expected_driver"),
+        [
+            ("postgres", "postgresql"),
+            ("postgresql", "postgresql"),
+            ("mysql", "mysql+pymysql"),
+            ("mariadb", "mysql+pymysql"),
+            ("clickhouse", "clickhouse+http"),
+            # Fallback dialect (issue #240 names "fallback dialects"): an
+            # unmapped type keeps its own name as the driver and must still
+            # encode reserved-char credentials safely.
+            ("customdb", "customdb"),
+        ],
+    )
+    def test_reserved_char_password_round_trips(
+        self, ds_type: str, expected_driver: str
+    ) -> None:
+        ds = DatasourceConfig(
+            name="example",
+            type=ds_type,
+            host="db.example",
+            port=5432,
+            database="analytics",
+            username="user",
+            password=self._RESERVED_PASSWORD,
+        )
+        cs = ds.get_connection_string()
+
+        # The reserved delimiters the issue names ('@', '/', ':') must be
+        # percent-encoded, not left as raw URL delimiters.
+        assert "%40" in cs  # '@'
+        assert "%2F" in cs  # '/'
+        assert "%3A" in cs  # ':'
+        assert self._RESERVED_PASSWORD not in cs
+
+        url = make_url(cs)
+        assert url.drivername == expected_driver
+        assert url.username == "user"
+        assert url.password == self._RESERVED_PASSWORD
+        assert url.host == "db.example"
+        assert url.port == 5432
+        assert url.database == "analytics"
+
+    @pytest.mark.parametrize(
+        "ds_type",
+        ["postgres", "postgresql", "mysql", "mariadb", "clickhouse", "customdb"],
+    )
+    def test_delimiter_safe_password_no_regression(self, ds_type: str) -> None:
+        # A password with no reserved characters must round-trip exactly as
+        # it did before the URL.create switch.
+        ds = DatasourceConfig(
+            name="example",
+            type=ds_type,
+            host="db.example",
+            port=5432,
+            database="analytics",
+            username="user",
+            password="plain_pass",  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.username == "user"
+        assert url.password == "plain_pass"
+        assert url.host == "db.example"
+        assert url.port == 5432
+        assert url.database == "analytics"
+
+    def test_password_without_username_is_dropped(self) -> None:
+        # Parity with the pre-fix generic branch, which only emitted the
+        # password when a username was present. URL.create matches this:
+        # a password without a username is not rendered.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="db.example",
+            port=5432,
+            database="analytics",
+            password="secret",  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.username is None
+        assert url.password is None
+        assert url.host == "db.example"
+        assert url.database == "analytics"
 
 
 class TestTimeGranularity:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1180,6 +1180,30 @@ class TestDatasourceConfig:
         assert url.port == 5432
         assert url.database == "analytics"
 
+    def test_reserved_char_username_round_trips(self) -> None:
+        # Issue #240 names manually interpolated usernames as affected too,
+        # not just passwords. URL.create must percent-encode reserved
+        # characters in the username so it round-trips intact.
+        username = "user@tenant/name:role"
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="db.example",
+            port=5432,
+            database="analytics",
+            username=username,
+            password="plain_pass",  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+        )
+        cs = ds.get_connection_string()
+
+        assert username not in cs  # raw delimiters must not leak through
+        url = make_url(cs)
+        assert url.username == username
+        assert url.password == "plain_pass"
+        assert url.host == "db.example"
+        assert url.port == 5432
+        assert url.database == "analytics"
+
     @pytest.mark.parametrize(
         "ds_type",
         ["postgres", "postgresql", "mysql", "mariadb", "clickhouse", "customdb"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1235,6 +1235,32 @@ class TestDatasourceConfig:
         assert url.host == "::1"
         assert url.port == 5432
 
+    def test_bracketed_ipv6_host_is_unwrapped(self) -> None:
+        # The pre-fix string branch tolerated a bracketed IPv6 host; URL.create
+        # wants the raw host, so the brackets are stripped.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="[::1]",
+            port=5432,
+            database="analytics",
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.host == "::1"
+        assert url.port == 5432
+
+    def test_bracketed_ipv6_host_with_embedded_port_is_split(self) -> None:
+        # Bracketed IPv6 with an embedded port and no separate port field.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="[::1]:5432",
+            database="analytics",
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.host == "::1"
+        assert url.port == 5432
+
     def test_password_without_username_is_dropped(self) -> None:
         # Parity with the pre-fix generic branch, which only emitted the
         # password when a username was present. URL.create matches this:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1203,6 +1203,38 @@ class TestDatasourceConfig:
         assert url.port == 5432
         assert url.database == "analytics"
 
+    def test_host_with_embedded_port_is_split(self) -> None:
+        # Backward-compat: the pre-fix generic branch let a caller stuff
+        # "host:port" into the host field with port unset. URL.create would
+        # otherwise treat the colon as an IPv6-style host and bracket it, so
+        # a single-colon numeric-port host is split back into host + port.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="db.example:5432",
+            database="analytics",
+            username="user",
+            password="plain_pass",  # NOSONAR(S2068) — test-only fixture credential, not a real secret
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.host == "db.example"
+        assert url.port == 5432
+        assert url.database == "analytics"
+
+    def test_ipv6_host_is_not_split(self) -> None:
+        # A bare IPv6 host (multiple colons, no bracket) must NOT be treated
+        # as host:port — URL.create brackets it correctly on its own.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="::1",
+            port=5432,
+            database="analytics",
+        )
+        url = make_url(ds.get_connection_string())
+        assert url.host == "::1"
+        assert url.port == 5432
+
     def test_password_without_username_is_dropped(self) -> None:
         # Parity with the pre-fix generic branch, which only emitted the
         # password when a username was present. URL.create matches this:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1249,6 +1249,31 @@ class TestDatasourceConfig:
         assert url.host == "::1"
         assert url.port == 5432
 
+    def test_conflicting_port_in_host_and_port_field_raises(self) -> None:
+        # A port embedded in the host AND a separate port field is
+        # contradictory config — raise rather than guess which wins.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="db.example:5432",
+            port=9999,
+            database="analytics",
+        )
+        with pytest.raises(ValueError, match="only one place"):
+            ds.get_connection_string()
+
+    def test_conflicting_port_bracketed_ipv6_and_port_field_raises(self) -> None:
+        # Same conflict for a bracketed IPv6 host that embeds a port.
+        ds = DatasourceConfig(
+            name="example",
+            type="postgres",
+            host="[::1]:5432",
+            port=9999,
+            database="analytics",
+        )
+        with pytest.raises(ValueError, match="only one place"):
+            ds.get_connection_string()
+
     def test_bracketed_ipv6_host_with_embedded_port_is_split(self) -> None:
         # Bracketed IPv6 with an embedded port and no separate port field.
         ds = DatasourceConfig(


### PR DESCRIPTION
## Summary

Fixes datasource connection-string generation for passwords containing reserved URL characters (issue #240). This branch is the **union of #241 and #242**: it builds on #242's fix and adds the documentation note from #241.

## What's included

**From #242 (the code fix):** `DatasourceConfig.get_connection_string()` builds the generic (non–SQL Server) connection URL via SQLAlchemy's structured `URL.create()` instead of manual f-string concatenation, so credentials with reserved characters (`@`, `/`, `:`, ...) are percent-encoded in the userinfo section rather than misparsed as URL delimiters. Affects PostgreSQL, MySQL/MariaDB, ClickHouse, and fallback dialects. Also preserves pre-fix host-field backward-compat:

- Bare IPv6 (`::1`) left for `URL.create` to bracket; bracketed IPv6 (`[::1]` / `[::1]:5432`) normalized.
- `host:port` embedded in the host field is split back out.
- Port specified in **both** the host field and the `port` field raises rather than silently guessing.

Full round-trip + no-regression + edge-case test coverage in `tests/test_models.py`.

**From #241 (the docs note):** `docs/configuration/datasources.md` now documents that SLayer URL-encodes reserved characters for component credential fields, and that a directly-supplied `connection_string` must be encoded by the caller.

## Relationship to the other PRs

- **Supersedes #241** — its docs note is included here verbatim; #242 was already a functional superset of #241's code.
- Builds on **#242** — merging this into `main` includes #242's commits, so #242 auto-closes as merged.

## Validation

- `poetry run pytest tests/test_models.py::TestDatasourceConfig -q` — 30 passed
- `poetry run pytest -m "not integration"` — full unit suite passes
- `poetry run ruff check slayer/ tests/` — clean

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved datasource connection string generation to correctly percent-encode reserved characters in credentials.
  * Added robust host parsing for IPv6 and hosts with embedded ports, including proper error handling for conflicting port inputs.
  * Improved URL construction to reliably preserve connection details across parsing/round-trips.

* **Documentation**
  * Clarified how credential encoding works for individual connection fields versus direct connection strings.

* **Tests**
  * Added coverage for reserved-character passwords, IPv6/port edge cases, and connection string round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->