### PR TITLE
Bump version to 0.9.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motley-slayer"
-version = "0.9.10"
+version = "0.9.11"
 description = "A lightweight, agent-first semantic layer for AI agents"
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
Bumps `motley-slayer` from 0.9.10 to 0.9.11.

Single-line change to `pyproject.toml` — that's the only place the version is declared (`slayer/__init__.py` reads it from package metadata via `importlib.metadata`), matching the scope of the previous bump in #244.

Cuts a release over the DEV-1692 work merged in #247, which fixed duplicate CTE names for multiple `time_shift()` calls in one query and the related silent-wrong-value collisions in hidden transform name allocation.