### PR TITLE
Don't let a failed PK lookup skip the whole table

### DIFF
--- a/slayer/engine/ingestion.py
+++ b/slayer/engine/ingestion.py
@@ -60,6 +60,10 @@ logger = logging.getLogger(__name__)
 # _sa_type_to_data_type). Keyed by upper-cased class name.
 _logged_unmapped_sa_types: set[str] = set()
 
+# Inspectors that report primary keys correctly, so empty means "no primary
+# key" rather than "ask INFORMATION_SCHEMA" (which BigQuery cannot resolve).
+_PK_AUTHORITATIVE_DIALECTS = frozenset({"sqlite", "bigquery"})
+
 # Database types with no usable equality operator — grouping, DISTINCT or
 # aggregating them fails at the database ("could not identify an equality
 # operator for type point"). These map to ``DataType.UNKNOWN``: stored and
@@ -737,9 +741,10 @@ def _safe_get_pk_constraint(
     """Get PK constraint, falling back to INFORMATION_SCHEMA on failure.
 
     ALWAYS returns a mapping — the one place normalizing an inspector that may
-    hand back ``None``. SQLite's PRAGMA reflection is authoritative.
+    hand back ``None``. Having no primary key is a normal shape, so a failed
+    lookup yields no columns rather than sinking the whole table.
     """
-    if sa_engine.dialect.name == "sqlite":
+    if sa_engine.dialect.name in _PK_AUTHORITATIVE_DIALECTS:
         try:
             result = inspector.get_pk_constraint(table_name=table_name, schema=schema)
         except Exception:
@@ -747,12 +752,16 @@ def _safe_get_pk_constraint(
         return result if isinstance(result, dict) else {"constrained_columns": []}
     try:
         result = inspector.get_pk_constraint(table_name, schema=schema)
-        if result.get("constrained_columns"):
+        if result and result.get("constrained_columns"):
             return result
-        # DuckDB's inspector returns empty PK — try INFORMATION_SCHEMA
+    except Exception:
+        logger.debug("Inspector PK lookup failed for %r", table_name, exc_info=True)
+    # DuckDB's inspector returns empty PK — try INFORMATION_SCHEMA.
+    try:
         return _get_pk_constraint_fallback(sa_engine, table_name, schema)
     except Exception:
-        return _get_pk_constraint_fallback(sa_engine, table_name, schema)
+        logger.debug("PK fallback failed for %r", table_name, exc_info=True)
+        return {"constrained_columns": []}
 
 
 def _introspect_query_columns_via_inspector(

--- a/slayer/engine/ingestion.py
+++ b/slayer/engine/ingestion.py
@@ -732,6 +732,20 @@ def _get_pk_constraint_fallback(
     return {"constrained_columns": [row[0] for row in rows]}
 
 
+def _normalized_pk(result: object) -> dict | None:
+    """The inspector's mapping if it carries a list of column names, else None.
+
+    Callers feed ``constrained_columns`` straight to ``set()``, where ``None``
+    raises and a bare string silently becomes a set of characters.
+    """
+    if not isinstance(result, dict):
+        return None
+    columns = result.get("constrained_columns")
+    if isinstance(columns, list) and all(isinstance(c, str) for c in columns):
+        return result
+    return None
+
+
 def _safe_get_pk_constraint(
     inspector: sa.engine.Inspector,
     sa_engine: sa.Engine,
@@ -749,11 +763,11 @@ def _safe_get_pk_constraint(
             result = inspector.get_pk_constraint(table_name=table_name, schema=schema)
         except Exception:
             return {"constrained_columns": []}
-        return result if isinstance(result, dict) else {"constrained_columns": []}
+        return _normalized_pk(result) or {"constrained_columns": []}
     try:
-        result = inspector.get_pk_constraint(table_name, schema=schema)
-        if result and result.get("constrained_columns"):
-            return result
+        normalized = _normalized_pk(inspector.get_pk_constraint(table_name, schema=schema))
+        if normalized and normalized["constrained_columns"]:
+            return normalized
     except Exception:
         logger.debug("Inspector PK lookup failed for %r", table_name, exc_info=True)
     # DuckDB's inspector returns empty PK — try INFORMATION_SCHEMA.

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -247,6 +247,85 @@ class TestGenerateJoinsDedup:
         assert len(joins) == 1
 
 
+class TestPkFallbackNeverSinksTheTable:
+    """A failing PK lookup must not take the table down with it.
+
+    BigQuery skipped every table: its inspector reports no primary keys, the
+    empty result was read as failure, and the unqualified INFORMATION_SCHEMA
+    fallback raised from both branches — the second time uncaught.
+    """
+
+    @staticmethod
+    def _inspector(pk):
+        inspector = MagicMock()
+        inspector.get_pk_constraint.return_value = pk
+        return inspector
+
+    @staticmethod
+    def _engine(dialect_name):
+        engine = MagicMock(spec=sa.Engine)
+        engine.dialect = MagicMock()
+        engine.dialect.name = dialect_name
+        return engine
+
+    def test_bigquery_skips_the_fallback_entirely(self):
+        """It can only fail there, and each attempt is a billed query."""
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback"
+        ) as fallback:
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector({"constrained_columns": []}),
+                sa_engine=self._engine("bigquery"),
+                table_name="orders",
+                schema="core",
+            )
+        assert result == {"constrained_columns": []}
+        fallback.assert_not_called()
+
+    def test_failing_fallback_yields_no_pk_instead_of_raising(self):
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback",
+            side_effect=Exception("403 Access Denied: information_schema"),
+        ) as fallback:
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector({"constrained_columns": []}),
+                sa_engine=self._engine("postgresql"),
+                table_name="orders",
+                schema="public",
+            )
+        assert result == {"constrained_columns": []}
+        # Once, not twice: the old except branch re-ran the failing call.
+        assert fallback.call_count == 1
+
+    def test_fallback_still_answers_when_the_inspector_is_empty(self):
+        """DuckDB's case — the reason the fallback exists."""
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback",
+            return_value={"constrained_columns": ["id"]},
+        ) as fallback:
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector({"constrained_columns": []}),
+                sa_engine=self._engine("duckdb"),
+                table_name="orders",
+                schema=None,
+            )
+        assert result == {"constrained_columns": ["id"]}
+        assert fallback.call_count == 1
+
+    def test_inspector_pk_short_circuits_the_fallback(self):
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback"
+        ) as fallback:
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector({"constrained_columns": ["id"]}),
+                sa_engine=self._engine("postgresql"),
+                table_name="orders",
+                schema=None,
+            )
+        assert result == {"constrained_columns": ["id"]}
+        fallback.assert_not_called()
+
+
 class TestSqliteSafeGetters:
     """Regression tests: SQLite engines must not hit information_schema fallback.
 

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -312,6 +312,47 @@ class TestPkFallbackNeverSinksTheTable:
         assert result == {"constrained_columns": ["id"]}
         assert fallback.call_count == 1
 
+    @pytest.mark.parametrize(
+        "malformed",
+        [
+            {"constrained_columns": None},
+            {"constrained_columns": "id"},
+            {"constrained_columns": [1, 2]},
+            {},
+            None,
+        ],
+        ids=["none", "bare-string", "non-str-items", "missing-key", "not-a-dict"],
+    )
+    def test_malformed_inspector_pk_normalizes(self, malformed):
+        """Callers feed the value to set(): None raises, a string splits to chars."""
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback",
+            return_value={"constrained_columns": []},
+        ):
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector(malformed),
+                sa_engine=self._engine("bigquery"),
+                table_name="orders",
+                schema=None,
+            )
+        assert result == {"constrained_columns": []}
+        assert set(result.get("constrained_columns", [])) == set()
+
+    def test_malformed_pk_still_reaches_the_fallback(self):
+        """Unusable is not an answer — try INFORMATION_SCHEMA, as for empty."""
+        with patch(
+            "slayer.engine.ingestion._get_pk_constraint_fallback",
+            return_value={"constrained_columns": ["id"]},
+        ) as fallback:
+            result = _safe_get_pk_constraint(
+                inspector=self._inspector({"constrained_columns": "id"}),
+                sa_engine=self._engine("postgresql"),
+                table_name="orders",
+                schema=None,
+            )
+        assert result == {"constrained_columns": ["id"]}
+        assert fallback.call_count == 1
+
     def test_inspector_pk_short_circuits_the_fallback(self):
         with patch(
             "slayer.engine.ingestion._get_pk_constraint_fallback"


### PR DESCRIPTION
Ingesting a BigQuery datasource skipped **every** table, leaving `created=0` with no errors recorded:

```
Reflected 7 tables for source <id>
Skipping table '<table>' ... 403 Access Denied: Table
  <project>:information_schema.key_column_usage
[SQL: SELECT kcu.column_name FROM information_schema.table_constraints tc
      JOIN information_schema.key_column_usage kcu ...]
SLayer reflection: created=0 updated=0 errors=0
```

## Cause

`_safe_get_pk_constraint` called the fallback from both branches:

```python
try:
    result = inspector.get_pk_constraint(...)
    if result.get("constrained_columns"):
        return result
    return _get_pk_constraint_fallback(...)   # raises here
except Exception:
    return _get_pk_constraint_fallback(...)   # same call again, uncaught
```

BigQuery's inspector hardcodes an empty PK list, so the empty result is read as "inspector failed" and the fallback runs. Its `information_schema` reference is unqualified — BigQuery needs `<dataset>.INFORMATION_SCHEMA.*` — so it raises **inside** the `try`, the `except` re-runs the identical call, and the second failure escapes, taking the table's model with it.

Reproduced with the fallback mocked to raise: **call count 2**, exception propagates.

Note `errors=0` next to `created=0` — tables are skipped upstream of the error accounting, so nothing surfaced as a failure.

## Fix

1. **The fallback runs at most once and never propagates.** Having no primary key is a normal shape (views, BigQuery), so a failed lookup returns no columns rather than sinking the table.
2. **BigQuery joins SQLite as PK-authoritative.** Its inspector is already correct, and the fallback there can only ever fail — at the cost of a billed query per table. Now zero.

## Testing

Four tests pinning each dialect path; reverting the fix fails two of them.

| case | fallback calls | result |
|---|---|---|
| bigquery, empty PK | 0 | no PK |
| postgres, fallback 403s | 1 | no PK (was: raise) |
| postgres, fallback answers | 1 | PK returned |
| postgres, inspector has PK | 0 | PK returned |
| duckdb, empty PK | 1 | PK returned |
| sqlite | 0 | authoritative |

Full suite: **8034 passed**, 83 skipped, 4 xfailed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved primary-key detection for SQLite and BigQuery.
  * Prevented ingestion failures when primary-key metadata is unavailable or malformed.
  * Preserved fallback detection for other database types.
  * Added safer handling when metadata lookups fail, avoiding unnecessary errors or retries.

* **Tests**
  * Added regression coverage for primary-key detection and fallback behavior across supported database types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->