### PR TITLE
DEV-1783: PR #286 review G1 — production correctness fixes (filter reachability, T-SQL OFFSET, ntile, host-rooted routing)

### DIFF
--- a/slayer/core/warnings.py
+++ b/slayer/core/warnings.py
@@ -60,8 +60,16 @@ class NormalizationWarning(SlayerWarning):
     normalized: str
     location: str
     rule_doc_url: Optional[str] = None
+    # Some rules (MALFORMED_DATE_RANGE) REPORT without rewriting; the message
+    # must not claim a transform that never happened (DEV-1783).
+    rewritten: bool = True
 
     def human_message(self) -> str:
+        if not self.rewritten:
+            return (
+                f"[{self.rule_id}] flagged {self.original}: {self.normalized} "
+                f"(at {self.location})"
+            )
         return (
             f"[{self.rule_id}] rewrote {self.original} → {self.normalized} "
             f"(at {self.location})"
@@ -108,7 +116,7 @@ class SlayerNormalizationWarning(UserWarning):
 
     def __init__(self, payload: NormalizationWarning) -> None:
         self.payload = payload
-        super().__init__(
-            f"[{payload.rule_id}] {payload.original!s} → {payload.normalized!s} "
-            f"(at {payload.location})"
-        )
+        # One source of truth for the wording, so a non-rewrite rule reads the
+        # same on the Python-warnings channel as in the structured payload
+        # (DEV-1783).
+        super().__init__(payload.human_message())

--- a/slayer/core/warnings.py
+++ b/slayer/core/warnings.py
@@ -45,7 +45,10 @@ class SlayerWarning(BaseModel):
 
 
 class NormalizationWarning(SlayerWarning):
-    """Structured payload describing one slack-normalization rewrite.
+    """Structured payload describing one slack-normalization event — a REWRITE
+    (``rewritten=True``, the default) or a report-only advisory
+    (``rewritten=False``, e.g. ``MALFORMED_DATE_RANGE``, which the planner
+    silently no-ops rather than rewriting).
 
     ``rule_id`` identifies the rule that fired (``FUNC_STYLE_AGG``,
     ``DOT_PATH_IN_SQL``, ``MISPLACED_MEASURE``). ``location`` is a

--- a/slayer/engine/cross_model_planner.py
+++ b/slayer/engine/cross_model_planner.py
@@ -521,8 +521,13 @@ def _route_host_rooted_filters(
 
     Nothing is ever DROPPED here, so no warning can arise: every filter is
     applied somewhere, either in the CTE or at the host.
+
+    ``where_ids`` stays EMPTY. It is the forward-CTE delegation instruction —
+    "the CTE took this over, so the host base must SKIP it" — but a host-rooted
+    CTE has no forward CTE, and the sub-plan already carries these predicates as
+    its own filters. Only ``applied`` (the audit) is populated (DEV-1783).
     """
-    where_ids: List[BoundFilterId] = []
+    applied_ids: List[BoundFilterId] = []
     for routing in host_filters:
         if routing.text is None:
             continue  # date_range bound — re-attached by the caller, in order
@@ -530,8 +535,8 @@ def _route_host_rooted_filters(
             continue
         if routing.bound is None:
             continue
-        where_ids.append(routing.filter_id)
-    return _FilterRoutes(applied=list(where_ids), where_ids=where_ids)
+        applied_ids.append(routing.filter_id)
+    return _FilterRoutes(applied=applied_ids, where_ids=[])
 
 
 

--- a/slayer/engine/filter_reachability.py
+++ b/slayer/engine/filter_reachability.py
@@ -258,12 +258,26 @@ def _leaf_paths(
     node, *, anchor_model, anchor_relation: str, bundle,
     cache: "Optional[dict]" = None,
 ) -> List[Path]:
-    """Join paths a LEAF key is itself anchored at.
+    """Join paths a key contributes ITSELF (not via its children).
 
     Composites contribute nothing here — their dependencies arrive through
-    ``_child_keys``. Split out of the traversal so the walk stays a two-line
-    "collect, then descend".
+    ``_child_keys`` — EXCEPT an ``AggregateKey``'s ``column_filter_key``, which
+    is not a plain child (its paths are OWNER-relative and re-anchored here).
+    Split out of the traversal so the walk stays a two-line "collect, then
+    descend".
     """
+    if isinstance(node, AggregateKey) and node.column_filter_key is not None:
+        # ``column_filter_key.referenced_join_paths`` are OWNER-relative
+        # (anchored at the aggregated column's owner, reached via
+        # ``source.path``). Re-anchor to the query root by prefixing
+        # ``source.path`` (DEV-1783); the reroot visitor leaves the owner in
+        # place for the same reason (keys.py: cfk copied unchanged).
+        source_path = tuple(getattr(node.source, "path", ()) or ())
+        return [
+            pre
+            for p in node.column_filter_key.referenced_join_paths
+            for pre in _prefixes(source_path + tuple(p))
+        ]
     if isinstance(node, ColumnSqlKey):
         # Own anchored path first, then whatever its expansion reaches — the
         # order the FROM builder consumes. Built as a NEW list rather than
@@ -314,16 +328,6 @@ def compute_key_join_paths(
             anchor_relation=anchor_relation, bundle=bundle, cache=cache,
         ):
             _add(path)
-        if isinstance(node, AggregateKey) and node.column_filter_key is not None:
-            # ``column_filter_key.referenced_join_paths`` are OWNER-relative
-            # (anchored at the aggregated column's owner, reached via
-            # ``source.path``). Re-anchor to the query root by prefixing
-            # ``source.path`` — the reroot visitor leaves the owner in place for
-            # the same reason (keys.py: cfk copied unchanged).
-            source_path = tuple(getattr(node.source, "path", ()) or ())
-            for p in node.column_filter_key.referenced_join_paths:
-                for pre in _prefixes(source_path + tuple(p)):
-                    _add(pre)
         for child in _child_keys(node):
             _walk(child)
 

--- a/slayer/engine/filter_reachability.py
+++ b/slayer/engine/filter_reachability.py
@@ -227,11 +227,15 @@ def _child_keys(node, *, descend_aggregates: bool = True) -> List:
     if isinstance(node, AggregateKey):
         if not descend_aggregates:
             return []
+        # ``column_filter_key`` is deliberately NOT a plain child: its
+        # ``referenced_join_paths`` are OWNER-relative and must be re-anchored
+        # by prefixing ``source.path``, which ``compute_key_join_paths`` does
+        # explicitly (DEV-1783). Descending it here would record them
+        # anchor-rooted and mis-route the filter.
         return [
             node.source,
             *node.args,
             *(v for _name, v in node.kwargs),
-            node.column_filter_key,
         ]
     if isinstance(node, TransformKey):
         return [
@@ -310,6 +314,16 @@ def compute_key_join_paths(
             anchor_relation=anchor_relation, bundle=bundle, cache=cache,
         ):
             _add(path)
+        if isinstance(node, AggregateKey) and node.column_filter_key is not None:
+            # ``column_filter_key.referenced_join_paths`` are OWNER-relative
+            # (anchored at the aggregated column's owner, reached via
+            # ``source.path``). Re-anchor to the query root by prefixing
+            # ``source.path`` — the reroot visitor leaves the owner in place for
+            # the same reason (keys.py: cfk copied unchanged).
+            source_path = tuple(getattr(node.source, "path", ()) or ())
+            for p in node.column_filter_key.referenced_join_paths:
+                for pre in _prefixes(source_path + tuple(p)):
+                    _add(pre)
         for child in _child_keys(node):
             _walk(child)
 

--- a/slayer/engine/isolation.py
+++ b/slayer/engine/isolation.py
@@ -31,7 +31,7 @@ whole aggregates.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Sequence, Set, Tuple
+from typing import Any, List, Sequence, Set, Tuple
 
 from slayer.core.keys import AggregateKey
 from slayer.engine.aggregate_input_paths import compute_aggregate_input_join_paths
@@ -160,7 +160,9 @@ def classify_isolation(
     return IsolationKind.HOST_ROOTED
 
 
-def _crossing_input_paths(*, key: AggregateKey, bundle: Any) -> list:
+def _crossing_input_paths(
+    *, key: AggregateKey, bundle: Any,
+) -> List[Tuple[str, ...]]:
     """Join paths a LOCAL aggregate's inputs cross.
 
     A ``Column.filter`` carries its crossings as typed
@@ -168,13 +170,24 @@ def _crossing_input_paths(*, key: AggregateKey, bundle: Any) -> list:
     ``Column.sql``, positional args including an explicit first/last time arg,
     and kwargs — column refs, user template fragments, and non-overridden
     model-default aggregation params) is computed structurally.
+
+    Both sources are UNIONED (DEV-1783): an aggregate whose column filter AND
+    whose source/args/kwargs each cross a different join must report both, or
+    the isolation decision under-counts and a fan-out-multiplying input inlines.
+    Order-stable (filter paths first) and de-duplicated.
     """
-    if key.column_filter_key is not None and key.column_filter_key.referenced_join_paths:
-        return list(key.column_filter_key.referenced_join_paths)
+    out: List[Tuple[str, ...]] = []
+    if key.column_filter_key is not None:
+        for p in key.column_filter_key.referenced_join_paths:
+            if p not in out:
+                out.append(p)
     source_model = getattr(bundle, "source_model", None)
-    return list(compute_aggregate_input_join_paths(
+    for p in compute_aggregate_input_join_paths(
         key=key,
         anchor_model=source_model,
         anchor_relation=source_model.name if source_model is not None else "",
         bundle=bundle,
-    ))
+    ):
+        if p not in out:
+            out.append(p)
+    return out

--- a/slayer/engine/normalization.py
+++ b/slayer/engine/normalization.py
@@ -597,6 +597,9 @@ def _apply_malformed_date_range(
             original=f"time_dimensions[{i}].date_range={list(date_range)!r}",
             normalized="(ignored — no date filter emitted)",
             location=f"time_dimensions[{i}].date_range",
+            # Reports but does NOT rewrite (planner silently no-ops the range);
+            # the message must not claim a transform (DEV-1783).
+            rewritten=False,
             # No rule_doc_url: docs/agent_input_slack.md does not exist, and a
             # link to a missing page is worse than no link.
         )

--- a/slayer/engine/normalization.py
+++ b/slayer/engine/normalization.py
@@ -469,6 +469,9 @@ def _apply_dot_path_in_sql(
                 original=original,
                 normalized="(ambiguous: shadowed by local alias or CTE — not rewritten)",
                 location=location,
+                # Shadowed ref is left untouched — reported, not rewritten
+                # (DEV-1783).
+                rewritten=False,
                 rule_doc_url="docs/agent_input_slack.md#dot-path-in-sql",
             )
             emitted.append(payload)

--- a/slayer/sql/dialects/tsql.py
+++ b/slayer/sql/dialects/tsql.py
@@ -347,6 +347,17 @@ class TsqlDialect(SqlDialect):
         to the base impl — T-SQL will still reject malformed SQL at the
         DB layer, but we don't make it worse.
         """
+        # SQL Server rejects OFFSET without ORDER BY. Synthesize the same no-op
+        # ordering ``apply_pagination`` uses BEFORE branching, so BOTH the AST
+        # path AND the base-impl fallback (a non-Select inner, base.py also
+        # emits a bare OFFSET) receive it. A user's ORDER BY is never replaced —
+        # this only fires when ``order`` is absent (DEV-1783).
+        if order is None and offset_arg is not None:
+            order = exp.Order(expressions=[
+                exp.Ordered(this=exp.Subquery(
+                    this=exp.Select().select(exp.Null()),
+                )),
+            ])
         parse_fn = parse if parse is not None else (
             lambda s: sqlglot.parse_one(s, dialect=self.sqlglot_name)
         )

--- a/slayer/sql/dialects/tsql.py
+++ b/slayer/sql/dialects/tsql.py
@@ -63,6 +63,20 @@ _TSQL_STAT_NAMES: dict[str, str] = {
 _TSQL_DOTTED_ALIAS_RE = re.compile(r"\[(\w+(?:\.\w+)+)\]", re.ASCII)
 
 
+def _offset_ordering_fallback(
+    order: "exp.Expression | None", offset_arg: "exp.Expression | None",
+) -> "exp.Expression | None":
+    """The ORDER BY an OFFSET-bearing outer wrap must carry: the caller's, or a
+    synthesized ``ORDER BY (SELECT NULL)`` no-op when there is none (SQL Server
+    rejects OFFSET without ORDER BY). Returns ``order`` unchanged otherwise, so
+    a user's ordering is never replaced (DEV-1783)."""
+    if order is not None or offset_arg is None:
+        return order
+    return exp.Order(expressions=[
+        exp.Ordered(this=exp.Subquery(this=exp.Select().select(exp.Null()))),
+    ])
+
+
 class TsqlDialect(SqlDialect):
     sqlglot_name: str = "tsql"
     ds_type_aliases: frozenset[str] = frozenset({"mssql", "sqlserver", "tsql"})
@@ -347,17 +361,10 @@ class TsqlDialect(SqlDialect):
         to the base impl — T-SQL will still reject malformed SQL at the
         DB layer, but we don't make it worse.
         """
-        # SQL Server rejects OFFSET without ORDER BY. Synthesize the same no-op
-        # ordering ``apply_pagination`` uses BEFORE branching, so BOTH the AST
-        # path AND the base-impl fallback (a non-Select inner, base.py also
-        # emits a bare OFFSET) receive it. A user's ORDER BY is never replaced —
-        # this only fires when ``order`` is absent (DEV-1783).
-        if order is None and offset_arg is not None:
-            order = exp.Order(expressions=[
-                exp.Ordered(this=exp.Subquery(
-                    this=exp.Select().select(exp.Null()),
-                )),
-            ])
+        # SQL Server rejects OFFSET without ORDER BY. Resolve the effective
+        # ordering BEFORE branching, so BOTH the AST path AND the base-impl
+        # fallback (a non-Select inner, base.py also emits a bare OFFSET) get it.
+        order = _offset_ordering_fallback(order, offset_arg)
         parse_fn = parse if parse is not None else (
             lambda s: sqlglot.parse_one(s, dialect=self.sqlglot_name)
         )

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -6258,16 +6258,11 @@ class SQLGenerator:
         if op == "dense_rank":
             return _over(exp.DenseRank(), order=rank_order)
         if op == "ntile":
-            n = kwarg_map.get("n")
-            if not isinstance(n, int):
-                # Decimal-normalised int.
-                try:
-                    n_int = int(n)
-                except (TypeError, ValueError):
-                    raise ValueError(
-                        f"ntile requires a positive integer n, got {n!r}",
-                    )
-                n = n_int
+            # Route through the shared normaliser (as lag / lead do) so bool is
+            # rejected and a non-integral Decimal raises rather than truncating
+            # (DEV-1783). The binder gates this too; this is the render-side
+            # defense-in-depth.
+            n = _normalise_periods(kwarg_map.get("n"), kw="n")
             if n <= 0:
                 raise ValueError(
                     f"ntile requires a positive integer n, got {n!r}",

--- a/slayer/sql/generator.py
+++ b/slayer/sql/generator.py
@@ -6262,7 +6262,7 @@ class SQLGenerator:
             # rejected and a non-integral Decimal raises rather than truncating
             # (DEV-1783). The binder gates this too; this is the render-side
             # defense-in-depth.
-            n = _normalise_periods(kwarg_map.get("n"), kw="n")
+            n = _normalise_periods(raw=kwarg_map.get("n"), kw="n")
             if n <= 0:
                 raise ValueError(
                     f"ntile requires a positive integer n, got {n!r}",

--- a/tests/test_dev1745_date_range_warning.py
+++ b/tests/test_dev1745_date_range_warning.py
@@ -23,6 +23,7 @@ import pytest
 from slayer.core.enums import DataType
 from slayer.core.models import Column, SlayerModel
 from slayer.core.query import SlayerQuery
+from slayer.core.warnings import NormalizationWarning, SlayerNormalizationWarning
 from slayer.engine.normalization import normalize_query
 
 from tests._engine_helpers import _engine_generate
@@ -83,8 +84,6 @@ class TestMalformedDateRangeWarns:
 
     @pytest.mark.parametrize("date_range", MALFORMED)
     def test_emits_on_the_python_warnings_channel(self, date_range) -> None:
-        from slayer.core.warnings import SlayerNormalizationWarning
-
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             normalize_query(query=_query(date_range))
@@ -105,7 +104,8 @@ class TestWarningWordingDescribesTheNoOp:
         msg = w.human_message()
         assert "rewrote" not in msg.lower(), msg
         assert "→" not in msg, msg
-        assert w.rule_id in msg and w.location in msg, msg
+        assert w.rule_id in msg, msg
+        assert w.location in msg, msg
 
     @pytest.mark.parametrize("date_range", MALFORMED)
     def test_python_warning_carrier_does_not_claim_a_rewrite(self, date_range) -> None:
@@ -121,8 +121,6 @@ class TestWarningWordingDescribesTheNoOp:
         assert all("→" not in t for t in texts), texts
 
     def test_a_genuine_rewrite_rule_still_says_rewrote(self) -> None:
-        from slayer.core.warnings import NormalizationWarning
-
         w = NormalizationWarning(
             rule_id="FUNC_STYLE_AGG", original="count(*)",
             normalized="*:count", location="measures[0].formula",

--- a/tests/test_dev1745_date_range_warning.py
+++ b/tests/test_dev1745_date_range_warning.py
@@ -93,6 +93,44 @@ class TestMalformedDateRangeWarns:
         ), f"no SlayerNormalizationWarning for date_range={date_range!r}"
 
 
+class TestWarningWordingDescribesTheNoOp:
+    """DEV-1783 item 7 — MALFORMED_DATE_RANGE reports but never rewrites, so its
+    message must not claim a rewrite. A real rewrite rule (FUNC_STYLE_AGG) still
+    says "rewrote"."""
+
+    @pytest.mark.parametrize("date_range", MALFORMED)
+    def test_structured_message_does_not_claim_a_rewrite(self, date_range) -> None:
+        [w] = _warnings_for(date_range)
+        assert w.rewritten is False, w
+        msg = w.human_message()
+        assert "rewrote" not in msg.lower(), msg
+        assert "→" not in msg, msg
+        assert w.rule_id in msg and w.location in msg, msg
+
+    @pytest.mark.parametrize("date_range", MALFORMED)
+    def test_python_warning_carrier_does_not_claim_a_rewrite(self, date_range) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            normalize_query(query=_query(date_range))
+        texts = [str(w.message) for w in caught if "date_range" in str(w.message)]
+        assert texts, "no date_range warning surfaced on the Python channel"
+        # Neither the verb "rewrote" nor the transform arrow — nothing was
+        # rewritten, so the carrier must not imply it (single source of truth
+        # with human_message).
+        assert all("rewrote" not in t.lower() for t in texts), texts
+        assert all("→" not in t for t in texts), texts
+
+    def test_a_genuine_rewrite_rule_still_says_rewrote(self) -> None:
+        from slayer.core.warnings import NormalizationWarning
+
+        w = NormalizationWarning(
+            rule_id="FUNC_STYLE_AGG", original="count(*)",
+            normalized="*:count", location="measures[0].formula",
+        )
+        assert w.rewritten is True
+        assert "rewrote" in w.human_message().lower()
+
+
 class TestWellFormedDateRangeIsSilent:
 
     def test_two_elements_does_not_warn(self) -> None:

--- a/tests/test_dev1745_reachability.py
+++ b/tests/test_dev1745_reachability.py
@@ -40,6 +40,7 @@ from slayer.core.keys import (
     LiteralKey,
     Phase,
     ScalarCallKey,
+    SqlExprKey,
 )
 from slayer.core.models import Column, ModelJoin, SlayerModel
 from slayer.core.query import SlayerQuery
@@ -245,8 +246,6 @@ class TestCompositeKeyKindsAreTotal:
         """``SqlExprKey`` carries its own precomputed crossed paths (a
         ``Column.filter`` interned onto an aggregate). It has an arm in the
         scan; this pins it."""
-        from slayer.core.keys import SqlExprKey
-
         key = SqlExprKey(
             canonical_sql="customers__regions.population > 1",
             referenced_join_paths=(("customers", "regions"),),
@@ -262,8 +261,6 @@ class TestCompositeKeyKindsAreTotal:
         ``source.path``. ``customers.balance:sum`` with a filter on
         ``regions.name`` must contribute ``("customers","regions")`` — never
         bare ``("regions",)``, which ``classify_host_filter`` would mis-route."""
-        from slayer.core.keys import SqlExprKey
-
         key = AggregateKey(
             agg="sum",
             source=ColumnKey(path=("customers",), leaf="balance"),

--- a/tests/test_dev1745_reachability.py
+++ b/tests/test_dev1745_reachability.py
@@ -255,6 +255,28 @@ class TestCompositeKeyKindsAreTotal:
         assert ("customers",) in paths, paths
         assert ("customers", "regions") in paths, paths
 
+    def test_aggregate_column_filter_key_is_owner_relative(self) -> None:
+        """DEV-1783 item 1. ``AggregateKey.column_filter_key`` paths are
+        OWNER-relative (anchored at the aggregated column's owner, reached via
+        ``source.path``), so the scan must re-anchor them by prefixing
+        ``source.path``. ``customers.balance:sum`` with a filter on
+        ``regions.name`` must contribute ``("customers","regions")`` — never
+        bare ``("regions",)``, which ``classify_host_filter`` would mis-route."""
+        from slayer.core.keys import SqlExprKey
+
+        key = AggregateKey(
+            agg="sum",
+            source=ColumnKey(path=("customers",), leaf="balance"),
+            column_filter_key=SqlExprKey(
+                canonical_sql="regions.name = 'Alpha'",
+                referenced_join_paths=(("regions",),),
+            ),
+        )
+        paths = _paths_for(key)
+        assert ("customers",) in paths, paths
+        assert ("customers", "regions") in paths, paths
+        assert ("regions",) not in paths, paths
+
     def test_in_values_are_walked_for_crossings(self) -> None:
         """``InKey.values`` are walked by the crossing scan, so a crossing
         reference sitting in the value list is a dependency like any other."""

--- a/tests/test_dev1746_isolation_classifier.py
+++ b/tests/test_dev1746_isolation_classifier.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import pytest
 
 from slayer.core.enums import TimeGranularity
+from slayer.core.keys import AggregateKey, ColumnKey, SqlExprKey
 from slayer.core.models import ModelMeasure
 from slayer.core.query import ColumnRef, SlayerQuery, TimeDimension
 from slayer.engine import isolation as isolation_mod
@@ -378,8 +379,6 @@ class TestCrossingInputPathsUnionsFilterAndStructural:
     decision and letting a fan-out-multiplying aggregate inline."""
 
     def test_filter_and_kwarg_crossings_are_both_reported(self) -> None:
-        from slayer.core.keys import AggregateKey, ColumnKey, SqlExprKey
-
         key = AggregateKey(
             agg="sum",
             source=ColumnKey(path=(), leaf="amount"),

--- a/tests/test_dev1746_isolation_classifier.py
+++ b/tests/test_dev1746_isolation_classifier.py
@@ -368,3 +368,29 @@ class TestMayInlineSeam:
         assert ScopeFrame.may_inline(
             ScopeFrame.__new__(ScopeFrame), [("customers_v2",)],
         ) is False
+
+
+class TestCrossingInputPathsUnionsFilterAndStructural:
+    """DEV-1783 item 6 — ``_crossing_input_paths`` must UNION a local
+    aggregate's ``Column.filter`` crossings with its structural input crossings
+    (source ``Column.sql`` / args / kwargs). The pre-fix early-return reported
+    the filter paths ALONE, hiding a crossing kwarg from the isolation
+    decision and letting a fan-out-multiplying aggregate inline."""
+
+    def test_filter_and_kwarg_crossings_are_both_reported(self) -> None:
+        from slayer.core.keys import AggregateKey, ColumnKey, SqlExprKey
+
+        key = AggregateKey(
+            agg="sum",
+            source=ColumnKey(path=(), leaf="amount"),
+            kwargs=(("weight", ColumnKey(path=("customers_v2",), leaf="balance")),),
+            column_filter_key=SqlExprKey(
+                canonical_sql="customers_v2__regions.name = 'X'",
+                referenced_join_paths=(("customers_v2", "regions"),),
+            ),
+        )
+        paths = isolation_mod._crossing_input_paths(key=key, bundle=_bundle())
+        assert ("customers_v2", "regions") in paths, paths  # column_filter_key
+        assert ("customers_v2",) in paths, paths            # kwarg — dropped pre-fix
+        # Order-stable + de-duplicated: filter paths first, then structural.
+        assert paths == [("customers_v2", "regions"), ("customers_v2",)], paths

--- a/tests/test_dev1746_pagination.py
+++ b/tests/test_dev1746_pagination.py
@@ -336,15 +336,25 @@ class TestEmitOuterWrapInjectsOrderingForOffset:
     def _offset(n: int) -> exp.Offset:
         return exp.Offset(expression=exp.Literal.number(n))
 
+    @staticmethod
+    def _assert_bare_offset_guarded(out: str) -> None:
+        """OFFSET is emitted, ordered by the synthesized no-op (a ``SELECT NULL``
+        subquery — sqlglot renders it via its NULLS-ordering ``CASE`` form, not a
+        literal ``ORDER BY (SELECT NULL)``), never a real column."""
+        assert re.search(r"\bORDER\s+BY\b", out, re.IGNORECASE), (
+            f"tsql outer-wrap emitted OFFSET without ORDER BY:\n{out}"
+        )
+        assert "OFFSET" in out.upper(), out
+        assert re.search(r"SELECT\s+NULL", out, re.IGNORECASE), (
+            f"OFFSET ordering is not the synthesized no-op:\n{out}"
+        )
+
     def test_ast_path_injects_ordering_for_a_bare_offset(self) -> None:
         out = get_dialect("tsql").emit_outer_wrap(
             inner_sql="SELECT 1 AS a", public=["a"],
             order=None, limit=None, offset_arg=self._offset(5),
         )
-        assert re.search(r"\bORDER\s+BY\b", out, re.IGNORECASE), (
-            f"tsql outer-wrap emitted OFFSET without ORDER BY:\n{out}"
-        )
-        assert "OFFSET" in out.upper(), out
+        self._assert_bare_offset_guarded(out)
 
     def test_base_fallback_injects_ordering_for_a_bare_offset(self) -> None:
         """A UNION inner parses to a non-``Select`` and takes the base-impl
@@ -354,9 +364,7 @@ class TestEmitOuterWrapInjectsOrderingForOffset:
             inner_sql="SELECT 1 AS a UNION SELECT 2 AS a", public=["a"],
             order=None, limit=None, offset_arg=self._offset(5),
         )
-        assert re.search(r"\bORDER\s+BY\b", out, re.IGNORECASE), (
-            f"tsql outer-wrap fallback emitted OFFSET without ORDER BY:\n{out}"
-        )
+        self._assert_bare_offset_guarded(out)
 
     def test_user_order_is_never_replaced(self) -> None:
         user_order = exp.Order(expressions=[
@@ -368,6 +376,10 @@ class TestEmitOuterWrapInjectsOrderingForOffset:
         )
         assert "SELECT NULL" not in out.upper(), (
             f"the user's ORDER BY was replaced by the fallback ordering:\n{out}"
+        )
+        assert "OFFSET" in out.upper(), out
+        assert re.search(r"\bORDER\s+BY\b.*\[a\]", out, re.IGNORECASE | re.DOTALL), (
+            f"the user's ORDER BY column was dropped:\n{out}"
         )
 
 

--- a/tests/test_dev1746_pagination.py
+++ b/tests/test_dev1746_pagination.py
@@ -324,6 +324,54 @@ class TestApplyPaginationHook:
 
 
 # =========================================================================== #
+# DEV-1783 item 2 — the OTHER outer wrap (emit_outer_wrap), which had no guard.
+# =========================================================================== #
+class TestEmitOuterWrapInjectsOrderingForOffset:
+    """``emit_outer_wrap`` (transform-chain / cross-model combined outer wrap)
+    must apply the same OFFSET-needs-ORDER-BY guard ``apply_pagination`` does —
+    SQL Server rejects OFFSET without ORDER BY. The guard must cover the AST
+    path AND the base-impl fallback taken for a non-``Select`` inner."""
+
+    @staticmethod
+    def _offset(n: int) -> exp.Offset:
+        return exp.Offset(expression=exp.Literal.number(n))
+
+    def test_ast_path_injects_ordering_for_a_bare_offset(self) -> None:
+        out = get_dialect("tsql").emit_outer_wrap(
+            inner_sql="SELECT 1 AS a", public=["a"],
+            order=None, limit=None, offset_arg=self._offset(5),
+        )
+        assert re.search(r"\bORDER\s+BY\b", out, re.IGNORECASE), (
+            f"tsql outer-wrap emitted OFFSET without ORDER BY:\n{out}"
+        )
+        assert "OFFSET" in out.upper(), out
+
+    def test_base_fallback_injects_ordering_for_a_bare_offset(self) -> None:
+        """A UNION inner parses to a non-``Select`` and takes the base-impl
+        fallback, which also appends OFFSET with no ORDER BY. The guard runs
+        before branching, so the fallback receives the synthesized ordering."""
+        out = get_dialect("tsql").emit_outer_wrap(
+            inner_sql="SELECT 1 AS a UNION SELECT 2 AS a", public=["a"],
+            order=None, limit=None, offset_arg=self._offset(5),
+        )
+        assert re.search(r"\bORDER\s+BY\b", out, re.IGNORECASE), (
+            f"tsql outer-wrap fallback emitted OFFSET without ORDER BY:\n{out}"
+        )
+
+    def test_user_order_is_never_replaced(self) -> None:
+        user_order = exp.Order(expressions=[
+            exp.Ordered(this=exp.column("a", quoted=True)),
+        ])
+        out = get_dialect("tsql").emit_outer_wrap(
+            inner_sql="SELECT 1 AS a", public=["a"],
+            order=user_order, limit=None, offset_arg=self._offset(5),
+        )
+        assert "SELECT NULL" not in out.upper(), (
+            f"the user's ORDER BY was replaced by the fallback ordering:\n{out}"
+        )
+
+
+# =========================================================================== #
 # Execution — pagination changes row sets, so parse-only is not enough (D5).
 # =========================================================================== #
 class TestPaginationExecution:

--- a/tests/test_dev1783_pr286_g1.py
+++ b/tests/test_dev1783_pr286_g1.py
@@ -64,8 +64,9 @@ class TestNtileNIsNormalised:
 
     def test_non_integral_decimal_is_rejected_not_truncated(self) -> None:
         """``Decimal("2.7")`` used to truncate to ``NTILE(2)`` silently."""
+        n = Decimal("2.7")
         with pytest.raises(ValueError):
-            _render_ntile(Decimal("2.7"))
+            _render_ntile(n)
 
     def test_bool_is_rejected(self) -> None:
         """``True`` is an ``int`` subclass, so ``isinstance(n, int)`` used to

--- a/tests/test_dev1783_pr286_g1.py
+++ b/tests/test_dev1783_pr286_g1.py
@@ -1,0 +1,109 @@
+"""DEV-1783 — PR #286 review G1 production-correctness fixes.
+
+Items 3 and 5, which have no natural home in an existing test module:
+
+* item 3 — ``ntile``'s ``n`` must route through ``_normalise_periods`` in the
+  generator, rejecting bool / non-integral Decimal rather than truncating
+  (``NTILE(2)`` for ``Decimal("2.7")``) or emitting ``NTILE(True)``. The binder
+  already gates this at bind time (``_ensure_positive_integer``); this pins the
+  generator's own defense-in-depth, so the test drives the render method with a
+  hand-built ``TransformKey`` the binder would have rejected.
+* item 5 — a HOST-ROOTED route must leave ``where_ids`` empty: the sub-plan
+  carries these predicates as its own filters, so listing them as forward-CTE
+  ``where_filter_ids`` (an instruction to the host base to SKIP them) is wrong.
+
+Items 1/2/6/7 live in their domain modules (reachability / pagination /
+isolation-classifier / date-range-warning). Item 4 is REJECTED as invalid — its
+"narrow the clear" fix would regress
+``test_dev1747_reroot_filter_routing.py::TestRerootedAggregateRefFilter``,
+turning a deliberate ``NotImplementedError`` into a silent wrong answer.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from slayer.core.keys import ColumnKey, Phase, TransformKey
+from slayer.engine.binding import BoundFilter
+from slayer.engine.cross_model_planner import (
+    HostFilterRouting,
+    _route_host_rooted_filters,
+)
+from slayer.engine.planned import ValueSlot
+from slayer.sql.generator import SQLGenerator
+
+
+# --------------------------------------------------------------------------- #
+# Item 3 — ntile n normalisation in the generator
+# --------------------------------------------------------------------------- #
+def _render_ntile(n) -> str:
+    """Render an ``ntile(revenue:sum, n=<n>)`` transform through the generator's
+    window-transform path, with a minimally-materialised input slot."""
+    gen = SQLGenerator(dialect="postgres")
+    input_key = ColumnKey(path=(), leaf="revenue")
+    nt_key = TransformKey(op="ntile", input=input_key, kwargs=(("n", n),))
+    in_slot = ValueSlot(
+        id="s_in", key=input_key, declared_name="revenue", phase=Phase.ROW,
+    )
+    nt_slot = ValueSlot(
+        id="s_nt", key=nt_key, declared_name="bucket", phase=Phase.POST,
+    )
+    return gen._render_window_transform_sql(
+        slot=nt_slot,
+        slots_by_id={"s_in": in_slot, "s_nt": nt_slot},
+        slot_id_by_key={input_key: "s_in", nt_key: "s_nt"},
+        available_alias_by_slot_id={"s_in": "revenue"},
+        planned_query=SimpleNamespace(projection=[]),
+    ).sql(dialect="postgres")
+
+
+class TestNtileNIsNormalised:
+
+    def test_non_integral_decimal_is_rejected_not_truncated(self) -> None:
+        """``Decimal("2.7")`` used to truncate to ``NTILE(2)`` silently."""
+        with pytest.raises(ValueError):
+            _render_ntile(Decimal("2.7"))
+
+    def test_bool_is_rejected(self) -> None:
+        """``True`` is an ``int`` subclass, so ``isinstance(n, int)`` used to
+        wave it through to ``NTILE(...)``."""
+        nt_key = TransformKey(op="ntile", input=ColumnKey(path=(), leaf="x"),
+                              kwargs=(("n", True),))
+        # Guard: only meaningful if the model kept the bool as a bool.
+        if dict(nt_key.kwargs).get("n") is not True:
+            pytest.skip("bool coerced away by the model; covered by the Decimal case")
+        with pytest.raises(ValueError):
+            _render_ntile(True)
+
+    def test_a_valid_integer_still_renders(self) -> None:
+        sql = _render_ntile(4)
+        assert "NTILE(4)" in sql.upper().replace(" ", ""), sql
+
+
+# --------------------------------------------------------------------------- #
+# Item 5 — host-rooted routes leave where_ids empty
+# --------------------------------------------------------------------------- #
+class TestHostRootedRoutesLeaveWhereIdsEmpty:
+
+    @staticmethod
+    def _row_routing(fid: str) -> HostFilterRouting:
+        return HostFilterRouting(
+            filter_id=fid,
+            phase=Phase.ROW,
+            text="status = 'paid'",
+            bound=BoundFilter(
+                value_key=ColumnKey(path=(), leaf="status"), phase=Phase.ROW,
+            ),
+        )
+
+    def test_where_ids_is_empty_but_applied_is_populated(self) -> None:
+        routes = _route_host_rooted_filters(host_filters=[self._row_routing("f1")])
+        assert routes.applied == ["f1"], routes
+        # ``where_ids`` is an instruction to the host base to SKIP the filter as
+        # forward-CTE-delegated. A host-rooted CTE has no forward CTE, so it must
+        # stay empty; the sub-plan already carries the predicate.
+        assert routes.where_ids == [], routes
+        assert routes.having_ids == [], routes


### PR DESCRIPTION
## DEV-1783 — PR #286 review G1: production correctness fixes

Group 1 of 4 from the CodeRabbit-review triage of umbrella PR #286. Targets the
umbrella branch (`egor/dev-1742-one-doctrine-consolidation-of-sql-generation-dev-1450`).

Each of the 7 triage items was re-validated against the current code. **6 are fixed; item 4 is rejected as invalid** (details below). Every fix lands with a test that fails without it.

### Fixes

1. **`filter_reachability` — `column_filter_key` paths mis-anchored.** `_child_keys` yielded `AggregateKey.column_filter_key` as a plain child, so the walk recorded its `referenced_join_paths` anchor-rooted — but they are OWNER-relative (`binding._resolve_column_filter_key` anchors them at the model owning the filtered column). `customers.spend:sum` with a filter on `regions.name` contributed bare `("regions",)` instead of `("customers","regions")`, mis-routing/dropping a legitimate filter. Now re-anchored by prefixing `source.path` in `compute_key_join_paths`.
2. **`tsql.emit_outer_wrap` — OFFSET without ORDER BY.** SQL Server rejects it. Synthesize `ORDER BY (SELECT NULL)` (as `apply_pagination` does) **before branching**, so both the AST path and the base-impl fallback (a non-`Select` inner such as a UNION — `base.py` also emits a bare OFFSET) are legal. A user's ORDER BY is never replaced.
3. **`generator` ntile `n` not normalised.** `isinstance(n, int)` accepted `bool` (`NTILE(True)`) and `int(Decimal("2.7"))` truncated silently. Now routed through `_normalise_periods` (as lag/lead already are).
4. **`_route_host_rooted_filters` — `where_ids` populated.** Host-rooted routes returned `where_ids = applied`, but `where_ids` is the forward-CTE delegation instruction (host base SKIPs). A host-rooted CTE has no forward CTE and the sub-plan already carries the predicates, so `where_ids` now stays empty (the sole consumer already hardcoded `where_filter_ids=[]`; this removes a latent trap).
5. **`isolation._crossing_input_paths` — early-return instead of union.** When `column_filter_key` contributed paths it returned them alone, ignoring the structural source/args/kwargs crossings → the isolation decision under-counted and could inline a fan-out-multiplying input. Now unioned (order-stable, de-duplicated).
6. **`MALFORMED_DATE_RANGE` warning claimed a rewrite that never happens.** The planner silently no-ops the malformed range, but `human_message`/carrier said "rewrote X → Y". Added `NormalizationWarning.rewritten` and corrected the wording on both surfaces (single source of truth). No behavior change.

### Item 4 (reroot over-clears `having_filter_ids`) — rejected as invalid

The proposed "narrow the clear to `where_filter_ids`" would **regress** `test_dev1747_reroot_filter_routing.py::TestRerootedAggregateRefFilter`. For a re-rooted cross-model plan `cte_root_model` is `None`, so `_plan_outer_where_filters` does not lift the AGGREGATE-phase predicate to the outer WHERE, and the re-rooted nested plan renders via its own path (not the forward `_cm_` HAVING). Keeping `having_filter_ids` would tell the host base to SKIP a predicate nothing else applies → a silent wrong answer (rows the user excluded return with NULL measures). The current "clear both + loud `NotImplementedError`" is the deliberate DEV-1747 B6 choice: an unsupported query beats a wrong one. (Confirmed by an independent Codex review of the plan.)

### Verification

- Full non-integration suite: **11635 passed, 4 skipped, 3 xfailed** (0 failures).
- `ruff check slayer/ tests/`: clean.

Closes DEV-1783.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization warnings to distinguish between rewritten and reported-only values.
  * Corrected filter routing and aggregate path handling for nested queries.
  * Ensured combined filter and structural paths are preserved without duplicates.
  * Fixed pagination with offsets but no ordering by adding a safe default ordering.
  * Tightened `ntile` validation to reject booleans and non-integral decimal values.
* **Tests**
  * Added coverage for warning messages, nested aggregate filters, query isolation, pagination, and `ntile` validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->