### PR TITLE
Unknown column type

### DIFF
--- a/slayer/core/enums.py
+++ b/slayer/core/enums.py
@@ -16,8 +16,13 @@ class DataType(StrEnum):
     a translation map. (DEV-1361.)
 
     ``UNKNOWN`` is the explicit *opaque* type: the column's database type was
-    detected but SLayer cannot operate on it (``point``, ``json``, ``xml``,
-    ``bytea``, arrays, ``tsvector``, PostGIS geometries, ...). Such a column is
+    detected but SLayer cannot operate on it — it has no default btree/hash
+    operator class, which is exactly what ``GROUP BY`` / ``DISTINCT`` require
+    (``json``, ``xml``, the geometric / PostGIS types, range types, ...).
+    Comparable types keep working as ``TEXT`` even when unmapped — ``jsonb``,
+    ``uuid``, ``bytea``, arrays and ``tsvector`` are all groupable and are
+    deliberately *not* opaque. ``slayer.engine.ingestion._OPAQUE_SA_TYPE_NAMES``
+    is the source of truth for that classification. Such a column is
     **stored and displayed** — its raw DB type string is kept on
     ``Column.db_type`` — but it is never used in ``GROUP BY``, ``DISTINCT``,
     aggregation, or ``CAST``, because those operations fail at the database

--- a/slayer/core/enums.py
+++ b/slayer/core/enums.py
@@ -13,7 +13,19 @@ class StrEnum(str, Enum):
 class DataType(StrEnum):
     """SLayer data types — values match sqlglot's ``exp.DataType.Type``
     byte-for-byte so SQL generation can ``CAST`` to the declared type without
-    a translation map. (DEV-1361.)"""
+    a translation map. (DEV-1361.)
+
+    ``UNKNOWN`` is the explicit *opaque* type: the column's database type was
+    detected but SLayer cannot operate on it (``point``, ``json``, ``xml``,
+    ``bytea``, arrays, ``tsvector``, PostGIS geometries, ...). Such a column is
+    **stored and displayed** — its raw DB type string is kept on
+    ``Column.db_type`` — but it is never used in ``GROUP BY``, ``DISTINCT``,
+    aggregation, or ``CAST``, because those operations fail at the database
+    (e.g. "could not identify an equality operator for type point"). Use the
+    :attr:`is_opaque` property rather than comparing against the member
+    directly. ``UNKNOWN`` is also a real ``sqlglot`` type name, so the
+    byte-equality invariant above still holds.
+    """
 
     TEXT = "TEXT"
     INT = "INT"
@@ -21,6 +33,12 @@ class DataType(StrEnum):
     BOOLEAN = "BOOLEAN"
     DATE = "DATE"
     TIMESTAMP = "TIMESTAMP"
+    UNKNOWN = "UNKNOWN"
+
+    @property
+    def is_opaque(self) -> bool:
+        """True when SLayer can store/display the column but not operate on it."""
+        return self is DataType.UNKNOWN
 
 
 # DEV-1361: lenient before-validator absorbs legacy lowercase type spellings
@@ -35,6 +53,7 @@ _LEGACY_DATATYPE_ALIASES: dict[str, str | None] = {
     "time": "TIMESTAMP",
     "date": "DATE",
     "boolean": "BOOLEAN",
+    "unknown": "UNKNOWN",
     # Aggregation pseudo-types — dropped in v5 because they were unused.
     "count": None,
     "count_distinct": None,

--- a/slayer/core/models.py
+++ b/slayer/core/models.py
@@ -176,6 +176,15 @@ class Column(BaseModel):
     name: str
     sql: str | None = None
     type: DataType = DataType.TEXT
+    db_type: str | None = Field(
+        default=None,
+        description=(
+            "Raw database type string (e.g. 'point', 'jsonb'), retained when "
+            "the declared DataType loses information. Populated by ingestion "
+            "for UNKNOWN (opaque) columns; None for mapped types, where the "
+            "declared DataType already carries everything we need."
+        ),
+    )
     primary_key: bool = False
     description: str | None = None
     label: str | None = None
@@ -592,6 +601,9 @@ class SlayerModel(BaseModel):
 
         A whitelist entry is accepted iff:
 
+        0. **Opaque rule** — the column's type is not opaque. An opaque
+           (``UNKNOWN``) column cannot be aggregated at all, so declaring a
+           whitelist on one is always a mistake.
         1. It is a known aggregation name (built-in or custom on this model).
         2. **PK rule** — if the column is a primary key, the entry must be in
            ``PRIMARY_KEY_AGGREGATIONS`` (``count`` / ``count_distinct`` only),
@@ -615,6 +627,14 @@ class SlayerModel(BaseModel):
         for c in self.columns:
             if c.allowed_aggregations is None:
                 continue
+            if c.type.is_opaque:
+                db_type_note = f" (db_type={c.db_type!r})" if c.db_type else ""
+                raise ValueError(
+                    f"Column '{c.name}'{db_type_note}: allowed_aggregations "
+                    f"cannot be declared on a column of type {c.type} — "
+                    f"aggregations are not supported for that type. Remove "
+                    f"allowed_aggregations, or give the column an operable type."
+                )
             for agg_name in c.allowed_aggregations:
                 if agg_name not in valid_names:
                     raise ValueError(

--- a/slayer/engine/enrichment.py
+++ b/slayer/engine/enrichment.py
@@ -2143,6 +2143,19 @@ async def _resolve_dimensions(
                     resolve_dimension_via_joins=resolve_dimension_via_joins,
                 )
             )
+        # Grouping by an opaque column emits SQL the database rejects (no
+        # equality operator), so fail here with an actionable message instead
+        # of surfacing a raw driver error. Projecting such a column is fine —
+        # only its use as a GROUP BY / DISTINCT key is refused.
+        if dim_def is not None and dim_def.type.is_opaque:
+            db_type = getattr(dim_def, "db_type", None)
+            described = f" (database type {db_type!r})" if db_type else ""
+            raise ValueError(
+                f"Column '{dim_ref.full_name}'{described} cannot be used as a "
+                f"dimension: its type does not support the grouping this query "
+                f"requires. Define a derived column that extracts a comparable "
+                f"value instead, e.g. sql=\"payload->>'status'\" with type TEXT."
+            )
         expanded_sql = await _maybe_expand(
             sql=dim_def.sql if dim_def else None,
             terminal_model=terminal_model,

--- a/slayer/engine/ingestion.py
+++ b/slayer/engine/ingestion.py
@@ -48,6 +48,39 @@ logger = logging.getLogger(__name__)
 # _sa_type_to_data_type). Keyed by upper-cased class name.
 _logged_unmapped_sa_types: set[str] = set()
 
+# Database types with no usable equality operator — grouping, DISTINCT or
+# aggregating them fails at the database ("could not identify an equality
+# operator for type point"). These map to ``DataType.UNKNOWN``: stored and
+# displayed, never operated on. To query inside one, define a derived Column
+# whose ``sql`` is a dialect-specific expression — e.g.
+# ``Column(name="status", sql="payload->>'status'", type=TEXT)`` — which is
+# emitted into the generated SQL and groups/filters like any other column.
+#
+# Deliberately a small allow-list of known-bad types rather than "everything
+# unrecognized": comparable-but-unmapped types (uuid, jsonb, bytea, arrays,
+# inet, citext, ...) are common and must keep working as TEXT. Marking one of
+# those opaque would tell an agent that a perfectly groupable column is
+# unusable — a worse failure than the query-time error opacity exists to
+# prevent, which the Data Profile fallback already degrades gracefully.
+# Membership verified against the Postgres catalog: a type is groupable iff it
+# has a *default* btree/hash operator class (that is exactly what GROUP BY and
+# DISTINCT require) —
+#   SELECT EXISTS (SELECT 1 FROM pg_opclass oc JOIN pg_am am ON am.oid = oc.opcmethod
+#                  WHERE oc.opcintype = t.oid AND am.amname IN ('btree','hash')
+#                    AND oc.opcdefault)
+# Note ``tsvector`` / ``tsquery`` ARE groupable and must not be listed here,
+# and ``jsonb`` is groupable while ``json`` is not.
+_OPAQUE_SA_TYPE_NAMES = frozenset({
+    "JSON",  # ``jsonb`` is groupable and deliberately absent
+    "XML",
+    "TXID_SNAPSHOT",
+    # Geometric / spatial — none have a default btree/hash opclass
+    "POINT", "LINE", "LSEG", "BOX", "PATH", "POLYGON", "CIRCLE",
+    "GEOMETRY", "GEOGRAPHY", "RASTER",
+    # Range types
+    "INT4RANGE", "INT8RANGE", "NUMRANGE", "TSRANGE", "TSTZRANGE", "DATERANGE",
+})
+
 # Map SQLAlchemy types to SLayer DataTypes.
 # DEV-1361: integer family → INT, floating family → DOUBLE, NUMERIC/DECIMAL
 # resolved via _sa_type_is_float (scale>0 → DOUBLE, scale=0 → INT).
@@ -187,6 +220,10 @@ def _sa_type_to_data_type(sa_type: sa.types.TypeEngine) -> DataType:
         return DataType.TEXT
     type_name = type(sa_type).__name__.upper()
     type_str = str(sa_type).split("(")[0].upper().strip()
+    # Types with no equality operator are opaque: querying them fails at the
+    # database, so declare that explicitly instead of pretending they're TEXT.
+    if type_name in _OPAQUE_SA_TYPE_NAMES or type_str in _OPAQUE_SA_TYPE_NAMES:
+        return DataType.UNKNOWN
     # DEV-1361: NUMERIC/DECIMAL with scale=0 are integer-shaped → INT.
     # Anything float-like (scale>0 or unknown) → DOUBLE.
     if type_name in _NUMERIC_DECIMAL_TYPES or type_str in _NUMERIC_DECIMAL_TYPES:
@@ -199,11 +236,32 @@ def _sa_type_to_data_type(sa_type: sa.types.TypeEngine) -> DataType:
         _logged_unmapped_sa_types.add(type_name)
         logger.warning(
             "Unrecognized SQLAlchemy type %r (str=%r); falling back to "
-            "DataType.TEXT. Consider adding to _SA_TYPE_MAP.",
+            "DataType.TEXT. Most unmapped types (uuid, jsonb, bytea, arrays) "
+            "are comparable and work as TEXT; add genuinely non-comparable "
+            "ones to _OPAQUE_SA_TYPE_NAMES and the rest to _SA_TYPE_MAP.",
             type_name,
             str(sa_type),
         )
     return DataType.TEXT
+
+
+def _raw_db_type_str(sa_type: sa.types.TypeEngine) -> str | None:
+    """Best-effort raw database type string for ``Column.db_type``.
+
+    ``str(sa_type)`` renders the dialect-level spelling (``"point"``,
+    ``"jsonb"``, ``"geometry(Point,4326)"``). Some third-party types raise
+    when compiled without a dialect, so fall back to the SA class name and
+    finally to ``None`` — ``db_type`` is metadata, never worth aborting an
+    ingest over.
+    """
+    try:
+        text = str(sa_type).strip()
+    except Exception:
+        text = ""
+    if text:
+        return text
+    name = type(sa_type).__name__
+    return name or None
 
 
 def _sa_type_is_float(sa_type: sa.types.TypeEngine) -> bool:
@@ -447,7 +505,12 @@ def _introspect_query_columns_via_inspector(
 ) -> list[tuple]:
     """Introspect columns from a rollup query or plain table.
 
-    Returns list of (column_name, DataType, is_primary_key, is_float) tuples.
+    Returns list of ``(column_name, DataType, is_primary_key, is_float,
+    db_type)`` tuples. ``db_type`` is the raw database type string and is only
+    populated when ``DataType`` came out opaque (``UNKNOWN``) — for mapped
+    types the declared ``DataType`` already carries everything, so leaving it
+    ``None`` keeps stored models and golden tests clean.
+
     For rollup queries, uses per-table inspector data since LIMIT 0
     type inference can be unreliable across databases.
     """
@@ -461,14 +524,17 @@ def _introspect_query_columns_via_inspector(
     for col in columns:
         col_name = col["name"]
         col_type = col["type"]
+        db_type: str | None = None
         if isinstance(col_type, DataType):
             data_type = col_type
             is_float = col.get("is_float", False)
         else:
             data_type = _sa_type_to_data_type(col_type)
             is_float = _sa_type_is_float(col_type)
+            if data_type.is_opaque:
+                db_type = _raw_db_type_str(col_type)
         is_pk = col_name in pk_columns
-        results.append((col_name, data_type, is_pk, is_float))
+        results.append((col_name, data_type, is_pk, is_float, db_type))
 
     # Build list of (ref_table, dotted_path) from joins — supports diamond joins
     # where the same table appears via multiple paths
@@ -498,14 +564,17 @@ def _introspect_query_columns_via_inspector(
                 continue
             alias = f"{path}.{col['name']}"
             col_type = col["type"]
+            ref_db_type: str | None = None
             if isinstance(col_type, DataType):
                 data_type = col_type
                 is_float = col.get("is_float", False)
             else:
                 data_type = _sa_type_to_data_type(col_type)
                 is_float = _sa_type_is_float(col_type)
+                if data_type.is_opaque:
+                    ref_db_type = _raw_db_type_str(col_type)
             is_pk = col["name"] in ref_pk_cols
-            results.append((alias, data_type, is_pk, is_float))
+            results.append((alias, data_type, is_pk, is_float, ref_db_type))
 
     return results
 
@@ -522,18 +591,20 @@ def _columns_to_model(
     sql_table: str | None = None,
     joins: list[ModelJoin] | None = None,
 ) -> SlayerModel:
-    """Generate a SlayerModel from introspected (column_name, DataType, is_pk, is_float) tuples.
+    """Generate a SlayerModel from introspected ``(column_name, DataType,
+    is_pk, is_float, db_type)`` tuples.
 
     In v2 every Column is potentially both a dimension and a measure — what it's
     used as is decided per query. This function emits one Column per non-joined
-    column, with format inferred from the column's data type.
+    column, with format inferred from the column's data type. ``db_type`` is
+    carried through verbatim (set only for opaque ``UNKNOWN`` columns).
     """
     cols: list[Column] = []
 
     _INT_FORMAT = NumberFormat(type=NumberFormatType.INTEGER)
     _FLOAT_FORMAT = NumberFormat(type=NumberFormatType.FLOAT)
 
-    for col_name, data_type, is_pk, is_float in columns:
+    for col_name, data_type, is_pk, is_float, db_type in columns:
         # Skip joined columns — they live on the target model and are
         # resolved via the join graph at query time.
         if "." in col_name:
@@ -555,6 +626,7 @@ def _columns_to_model(
                 name=column_name,
                 sql=col_name,
                 type=data_type,
+                db_type=db_type,
                 primary_key=is_pk,
                 format=fmt,
             )
@@ -577,7 +649,7 @@ def _sqlite_probe_integer_columns(
 ) -> list[tuple]:
     """DEV-1538: per-column SQLite affinity probe.
 
-    Walks the tuples ``(col_name, DataType, is_pk, is_float)`` produced by
+    Walks the tuples ``(col_name, DataType, is_pk, is_float, db_type)`` produced by
     :func:`_introspect_query_columns_via_inspector` and, for every base
     column (alias without ``.``) that the SA inspector reported as
     :class:`DataType.INT`, runs
@@ -603,9 +675,9 @@ def _sqlite_probe_integer_columns(
     schema, table = _parse_qualified_sql_table(sql_table)
     out: list[tuple] = []
     with sa_engine.connect() as conn:
-        for col_name, data_type, is_pk, is_float in columns:
+        for col_name, data_type, is_pk, is_float, db_type in columns:
             if data_type is not DataType.INT or "." in col_name:
-                out.append((col_name, data_type, is_pk, is_float))
+                out.append((col_name, data_type, is_pk, is_float, db_type))
                 continue
             try:
                 verdict = probe_sqlite_integer_column(
@@ -627,10 +699,10 @@ def _sqlite_probe_integer_columns(
                 )
                 verdict = None
             if verdict is None or verdict is DataType.INT:
-                out.append((col_name, data_type, is_pk, is_float))
+                out.append((col_name, data_type, is_pk, is_float, db_type))
                 continue
             new_is_float = verdict is DataType.DOUBLE
-            out.append((col_name, verdict, is_pk, new_is_float))
+            out.append((col_name, verdict, is_pk, new_is_float, db_type))
     return out
 
 

--- a/slayer/engine/profiling.py
+++ b/slayer/engine/profiling.py
@@ -340,6 +340,11 @@ def _is_sample_cached(column: Column) -> bool:
     """
     if column.hidden or column.primary_key:
         return True
+    if column.type.is_opaque:
+        # Opaque columns are never profiled (DISTINCT / min / max fail on the
+        # underlying DB type), so report them as "cached" — same convention as
+        # hidden / PK columns — and keep callers from re-querying every read.
+        return True
     if column.type in _CATEGORICAL_TYPES:
         return column.sampled_values is not None
     return column.sampled is not None
@@ -430,15 +435,20 @@ async def profile_column(
 ) -> ColumnSample | None:
     """Return the :class:`ColumnSample` for ``column`` on ``model``.
 
-    Returns ``None`` for primary-key / hidden columns and when the
-    profile query fails or yields no data. Caller decides whether to
-    persist the ``None`` (clearing any stale value) or skip it.
+    Returns ``None`` for primary-key / hidden / opaque (``UNKNOWN``) columns
+    and when the profile query fails or yields no data. Caller decides whether
+    to persist the ``None`` (clearing any stale value) or skip it.
 
     DEV-1480: signature widened from ``Optional[str]`` to
     ``Optional[ColumnSample]`` so the structured ``sampled_values`` and
     ``distinct_count`` are returned alongside the legacy text.
     """
     if column.hidden or column.primary_key:
+        return None
+    if column.type.is_opaque:
+        # No equality operator / no orderable comparison on the underlying DB
+        # type — both the categorical top-values scan and the batched min/max
+        # query would raise. Skip sample-value profiling entirely.
         return None
     if column.type in _CATEGORICAL_TYPES:
         return await _profile_categorical_with_total(
@@ -629,7 +639,7 @@ async def ensure_column_sample_fresh(
     Returns the **input column unchanged** when:
 
     - ``_is_sample_cached(column)`` is True (cache hit; includes hidden /
-      primary-key columns by convention),
+      primary-key / opaque ``UNKNOWN`` columns by convention),
     - :func:`profile_column` returns ``None`` (e.g. transient query failure
       or no rows),
     - :func:`profile_column` raises (logged + swallowed),

--- a/slayer/engine/schema_drift.py
+++ b/slayer/engine/schema_drift.py
@@ -199,6 +199,22 @@ def data_type_bucket(dt: DataType) -> str:
     return str(dt)
 
 
+def _type_buckets_conflict(*, persisted: DataType, live: DataType) -> bool:
+    """True when persisted vs live types are genuinely incompatible.
+
+    An opaque (``UNKNOWN``) type on either side is treated as compatible with
+    anything. Unmapped DB types (``point``, ``jsonb``, PostGIS, ...) used to
+    coarse to TEXT at introspection time and now read as UNKNOWN, so a strict
+    bucket comparison would report every such pre-existing column as a
+    spurious drift-delete. UNKNOWN carries no type claim to contradict — it
+    only says "we could not classify this" — so it never triggers drift in
+    either direction.
+    """
+    if persisted.is_opaque or live.is_opaque:
+        return False
+    return data_type_bucket(persisted) != data_type_bucket(live)
+
+
 def _is_bare_identifier(s: str | None) -> bool:
     """``s`` is a bare SQL identifier (alphanumeric + underscore, no leading digit)."""
     if not s:
@@ -246,7 +262,7 @@ def _diff_sql_table_columns(
             )
             continue
         live_dt = live_table.columns[bare_name]
-        if data_type_bucket(col.type) != data_type_bucket(live_dt):
+        if _type_buckets_conflict(persisted=col.type, live=live_dt):
             dropped.append(col.name)
             reasons.append(
                 DeleteReason(
@@ -427,7 +443,7 @@ def diff_sql_model(
                     )
                 )
             continue
-        if data_type_bucket(col.type) != data_type_bucket(live_dt):
+        if _type_buckets_conflict(persisted=col.type, live=live_dt):
             dropped_cols.append(col.name)
             reasons.append(
                 DeleteReason(

--- a/slayer/engine/schema_drift.py
+++ b/slayer/engine/schema_drift.py
@@ -202,15 +202,27 @@ def data_type_bucket(dt: DataType) -> str:
 def _type_buckets_conflict(*, persisted: DataType, live: DataType) -> bool:
     """True when persisted vs live types are genuinely incompatible.
 
-    An opaque (``UNKNOWN``) type on either side is treated as compatible with
-    anything. Unmapped DB types (``point``, ``jsonb``, PostGIS, ...) used to
-    coarse to TEXT at introspection time and now read as UNKNOWN, so a strict
-    bucket comparison would report every such pre-existing column as a
-    spurious drift-delete. UNKNOWN carries no type claim to contradict — it
-    only says "we could not classify this" — so it never triggers drift in
-    either direction.
+    Opacity is deliberately **one-way**:
+
+    - *live* opaque + operable persisted type → **conflict**. The physical
+      column has no equality operator, so the persisted model is promising a
+      ``GROUP BY`` / ``DISTINCT`` / aggregation the database will refuse. That
+      is a real runtime hazard and must surface rather than be hidden.
+    - *persisted* opaque + known live type → no conflict. ``UNKNOWN`` makes no
+      type claim to contradict; it only says "we could not classify this", and
+      the live type is strictly more information.
+    - both opaque → no conflict (they agree).
+    - both known → ordinary bucket comparison.
+
+    Note this means models ingested before opaque classification existed (an
+    exotic column coarsed to TEXT back then, read as UNKNOWN now) will be
+    reported. That is intentional: those columns really are unusable as
+    declared. The remedy is to re-ingest / retype the column to ``UNKNOWN``,
+    after which the conflict disappears.
     """
-    if persisted.is_opaque or live.is_opaque:
+    if live.is_opaque:
+        return not persisted.is_opaque
+    if persisted.is_opaque:
         return False
     return data_type_bucket(persisted) != data_type_bucket(live)
 

--- a/slayer/facade/catalog.py
+++ b/slayer/facade/catalog.py
@@ -278,11 +278,12 @@ def build_catalog_grouped_by_schema(
 
 def _column_types_supported(*, model: SlayerModel) -> bool:
     """Reject the whole model if any non-hidden column has a Column.type
-    outside the six base types (§12 gotcha #7). DataType is a StrEnum so the
-    pydantic field is already constrained to the six values — but a future
-    extension that adds a new variant would silently surface here as
+    outside ``SUPPORTED_DATATYPES`` (§12 gotcha #7). DataType is a StrEnum so
+    the pydantic field is already constrained to the known values — but a
+    future extension that adds a new variant would silently surface here as
     unmappable, which we'd rather catch with a clear warning than emit a
-    half-typed catalog."""
+    half-typed catalog. Opaque ``UNKNOWN`` columns ARE supported: they map to
+    VARCHAR and carry no aggregations (see DEFAULT_AGGREGATIONS_BY_TYPE)."""
     supported = set(SUPPORTED_DATATYPES)
     for col in model.columns:
         if col.hidden:

--- a/slayer/facade/datatypes.py
+++ b/slayer/facade/datatypes.py
@@ -18,6 +18,9 @@ _DATATYPE_TO_JDBC: dict[DataType, str] = {
     DataType.BOOLEAN: "BOOLEAN",
     DataType.DATE: "DATE",
     DataType.TIMESTAMP: "TIMESTAMP",
+    # Opaque columns travel as text over the wire — the value is whatever the
+    # driver stringified, and no client-side type claim would be honest.
+    DataType.UNKNOWN: "VARCHAR",
 }
 
 

--- a/slayer/flight/types.py
+++ b/slayer/flight/types.py
@@ -4,14 +4,17 @@ The pyarrow-bound half of the facade type system. The pyarrow-free half
 (``SUPPORTED_DATATYPES`` + ``datatype_to_jdbc``) lives in
 ``slayer.facade.datatypes`` and is re-exported here for backward compat.
 
-* SLayer's ``DataType`` (``slayer.core.enums``) — six canonical values.
+* SLayer's ``DataType`` (``slayer.core.enums``) — six operable values plus
+  the opaque ``UNKNOWN`` marker.
 * Apache Arrow ``DataType`` — the wire encoding the Flight SQL gRPC
   server emits to clients.
 
-The forward direction (``DataType → Arrow``) is total over the six
-supported values. The reverse (``Arrow → DataType``) collapses Arrow's
-wider type space onto the six SLayer types; ``arrow_to_datatype``
-returns ``None`` for genuinely unmappable Arrow types.
+The forward direction (``DataType → Arrow``) is total over every value.
+The reverse (``Arrow → DataType``) collapses Arrow's wider type space onto
+the six operable SLayer types; ``arrow_to_datatype`` returns ``None`` for
+genuinely unmappable Arrow types. The round trip is lossy for ``UNKNOWN``
+(it goes out as ``utf8`` and comes back as ``TEXT``) — Arrow has no
+"unclassified" type to preserve it.
 """
 
 from __future__ import annotations
@@ -30,6 +33,10 @@ _DATATYPE_TO_ARROW: dict[DataType, pa.DataType] = {
     DataType.BOOLEAN: pa.bool_(),
     DataType.DATE: pa.date32(),
     DataType.TIMESTAMP: pa.timestamp("us"),
+    # Opaque columns travel as Arrow strings — see DataType.is_opaque. The
+    # forward map is intentionally lossy here: UNKNOWN -> utf8 -> TEXT does
+    # not round-trip back to UNKNOWN.
+    DataType.UNKNOWN: pa.utf8(),
 }
 
 

--- a/slayer/inspect/model_render.py
+++ b/slayer/inspect/model_render.py
@@ -996,6 +996,10 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
     sample_sql: str | None = None
     sample_data: dict[str, Any] | None = None
     sample_error: str | None = None
+    # Set when the profile fell back to a row count so JSON callers can tell a
+    # reduced profile from a complete one (the markdown note is not machine
+    # readable).
+    sample_reduced_reason: str | None = None
     if engine is not None and "samples" in included_set:
         query_args = _build_sample_query_args(
             model=model, num_rows=num_rows, measure_types=measure_types,
@@ -1019,10 +1023,11 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
                 sample_result = await engine.execute(
                     query=sample_query, data_source=model.data_source or None
                 )
-                note = (
-                    "\n\n_Reduced to a row count: at least one column's type does not "
-                    "support the grouping/DISTINCT this profile uses._"
+                sample_reduced_reason = (
+                    "at least one column's type does not support the "
+                    "grouping/DISTINCT this profile uses"
                 )
+                note = f"\n\n_Reduced to a row count: {sample_reduced_reason}._"
             sample_sql = sample_result.sql
             cols, data = _strip_model_prefix(
                 columns=sample_result.columns,
@@ -1219,6 +1224,8 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
         if "samples" in included_set:
             payload["sample_data"] = sample_data
             payload["sample_data_error"] = sample_error
+            payload["sample_data_reduced"] = sample_reduced_reason is not None
+            payload["sample_data_reduced_reason"] = sample_reduced_reason
             if show_sql and sample_sql:
                 payload["sample_sql"] = sample_sql
 

--- a/slayer/inspect/model_render.py
+++ b/slayer/inspect/model_render.py
@@ -225,6 +225,19 @@ def _markdown_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     return "\n".join([header, sep] + body)
 
 
+def _render_column_type(column: Column) -> str:
+    """Render the ``type`` cell of the Columns table.
+
+    Opaque (``UNKNOWN``) columns are still shown — SLayer stores and displays
+    them — but annotated with their raw database type and a marker saying they
+    can't be queried, so an agent doesn't try to group or aggregate on them.
+    """
+    if not column.type.is_opaque:
+        return str(column.type)
+    detail = column.db_type or "unrecognized DB type"
+    return f"{column.type} ({detail}; not queryable)"
+
+
 def _choose_sample_dims(
     model: SlayerModel,
 ) -> tuple[list[dict[str, str]], set]:
@@ -236,7 +249,8 @@ def _choose_sample_dims(
     for c in model.columns:
         if c.hidden or c.primary_key:
             continue
-        # DEV-1361: TEXT/BOOLEAN are the categorical-shaped types.
+        # DEV-1361: TEXT/BOOLEAN are the categorical-shaped types. This filter
+        # also excludes opaque (UNKNOWN) columns, which cannot be GROUP BY'd.
         if c.type not in (DataType.TEXT, DataType.BOOLEAN):
             continue
         dims.append({"name": c.name})
@@ -260,7 +274,12 @@ def _choose_sample_agg(
     - Otherwise (``avg`` permitted): prefer ``avg`` for numeric columns, else
       ``count_distinct`` (type inferred from ``measure_types`` — the lowercase
       ``engine.get_column_types`` contract — or the column's own ``type``).
+    - Opaque (``UNKNOWN``) columns are always skipped: the DB has no equality
+      operator for their underlying type, so ``count_distinct``/``min``/``max``
+      would fail and take the whole Data Profile query down with them.
     """
+    if column.type.is_opaque:
+        return None
     allowed = column.allowed_aggregations
     if allowed is not None and "avg" not in allowed:
         if not allowed:
@@ -859,7 +878,7 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
                 sampled_cell = measure_profile.get(c.name)
             col_rows.append({
                 "name": c.name,
-                "type": str(c.type),
+                "type": _render_column_type(c),
                 "primary_key": "yes" if c.primary_key else "",
                 "sql": c.sql if c.sql else c.name,
                 "allowed_aggregations": aggs,
@@ -981,11 +1000,29 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
         query_args = _build_sample_query_args(
             model=model, num_rows=num_rows, measure_types=measure_types,
         )
+        # A single column whose underlying DB type has no equality operator
+        # (point, json, xml — all coarsed to TEXT here, so undetectable up
+        # front) makes the grouped/DISTINCT profile fail. Retry once with a
+        # row-count-only profile so one exotic column can't sink the section.
+        note = ""
         try:
-            sample_query = SlayerQuery.model_validate(query_args)
-            sample_result = await engine.execute(
-                query=sample_query, data_source=model.data_source or None
-            )
+            try:
+                sample_query = SlayerQuery.model_validate(query_args)
+                sample_result = await engine.execute(
+                    query=sample_query, data_source=model.data_source or None
+                )
+            except Exception:
+                minimal_args = dict(query_args)
+                minimal_args["measures"] = [{"formula": "*:count"}]
+                minimal_args["dimensions"] = []
+                sample_query = SlayerQuery.model_validate(minimal_args)
+                sample_result = await engine.execute(
+                    query=sample_query, data_source=model.data_source or None
+                )
+                note = (
+                    "\n\n_Reduced to a row count: at least one column's type does not "
+                    "support the grouping/DISTINCT this profile uses._"
+                )
             sample_sql = sample_result.sql
             cols, data = _strip_model_prefix(
                 columns=sample_result.columns,
@@ -995,7 +1032,7 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
             sample_data = {"columns": cols, "rows": data}
             sample_result.columns = cols
             sample_result.data = data
-            sample_section = f"## Data Profile\n\n{sample_result.to_markdown()}"
+            sample_section = f"## Data Profile\n\n{sample_result.to_markdown()}{note}"
             if show_sql and sample_sql:
                 sample_section = (
                     f"## Data Profile SQL\n\n```sql\n{sample_sql}\n```\n\n"
@@ -1103,6 +1140,12 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
                 col_payloads.append({
                     "name": c.name,
                     "type": str(c.type),
+                    # Opaque columns only: the raw DB type plus an explicit
+                    # not-queryable marker (see _render_column_type).
+                    **(
+                        {"db_type": c.db_type, "queryable": False}
+                        if c.type.is_opaque else {}
+                    ),
                     "primary_key": c.primary_key,
                     **({"sql": c.sql} if show_sql else {}),
                     "allowed_aggregations": c.allowed_aggregations,

--- a/slayer/inspect/model_render.py
+++ b/slayer/inspect/model_render.py
@@ -37,6 +37,39 @@ logger = logging.getLogger(__name__)
 # no time-column context needed.
 _SAFE_SAMPLE_AGGS = frozenset({"avg", "sum", "min", "max", "count", "count_distinct", "median"})
 
+# The one failure the Data Profile's count-only retry is designed to recover
+# from: the database cannot group / deduplicate one of the column types. Kept
+# deliberately narrow — every other failure (permission, connection, syntax,
+# validation) must keep its own cause rather than being relabeled as a type
+# problem, which would both mislead the caller and hide the real error.
+_UNSUPPORTED_GROUPING_SIGNATURES = (
+    "could not identify an equality operator",
+    "could not identify a comparison function",
+)
+# Postgres SQLSTATE 42883 (undefined_function) is what the missing equality /
+# comparison operator behind GROUP BY / DISTINCT actually raises.
+_UNSUPPORTED_GROUPING_SQLSTATES = frozenset({"42883"})
+
+
+def _is_unsupported_grouping_error(exc: BaseException) -> bool:
+    """True when ``exc`` says the database can't group/deduplicate a column type.
+
+    Checks the driver SQLSTATE first (precise) and falls back to the message
+    text. Anything not matched is treated as an unrelated failure, so it
+    propagates with its own cause instead of being retried and mislabeled.
+    """
+    for err in (exc, getattr(exc, "orig", None)):
+        if err is None:
+            continue
+        code = getattr(err, "sqlstate", None) or getattr(err, "pgcode", None)
+        if code in _UNSUPPORTED_GROUPING_SQLSTATES:
+            return True
+    text = str(exc).lower()
+    orig = getattr(exc, "orig", None)
+    if orig is not None:
+        text = f"{text} {str(orig).lower()}"
+    return any(sig in text for sig in _UNSUPPORTED_GROUPING_SIGNATURES)
+
 # Section-level budgeting for inspect_model output.
 # columns/measures/aggregations/joins fall back to a names-only CSV when the
 # caller drops the section from `sections`; samples/learnings are fully
@@ -1004,10 +1037,14 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
         query_args = _build_sample_query_args(
             model=model, num_rows=num_rows, measure_types=measure_types,
         )
-        # A single column whose underlying DB type has no equality operator
-        # (point, json, xml — all coarsed to TEXT here, so undetectable up
-        # front) makes the grouped/DISTINCT profile fail. Retry once with a
-        # row-count-only profile so one exotic column can't sink the section.
+        # A column whose underlying DB type has no equality operator (point,
+        # json, xml — all coarsed to TEXT before opaque classification existed,
+        # so still undetectable on older models) makes the grouped/DISTINCT
+        # profile fail. Retry once with a row-count-only profile so one exotic
+        # column can't sink the section — but ONLY for that specific failure.
+        # Any other error (permission, connection, validation, syntax) must
+        # surface with its own cause instead of being relabeled as a type
+        # problem; the outer handler still degrades the section gracefully.
         note = ""
         try:
             try:
@@ -1015,14 +1052,21 @@ async def render_model_inspection(  # NOSONAR(S3776) — faithful extraction of 
                 sample_result = await engine.execute(
                     query=sample_query, data_source=model.data_source or None
                 )
-            except Exception:
+            except Exception as exc:
+                if not _is_unsupported_grouping_error(exc):
+                    raise
                 minimal_args = dict(query_args)
                 minimal_args["measures"] = [{"formula": "*:count"}]
                 minimal_args["dimensions"] = []
                 sample_query = SlayerQuery.model_validate(minimal_args)
-                sample_result = await engine.execute(
-                    query=sample_query, data_source=model.data_source or None
-                )
+                try:
+                    sample_result = await engine.execute(
+                        query=sample_query, data_source=model.data_source or None
+                    )
+                except Exception:
+                    # The reduced profile failed too — report the original
+                    # cause, not this second failure.
+                    raise exc
                 sample_reduced_reason = (
                     "at least one column's type does not support the "
                     "grouping/DISTINCT this profile uses"

--- a/slayer/pg_facade/types.py
+++ b/slayer/pg_facade/types.py
@@ -3,7 +3,8 @@
 Three concerns:
 
 1. ``DATATYPE_TO_OID`` / ``datatype_to_oid`` — SLayer ``DataType`` → Postgres
-   type OID. Only the six built-in OIDs are ever emitted (unknown → text), so
+   type OID. Only the six built-in OIDs are ever emitted (opaque / unmapped
+   → text), so
    asyncpg never has to run its ``pg_type`` introspection path.
 2. ``value_to_text`` / ``value_to_binary`` — engine value → wire bytes for a
    ``DataRow``, in the per-column format the client requested in ``Bind``.
@@ -42,6 +43,8 @@ DATATYPE_TO_OID: dict[DataType, int] = {
     DataType.BOOLEAN: OID_BOOL,
     DataType.DATE: OID_DATE,
     DataType.TIMESTAMP: OID_TIMESTAMP,
+    # Opaque columns go out as text — see slayer.core.enums.DataType.is_opaque.
+    DataType.UNKNOWN: OID_TEXT,
 }
 
 # Postgres binary date/timestamp epoch.

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -35,7 +35,9 @@ def _wrap_cast_for_type(expr: exp.Expression, dt: DataType | None) -> exp.Expres
     Skipped when ``dt`` is ``None`` (no declared type) or ``DataType.TEXT``
     (cosmetic — SQL TEXT/VARCHAR roundtripping is already a no-op for our
     purposes and ``CAST(... AS TEXT)`` does not unwrap SQLite's
-    JSON-quoted-string return values anyway). Skipped when ``expr`` is a
+    JSON-quoted-string return values anyway). Also skipped when ``dt`` is
+    opaque (``DataType.UNKNOWN``) — there is no such SQL type, so
+    ``CAST(x AS UNKNOWN)`` is invalid in every dialect. Skipped when ``expr`` is a
     plain ``exp.Column`` (possibly qualified ``model.col``) — those are
     bare column references whose runtime type already matches the declared
     type by definition; wrapping them in CAST is dead noise and on SQLite
@@ -43,7 +45,7 @@ def _wrap_cast_for_type(expr: exp.Expression, dt: DataType | None) -> exp.Expres
     to a year). Idempotent: if ``expr`` is already a CAST to the same
     target, return it unchanged.
     """
-    if dt is None or dt == DataType.TEXT:
+    if dt is None or dt == DataType.TEXT or dt.is_opaque:
         return expr
     if isinstance(expr, exp.Column):
         return expr

--- a/tests/flight/test_types.py
+++ b/tests/flight/test_types.py
@@ -81,10 +81,22 @@ def test_arrow_to_datatype_returns_none_for_unmappable(arrow_type: pa.DataType) 
 
 
 def test_forward_then_reverse_round_trip() -> None:
-    """For every SLayer DataType, forward-map to Arrow then reverse-map back."""
+    """For every operable SLayer DataType, forward-map to Arrow then back.
+
+    ``UNKNOWN`` is excluded by design: opaque columns travel as Arrow strings,
+    so the reverse map lands on TEXT. Arrow has no "we could not classify
+    this" type to round-trip through.
+    """
     for dt in DataType:
+        if dt.is_opaque:
+            continue
         round_tripped = arrow_to_datatype(datatype_to_arrow(dt))
         assert round_tripped == dt, f"{dt} did not round-trip cleanly"
+
+
+def test_opaque_datatype_maps_to_utf8() -> None:
+    assert datatype_to_arrow(DataType.UNKNOWN) == pa.utf8()
+    assert datatype_to_jdbc(DataType.UNKNOWN) == "VARCHAR"
 
 
 def test_pa_table_from_pylist_with_explicit_schema_preserves_null_cells() -> None:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -10,11 +10,12 @@ from slayer.core.enums import (
 
 
 class TestDataTypeShape:
-    """The new enum has exactly TEXT, INT, DOUBLE, BOOLEAN, DATE, TIMESTAMP."""
+    """The enum has exactly TEXT, INT, DOUBLE, BOOLEAN, DATE, TIMESTAMP —
+    plus the explicit opaque marker UNKNOWN."""
 
     def test_exact_member_set(self) -> None:
         assert {m.name for m in DataType} == {
-            "TEXT", "INT", "DOUBLE", "BOOLEAN", "DATE", "TIMESTAMP",
+            "TEXT", "INT", "DOUBLE", "BOOLEAN", "DATE", "TIMESTAMP", "UNKNOWN",
         }
 
     def test_no_legacy_string_member(self) -> None:
@@ -46,11 +47,32 @@ class TestDataTypeValuesMatchSqlglot:
 
     @pytest.mark.parametrize(
         "name",
-        ["TEXT", "INT", "DOUBLE", "BOOLEAN", "DATE", "TIMESTAMP"],
+        ["TEXT", "INT", "DOUBLE", "BOOLEAN", "DATE", "TIMESTAMP", "UNKNOWN"],
     )
     def test_value_equals_sqlglot_name(self, name: str) -> None:
         assert getattr(DataType, name).value == name
         assert exp.DataType.Type(getattr(DataType, name).value).name == name
+
+
+class TestDataTypeIsOpaque:
+    """``is_opaque`` is the single semantic hook for "stored + displayed, but
+    not operable on" — consumers must not compare against UNKNOWN directly."""
+
+    def test_unknown_is_opaque(self) -> None:
+        assert DataType.UNKNOWN.is_opaque is True
+
+    @pytest.mark.parametrize(
+        "dt",
+        [m for m in DataType if m is not DataType.UNKNOWN],
+        ids=lambda m: m.name,
+    )
+    def test_every_other_member_is_not_opaque(self, dt: DataType) -> None:
+        assert dt.is_opaque is False
+
+    def test_unknown_has_no_default_aggregations(self) -> None:
+        # An opaque column can't be aggregated at all, so it must not appear
+        # in the type-default eligibility table.
+        assert DataType.UNKNOWN not in DEFAULT_AGGREGATIONS_BY_TYPE
 
 
 class TestDefaultAggregationsByType:

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -19,6 +19,10 @@ from sqlalchemy.dialects.mssql import (
     TIMESTAMP as MSSQL_TIMESTAMP,
     TINYINT,
 )
+from sqlalchemy.dialects.postgresql import ARRAY as PG_ARRAY
+from sqlalchemy.dialects.postgresql import JSON as PG_JSON
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from slayer.core.enums import DataType
 from slayer.engine.ingestion import (
@@ -393,6 +397,73 @@ class TestSaTypeToDataTypeIntDouble:
         assert _sa_type_to_data_type(MSSQL_TIMESTAMP()) is DataType.TEXT
 
 
+class TestUnmappedTypeBecomesOpaque:
+    """DB types with no equality operator map to the explicit opaque
+    ``UNKNOWN`` type, and the raw type string is retained on
+    ``Column.db_type``. Comparable types — including unmapped ones — keep
+    working as TEXT."""
+
+    def test_non_comparable_sa_type_maps_to_unknown(self) -> None:
+        assert _sa_type_to_data_type(PG_JSON()) is DataType.UNKNOWN
+        assert _sa_type_to_data_type(PG_JSON()).is_opaque is True
+
+    @pytest.mark.parametrize(
+        "sa_type",
+        [
+            JSONB(),  # jsonb HAS ``=`` in Postgres, unlike json
+            PG_UUID(),
+            sa.LargeBinary(),  # bytea
+            PG_ARRAY(sa.Text()),
+        ],
+        ids=["jsonb", "uuid", "bytea", "array"],
+    )
+    def test_comparable_unmapped_types_stay_text(self, sa_type) -> None:
+        """Regression: these are groupable/joinable and must not be marked
+        opaque — doing so would tell an agent a usable column is unusable."""
+        mapped = _sa_type_to_data_type(sa_type)
+        assert mapped is DataType.TEXT
+        assert mapped.is_opaque is False
+
+    def test_mapped_sa_type_unaffected(self) -> None:
+        assert _sa_type_to_data_type(sa.VARCHAR(32)) is DataType.TEXT
+
+    def test_mssql_rowversion_special_case_still_text(self) -> None:
+        # The explicit isinstance guard must survive the UNKNOWN fallback.
+        assert _sa_type_to_data_type(MSSQL_TIMESTAMP()) is DataType.TEXT
+
+    def test_ingest_populates_db_type_only_for_opaque_columns(self) -> None:
+        from slayer.core.models import DatasourceConfig
+        from slayer.engine.ingestion import ingest_datasource
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "opaque.db")
+            engine = sa.create_engine(f"sqlite:///{db_path}")
+            with engine.connect() as c:
+                c.execute(sa.text(
+                    "CREATE TABLE t (id INTEGER PRIMARY KEY, "
+                    "name VARCHAR(64), payload JSON, blob_col BLOB)"
+                ))
+                c.commit()
+            engine.dispose()
+
+            ds = DatasourceConfig(name="opaque_ds", type="sqlite", database=db_path)
+            model = next(m for m in ingest_datasource(datasource=ds) if m.name == "t")
+            by_name = {c.name: c for c in model.columns}
+
+            # Opaque: explicit UNKNOWN + raw DB type retained.
+            assert by_name["payload"].type is DataType.UNKNOWN
+            assert by_name["payload"].db_type == "JSON"
+
+            # Mapped types are untouched and carry no db_type.
+            assert by_name["name"].type is DataType.TEXT
+            assert by_name["name"].db_type is None
+            assert by_name["id"].type is DataType.INT
+            assert by_name["id"].db_type is None
+            # bytea/BLOB is comparable — it must NOT be marked opaque.
+            assert by_name["blob_col"].type is DataType.TEXT
+            assert by_name["blob_col"].db_type is None
+
+
 class TestSqliteIngestionRoundTrip:
     """End-to-end: introspect a real SQLite table and confirm narrow types."""
 
@@ -644,8 +715,8 @@ class TestSqliteIngestionProbe:
         ):
             # Mixed bag: one base column (no '.') and one dotted alias.
             columns = [
-                ("qty", DataType.INT, False, False),
-                ("customers.region_id", DataType.INT, False, False),
+                ("qty", DataType.INT, False, False, None),
+                ("customers.region_id", DataType.INT, False, False, None),
             ]
             _sqlite_probe_integer_columns(
                 sa_engine=sa_engine,

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -25,7 +25,9 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from slayer.core.enums import DataType
+from slayer.core.models import DatasourceConfig
 from slayer.engine.ingestion import (
+    ingest_datasource,
     _generate_joins,
     _get_columns_fallback,
     _get_pk_constraint_fallback,
@@ -432,9 +434,6 @@ class TestUnmappedTypeBecomesOpaque:
         assert _sa_type_to_data_type(MSSQL_TIMESTAMP()) is DataType.TEXT
 
     def test_ingest_populates_db_type_only_for_opaque_columns(self) -> None:
-        from slayer.core.models import DatasourceConfig
-        from slayer.engine.ingestion import ingest_datasource
-
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = os.path.join(tmpdir, "opaque.db")
             engine = sa.create_engine(f"sqlite:///{db_path}")

--- a/tests/test_ingestion_clickhouse.py
+++ b/tests/test_ingestion_clickhouse.py
@@ -178,6 +178,8 @@ class TestUnmappedTypeWarning:
     def test_warning_fires_once_per_type_name(self, caplog):
         with caplog.at_level(logging.WARNING, logger="slayer.engine.ingestion"):
             for _ in range(3):
+                # Unrecognized types stay TEXT: most unmapped types are
+                # comparable. Only the known non-comparable ones are opaque.
                 result = _sa_type_to_data_type(_FakeUnknownType())
                 assert result is DataType.TEXT
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1404,6 +1404,30 @@ class TestBuildSampleQueryArgs:
             "*:count", "extra_string:count_distinct", "quantity:avg",
         ]
 
+    def test_opaque_column_excluded_from_data_profile(self) -> None:
+        """An opaque (``UNKNOWN``) column has no equality operator in the DB,
+        so ``count_distinct``/``min``/``max`` on it would take the whole Data
+        Profile query down. It must be skipped as both measure and dimension."""
+        from slayer.inspect.model_render import _choose_sample_agg
+
+        opaque = Column(name="loc", type=DataType.UNKNOWN, db_type="point")
+        assert _choose_sample_agg(opaque, measure_types={}) is None
+        # ...even when the driver reports a categorical-looking cursor type.
+        assert _choose_sample_agg(opaque, measure_types={"loc": "string"}) is None
+
+        model = SlayerModel(
+            name="places", sql_table="places", data_source="ds",
+            columns=[
+                Column(name="id", type=DataType.INT, primary_key=True),
+                Column(name="city", type=DataType.TEXT),
+                opaque,
+                Column(name="area", type=DataType.DOUBLE),
+            ],
+        )
+        args = _build_sample_query_args(model=model, num_rows=3)
+        assert [f["formula"] for f in args["measures"]] == ["*:count", "area:avg"]
+        assert [d["name"] for d in args["dimensions"]] == ["city"]
+
 
 class TestMarkdownHelpers:
     def test_escape_none_and_empty(self) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,7 +18,10 @@ from slayer.core.models import (
     ModelMeasure,
     SlayerModel,
 )
-from slayer.inspect.model_render import _choose_sample_agg
+from slayer.inspect.model_render import (
+    _choose_sample_agg,
+    render_model_inspection,
+)
 from slayer.mcp.server import (
     _build_sample_query_args,
     _escape_md_cell,
@@ -3068,3 +3071,110 @@ class TestFormatTable:
 # see tests/test_help_seed.py.
 
 
+
+
+class TestDataProfileRetryScope:
+    """The Data Profile's count-only retry exists for exactly one failure: the
+    database cannot group/deduplicate a column type. Every other failure must
+    keep its own cause instead of being retried and relabeled as a type issue.
+
+    The renderer also issues dimension-less row-count / numeric-profiling
+    queries, so these fakes key off ``query.dimensions`` to hit only the full
+    profile, and the assertions are on outcomes rather than call counts.
+    """
+
+    @staticmethod
+    def _model() -> SlayerModel:
+        return SlayerModel(
+            name="profile_scope",
+            sql_table="t",
+            data_source="test",
+            columns=[
+                Column(name="id", type=DataType.INT, primary_key=True),
+                Column(name="status", type=DataType.TEXT),
+            ],
+        )
+
+    class _CountResult:
+        sql = "SELECT COUNT(*) FROM t"
+        columns = ["profile_scope._count"]
+        data = [{"profile_scope._count": 7}]
+
+        def to_markdown(self) -> str:
+            return "| _count |\n|---|\n| 7 |"
+
+    async def _render(self, storage, engine) -> dict:
+        out = await render_model_inspection(
+            model=self._model(), storage=storage, engine=engine,
+            format="json", compact=False, sections=["samples"],
+        )
+        return json.loads(out)
+
+    async def test_unrelated_failure_is_not_relabeled_as_reduced(
+        self, storage: YAMLStorage
+    ) -> None:
+        outer = self
+
+        class _Engine:
+            async def get_column_types(self, **kwargs):
+                return {}
+
+            async def execute(self, *, query, **kwargs):
+                if query.dimensions:
+                    raise RuntimeError("permission denied for table t")
+                return outer._CountResult()
+
+        payload = await self._render(storage, _Engine())
+        # A permission failure must NOT masquerade as a type/grouping problem.
+        assert payload["sample_data_reduced"] is False
+        assert payload["sample_data_reduced_reason"] is None
+        assert "permission denied" in (payload["sample_data_error"] or "")
+
+    async def test_grouping_failure_retries_and_reports_reduced(
+        self, storage: YAMLStorage
+    ) -> None:
+        outer = self
+
+        class _Engine:
+            async def get_column_types(self, **kwargs):
+                return {}
+
+            async def execute(self, *, query, **kwargs):
+                if query.dimensions:
+                    raise RuntimeError(
+                        "could not identify an equality operator for type point"
+                    )
+                return outer._CountResult()
+
+        payload = await self._render(storage, _Engine())
+        assert payload["sample_data_reduced"] is True
+        assert "does not support" in payload["sample_data_reduced_reason"]
+        assert payload["sample_data_error"] is None
+
+    async def test_original_cause_survives_a_failing_retry(
+        self, storage: YAMLStorage
+    ) -> None:
+        """When the reduced profile also fails, report the first cause."""
+
+        class _Engine:
+            def __init__(self) -> None:
+                self.dimensioned_seen = False
+
+            async def get_column_types(self, **kwargs):
+                return {}
+
+            async def execute(self, *, query, **kwargs):
+                if query.dimensions:
+                    self.dimensioned_seen = True
+                    raise RuntimeError(
+                        "could not identify an equality operator for type point"
+                    )
+                if self.dimensioned_seen:
+                    # This is the count-only retry — fail it too.
+                    raise RuntimeError("connection closed unexpectedly")
+                raise RuntimeError("row count unavailable")
+
+        payload = await self._render(storage, _Engine())
+        assert "equality operator" in (payload["sample_data_error"] or "")
+        assert "connection closed" not in (payload["sample_data_error"] or "")
+        assert payload["sample_data_reduced"] is False

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ from slayer.core.models import (
     ModelMeasure,
     SlayerModel,
 )
+from slayer.inspect.model_render import _choose_sample_agg
 from slayer.mcp.server import (
     _build_sample_query_args,
     _escape_md_cell,
@@ -579,6 +580,10 @@ Column(name="m", sql="val", type=DataType.DOUBLE)
         assert parsed["model_name"] == "jtest"
         # sample_sql should NOT appear when show_sql is not requested
         assert "sample_sql" not in parsed
+        # A complete profile must advertise itself as not reduced, so a JSON
+        # caller can distinguish it from the count-only fallback.
+        assert parsed["sample_data_reduced"] is False
+        assert parsed["sample_data_reduced_reason"] is None
 
 
 class TestInspectModelShowSQL:
@@ -1408,8 +1413,6 @@ class TestBuildSampleQueryArgs:
         """An opaque (``UNKNOWN``) column has no equality operator in the DB,
         so ``count_distinct``/``min``/``max`` on it would take the whole Data
         Profile query down. It must be skipped as both measure and dimension."""
-        from slayer.inspect.model_render import _choose_sample_agg
-
         opaque = Column(name="loc", type=DataType.UNKNOWN, db_type="point")
         assert _choose_sample_agg(opaque, measure_types={}) is None
         # ...even when the driver reports a categorical-looking cursor type.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2120,6 +2120,53 @@ class TestColumnTypeLenientValidator:
         col = Column(name="x", type=DataType.INT)
         assert col.type == DataType.INT
 
+    def test_legacy_lowercase_unknown_maps_to_unknown(self) -> None:
+        col = Column(name="x", type="unknown")
+        assert col.type == DataType.UNKNOWN
+        assert col.type.is_opaque is True
+
+
+class TestOpaqueColumn:
+    """Opaque (``UNKNOWN``) columns are stored + displayed but never operated
+    on — the raw DB type rides along on ``db_type``."""
+
+    def test_db_type_defaults_to_none(self) -> None:
+        assert Column(name="x", type=DataType.TEXT).db_type is None
+
+    def test_db_type_round_trips(self) -> None:
+        col = Column(name="loc", type=DataType.UNKNOWN, db_type="point")
+        assert col.db_type == "point"
+        assert Column.model_validate(col.model_dump()).db_type == "point"
+
+    def test_allowed_aggregations_rejected_on_opaque_column(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            SlayerModel(
+                name="places",
+                sql_table="places",
+                data_source="ds",
+                columns=[
+                    Column(
+                        name="loc",
+                        type=DataType.UNKNOWN,
+                        db_type="point",
+                        allowed_aggregations=["count"],
+                    ),
+                ],
+            )
+        msg = str(exc_info.value)
+        assert "loc" in msg
+        assert "point" in msg
+        assert "not supported" in msg
+
+    def test_opaque_column_without_allowed_aggregations_is_valid(self) -> None:
+        model = SlayerModel(
+            name="places",
+            sql_table="places",
+            data_source="ds",
+            columns=[Column(name="loc", type=DataType.UNKNOWN, db_type="point")],
+        )
+        assert model.columns[0].type is DataType.UNKNOWN
+
 
 class TestModelMeasureType:
     """DEV-1361: ModelMeasure gains an optional ``type`` declaring the formula's

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2139,19 +2139,20 @@ class TestOpaqueColumn:
         assert Column.model_validate(col.model_dump()).db_type == "point"
 
     def test_allowed_aggregations_rejected_on_opaque_column(self) -> None:
+        # Built outside the raises block so only the SlayerModel construction
+        # can produce the expected failure.
+        opaque_col = Column(
+            name="loc",
+            type=DataType.UNKNOWN,
+            db_type="point",
+            allowed_aggregations=["count"],
+        )
         with pytest.raises(ValidationError) as exc_info:
             SlayerModel(
                 name="places",
                 sql_table="places",
                 data_source="ds",
-                columns=[
-                    Column(
-                        name="loc",
-                        type=DataType.UNKNOWN,
-                        db_type="point",
-                        allowed_aggregations=["count"],
-                    ),
-                ],
+                columns=[opaque_col],
             )
         msg = str(exc_info.value)
         assert "loc" in msg

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -5756,7 +5756,10 @@ class TestCastEmissionOpaqueType:
         wrapped = _wrap_cast_for_type(expr, DataType.DOUBLE)
         assert isinstance(wrapped, sqlglot.exp.Cast)
 
-    async def test_opaque_column_emits_no_cast(self) -> None:
+    async def test_opaque_column_rejected_as_dimension(self) -> None:
+        """An opaque column has no equality operator, so grouping by it would
+        emit SQL the database refuses. Reject it up front with an actionable
+        message rather than letting a raw driver error surface."""
         model = SlayerModel(
             name="places",
             sql_table="public.places",
@@ -5773,6 +5776,33 @@ class TestCastEmissionOpaqueType:
         )
         gen = SQLGenerator(dialect="postgres")
         query = SlayerQuery(source_model="places", dimensions=[ColumnRef(name="loc")])
+        with pytest.raises(ValueError, match="cannot be used as a dimension"):
+            await _generate(gen, query, model)
+
+    async def test_opaque_column_emits_no_cast_when_projected(self) -> None:
+        """The CAST guard still holds for a query that doesn't group by the
+        opaque column: no ``CAST(... AS UNKNOWN)`` may reach the SQL."""
+        model = SlayerModel(
+            name="places",
+            sql_table="public.places",
+            data_source="test",
+            columns=[
+                Column(name="id", sql="id", type=DataType.INT, primary_key=True),
+                Column(name="city", sql="city", type=DataType.TEXT),
+                Column(
+                    name="loc",
+                    sql="coalesce(loc, home_loc)",
+                    type=DataType.UNKNOWN,
+                    db_type="point",
+                ),
+            ],
+        )
+        gen = SQLGenerator(dialect="postgres")
+        query = SlayerQuery(
+            source_model="places",
+            measures=["*:count"],
+            dimensions=[ColumnRef(name="city")],
+        )
         sql = await _generate(gen, query, model)
         assert "UNKNOWN" not in sql.upper()
         assert "CAST(" not in sql.upper()

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -22,7 +22,12 @@ from slayer.engine.enriched import (
 from slayer.engine.enrichment import enrich_query
 from slayer.engine.query_engine import SlayerQueryEngine
 from slayer.sql.dialects import BigqueryDialect
-from slayer.sql.generator import SQLGenerator, _cte_name_from_alias, _validate_agg_param_value
+from slayer.sql.generator import (
+    SQLGenerator,
+    _cte_name_from_alias,
+    _validate_agg_param_value,
+    _wrap_cast_for_type,
+)
 from slayer.storage.yaml_storage import YAMLStorage
 
 
@@ -5736,6 +5741,41 @@ class TestCastEmissionColumn:
         # Exactly one CAST in the projection. Any double-wrap would produce
         # CAST(CAST(... AS ...) AS ...) — assert that pattern is absent.
         assert "CAST(CAST(" not in sql.upper()
+
+
+class TestCastEmissionOpaqueType:
+    """``CAST(x AS UNKNOWN)`` is not valid SQL in any dialect, so opaque types
+    are skipped by ``_wrap_cast_for_type`` exactly like TEXT/None."""
+
+    def test_unknown_returns_expression_unchanged(self) -> None:
+        expr = sqlglot.parse_one("json_extract(blob, '$.x')")
+        assert _wrap_cast_for_type(expr, DataType.UNKNOWN) is expr
+
+    def test_operable_type_still_casts(self) -> None:
+        expr = sqlglot.parse_one("json_extract(blob, '$.x')")
+        wrapped = _wrap_cast_for_type(expr, DataType.DOUBLE)
+        assert isinstance(wrapped, sqlglot.exp.Cast)
+
+    async def test_opaque_column_emits_no_cast(self) -> None:
+        model = SlayerModel(
+            name="places",
+            sql_table="public.places",
+            data_source="test",
+            columns=[
+                Column(name="id", sql="id", type=DataType.INT, primary_key=True),
+                Column(
+                    name="loc",
+                    sql="coalesce(loc, home_loc)",
+                    type=DataType.UNKNOWN,
+                    db_type="point",
+                ),
+            ],
+        )
+        gen = SQLGenerator(dialect="postgres")
+        query = SlayerQuery(source_model="places", dimensions=[ColumnRef(name="loc")])
+        sql = await _generate(gen, query, model)
+        assert "UNKNOWN" not in sql.upper()
+        assert "CAST(" not in sql.upper()
 
 
 class TestCastEmissionMeasure:


### PR DESCRIPTION
Added `UNKNOWN` column type. To prevent fails on special column types which don't support equality operator, usage as grouping keys (like Postgres geo `point`, JSON, etc.), which happens e.g. in inspect tool, as now we treat them as string/text column+dimension. Meanwhile, such columns should stay present and queryable, especially via DB-specific functions, which we pass as is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opaque/unknown column types via `DataType.UNKNOWN`, including propagation and inspection/JSON visibility of raw DB type (`db_type`).
* **Bug Fixes**
  * Opaque columns are treated as non-queryable and excluded from profiling, data-profile aggregation, grouping/dimensions, and dimension SQL casting.
  * Improved schema drift handling and JDBC/Arrow/Postgres type mappings for unknown/opaque values.
* **Tests**
  * Expanded coverage for opaque mappings, round-trips, and rejection rules (including reduced sample-data retry behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->