### PR TITLE
Bump version to 0.9.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.9.9"
+version = "0.9.10"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Patch release bump `0.9.9` → `0.9.10`.

Ships the datasource credential URL-encoding fix for issue #240 (merged in #243): passwords/usernames containing reserved URL characters (`@`, `/`, `:`, ...) are now percent-encoded via SQLAlchemy's structured `URL.create()` instead of being misparsed as URL delimiters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.9.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->