### PR TITLE
Accept SQL-cased boolean literals in filters

### DIFF
--- a/slayer/core/formula.py
+++ b/slayer/core/formula.py
@@ -1277,7 +1277,18 @@ def _attribute_to_sql(node: ast.Attribute, columns: list[str]) -> str:
     return dotted
 
 
+#: SQL spells its boolean literals in lower case, but Python's ``ast`` only
+#: recognises ``True`` / ``False`` as constants — every other casing arrives
+#: here as a name and would otherwise be resolved as a column.
+_SQL_BOOLEAN_LITERALS = {"true": "TRUE", "false": "FALSE"}
+
+
 def _name_to_sql(node: ast.Name, columns: list[str]) -> str:
+    literal = _SQL_BOOLEAN_LITERALS.get(node.id.lower())
+    if literal is not None:
+        # Deliberately not appended to ``columns``: it is a value, not a
+        # reference, so strict name resolution must not see it.
+        return literal
     if node.id != "None":
         columns.append(node.id)
     return node.id

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -431,6 +431,45 @@ class TestExtractFilterTransforms:
         assert "price:weighted_avg(col1, weight=quantity)" in transforms[0][1]
 
 
+class TestParseFilterBooleanLiterals:
+    """SQL spells its boolean literals in lower case; Python's ``ast`` does not.
+
+    ``true`` / ``false`` arrive as names rather than constants, so without
+    special handling they are collected as column references and then rejected
+    as unknown names.
+    """
+
+    @pytest.mark.parametrize(
+        ("expression", "expected"),
+        [
+            ("is_active = true", "is_active = TRUE"),
+            ("is_active = false", "is_active = FALSE"),
+            ("is_active = TRUE", "is_active = TRUE"),
+            ("is_active <> false", "is_active != FALSE"),
+        ],
+    )
+    def test_boolean_literal_renders_as_sql(
+        self, expression: str, expected: str,
+    ) -> None:
+        parsed = parse_filter(expression)
+        assert parsed.sql == expected
+        # A literal is a value, not a reference — strict name resolution in
+        # enrichment rejects anything that lands in ``columns``.
+        assert parsed.columns == ["is_active"]
+
+    def test_python_cased_literals_keep_working(self) -> None:
+        """``True`` / ``False`` are ``ast`` constants, so they never reached
+        the name path. SQL keywords are case-insensitive, so both render fine."""
+        assert parse_filter("is_active = True").sql == "is_active = True"
+        assert parse_filter("is_active = False").sql == "is_active = False"
+
+    def test_bare_literal_is_not_a_column_reference(self) -> None:
+        """Documents the trade-off: ``true`` always wins over a same-named
+        column. Both spellings are SQL reserved words, so no dialect allows
+        them as unquoted column names anyway."""
+        assert parse_filter("true").columns == []
+
+
 class TestParseFilterInjection:
     """SQL-injection hardening for ``parse_filter``.
 


### PR DESCRIPTION
## The problem

`is_active = true` fails:

```
ValueError: Filter references unknown name 'true' on model 'orders'. It is not a
Column, a ModelMeasure, a custom aggregation, or a named measure / transform
alias in this query. Define it on the model first or check spelling.
```

Python's `ast` recognises only `True` / `False` as constants. Every other casing parses as `ast.Name`, so `_name_to_sql` appends it to the collected column references, and strict name resolution in enrichment then rejects it as an unknown column.

SQL spells its booleans lower case, so this is the spelling anyone coming from SQL — or any LLM agent — writes first.

## From production

A customer's agent, filtering to completed months:

| sent | result |
|---|---|
| `is_complete_month = true` | `Filter references unknown name 'true'` |
| `is_complete_month = 1` | BigQuery 400: `No matching signature for operator = for argument types: BOOL, INT64` |

It then abandoned the filter and queried unfiltered data. The second attempt is a direct consequence of the first: the error told it the *name* was wrong, so it changed the value.

## The fix

`true` / `false` render as SQL literals in any casing, and are kept out of the collected column references — they are values, not references:

```
is_active = true   ->  is_active = TRUE
is_active <> false ->  is_active != FALSE
```

`True` / `False` are unaffected: they never reached the name path, and SQL keywords are case-insensitive so `str(True)` was already valid.

The trade-off is that a column named `true` could no longer be referenced unquoted in a filter. Both spellings are reserved words in every dialect we target, so no such column can exist unquoted anyway; a test documents this.

## Still open

`<boolean column> = 1` continues to emit `<expr> = 1`, which DuckDB accepts and BigQuery and Postgres reject. Fixing it needs the column's type at filter-parse time, and `parse_filter` currently receives no model. That is a wider change than this one, so it is deliberately not in scope here — see the PR discussion.

## Testing

`TestParseFilterBooleanLiterals` covers all four casings plus the constant path. Ran the filter, formula, predicate, cube-filter, dbt-filter, named-measure and model suites locally: 563 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean filter values now generate valid SQL `TRUE` and `FALSE` literals.
  * Boolean literals are no longer incorrectly treated as column references.
  * Lowercase and uppercase boolean values are supported consistently in filter comparisons.

* **Tests**
  * Added coverage for boolean parsing, SQL rendering, and column-reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->