### PR TITLE
Mask inline BigQuery credentials in datasource output

### DIFF
--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -160,6 +160,7 @@ Statement-level timeout is enforced via
 | `username` | string | No | Database username |
 | `password` | string | No | Database password |
 | `connection_string` | string | No | Full connection string (alternative to individual fields) |
+| `credentials_json` | string | No | Inline BigQuery service-account JSON; masked in REST and CLI datasource detail output |
 | `schema_name` | string | No | Default schema name |
 
 !!! note

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -160,7 +160,7 @@ Statement-level timeout is enforced via
 | `username` | string | No | Database username |
 | `password` | string | No | Database password |
 | `connection_string` | string | No | Full connection string (alternative to individual fields) |
-| `credentials_json` | string | No | Inline BigQuery service-account JSON; masked in REST and CLI datasource detail output |
+| `credentials_json` | string | No | Credentials JSON (used for BigQuery service accounts) |
 | `schema_name` | string | No | Default schema name |
 
 !!! note

--- a/docs/interfaces/rest-api.md
+++ b/docs/interfaces/rest-api.md
@@ -124,7 +124,7 @@ DELETE /datasources/{name}       # Delete a datasource
 # List datasources
 curl http://localhost:5143/datasources
 
-# Get datasource (password/connection_string shown as ***)
+# Get datasource (credential fields shown as ***)
 curl http://localhost:5143/datasources/my_postgres
 ```
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -96,7 +96,7 @@ DELETE /datasources/{name}       # Delete a datasource
 # List datasources
 curl http://localhost:5143/datasources
 
-# Get datasource (password/connection_string shown as ***)
+# Get datasource (credential fields shown as ***)
 curl http://localhost:5143/datasources/my_postgres
 ```
 

--- a/slayer/api/server.py
+++ b/slayer/api/server.py
@@ -518,7 +518,7 @@ def create_app(  # NOSONAR(S3776) — FastAPI route-handler factory; complexity 
             )
         # Mask credentials
         data = ds.model_dump(exclude_none=True)
-        for secret_field in ("password", "connection_string"):
+        for secret_field in ("password", "connection_string", "credentials_json"):
             if secret_field in data:
                 data[secret_field] = "***"
         return data

--- a/slayer/cli.py
+++ b/slayer/cli.py
@@ -1666,10 +1666,9 @@ def _run_datasources(args):
             print(f"Datasource '{args.name}' not found.")
             sys.exit(1)
         data = ds.model_dump(mode="json", exclude_none=True)
-        if "password" in data:
-            data["password"] = "********"
-        if "connection_string" in data:
-            data["connection_string"] = "********"
+        for secret_field in ("password", "connection_string", "credentials_json"):
+            if secret_field in data:
+                data[secret_field] = "********"
         print(yaml.dump(data, sort_keys=False, default_flow_style=False).rstrip())
 
     elif args.datasources_command == "create":

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -193,13 +193,21 @@ class TestDatasources:
         assert entries[0]["type"] == "postgres"
 
     def test_get_datasource(self, client: TestClient) -> None:
-        ds = {"name": "mydb", "type": "postgres", "host": "localhost", "password": "secret"}
+        ds = {
+            "name": "mydb",
+            "type": "bigquery",
+            "password": "PASSWORD_SENTINEL",
+            "connection_string": "bigquery://project",
+            "credentials_json": '{"private_key": "PRIVATE_KEY_SENTINEL"}',
+        }
         client.post("/datasources", json=ds)
         resp = client.get("/datasources/mydb")
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "mydb"
         assert data["password"] == "***"
+        assert data["connection_string"] == "***"
+        assert data["credentials_json"] == "***"
 
     def test_get_datasource_not_found(self, client: TestClient) -> None:
         resp = client.get("/datasources/nope")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,13 @@
 """Tests for CLI helpers."""
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
+import yaml
 
-from slayer.cli import _parse_cli_variables, _parse_connection_string, _run_query
+from slayer.cli import _parse_cli_variables, _parse_connection_string, _run_datasources, _run_query
+from slayer.core.models import DatasourceConfig
 
 
 class TestParseConnectionString:
@@ -73,6 +76,26 @@ class TestParseCliVariables:
         args = SimpleNamespace(variables=None, variables_json='[1, 2, 3]')
         with pytest.raises(SystemExit, match="must decode to a JSON object"):
             _parse_cli_variables(args)
+
+
+class TestRunDatasources:
+    def test_show_masks_all_credentials(self, monkeypatch, capsys):
+        datasource = DatasourceConfig(
+            name="mydb",
+            type="bigquery",
+            password="PASSWORD_SENTINEL",
+            connection_string="bigquery://project",
+            credentials_json='{"private_key": "PRIVATE_KEY_SENTINEL"}',
+        )
+        storage = SimpleNamespace(get_datasource=AsyncMock(return_value=datasource))
+        monkeypatch.setattr("slayer.cli._resolve_storage", lambda _args: storage)
+
+        _run_datasources(SimpleNamespace(datasources_command="show", name="mydb"))
+
+        data = yaml.safe_load(capsys.readouterr().out)
+        assert data["password"] == "********"
+        assert data["connection_string"] == "********"
+        assert data["credentials_json"] == "********"
 
 
 class TestRunQueryFileLoading:


### PR DESCRIPTION
## Summary

- mask inline BigQuery `credentials_json` in REST datasource detail responses
- mask the same field in `slayer datasources show`
- cover all three credential-bearing fields in REST and CLI regression tests
- document `credentials_json` and the credential-masking output contract

## Root cause

`credentials_json` was added after the existing masking code, which only
handled `password` and `connection_string`. Because `repr=False` does not
exclude a Pydantic field from `model_dump()`, datasource detail output returned
the full service-account JSON.

## Impact

REST and CLI datasource detail output no longer exposes inline BigQuery
service-account credentials. Existing storage and connection behavior is
unchanged.

## Validation

- `.venv/bin/pytest tests/test_api_server.py tests/test_cli.py -q` — 61 passed
- `.venv/bin/pytest tests/ -q -m "not integration"` — 6486 passed; one
  pre-existing YAML case-sensitivity test fails on a case-insensitive macOS
  filesystem
- `.venv/bin/pytest tests/ --ignore=tests/perf --ignore=tests/integration -q -k 'not test_case_sensitive_ids'` — 6485 passed, 4 skipped, 2 deselected, 3 xfailed
- `.venv/bin/ruff check slayer/ tests/` — passed

`ruff format --check` reports existing whole-file formatting drift on the
touched Python files at `upstream/main`; this PR does not introduce the
reported formatter changes. GitHub Actions is awaiting upstream approval for
this first-time fork workflow, rather than reporting a test failure.

Closes #245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive datasource credential fields are now consistently redacted across REST responses and CLI datasource detail output.
  * `credentials_json` is additionally masked alongside existing credential fields.
* **Tests**
  * Added regression coverage to ensure all supported credential fields are redacted for both the API and CLI.
* **Documentation**
  * Updated REST API and datasources documentation to reflect the expanded set of masked credential fields, including the new optional `credentials_json` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->