### PR TITLE
Document that HAVING filters depend on the group grain

### DIFF
--- a/slayer/memories/help_content/06_filters.md
+++ b/slayer/memories/help_content/06_filters.md
@@ -47,6 +47,13 @@ Multiple entries in the `filters` list are AND-ed:
 
 Inner and outer filters can mix in one query — {{product}} splits them.
 
+**A HAVING filter depends on the group grain.** `revenue:sum < 0` compares
+the sum *per group*, so the same filter can keep or drop a row set as the
+`dimensions` change. Two queries with the same filter but different
+dimensions can return different cohorts — that is correct SQL, not a bug.
+To define a cohort, prefer the predicate the model documents (for example
+a filtered column — see below) over a proxy filter on an aggregate.
+
 ## Filtering on computed measures
 
 Reference a named measure from `measures` by its `name`:


### PR DESCRIPTION
## Summary

From the Rentman session postmortem: an agent filtered on `cmrr_contraction:sum < 0` as a cohort proxy and got 114 vs 115 rows depending on the group grain. Correct SQL, but `help.filters` did not warn about it.

Add a note to the auto-routing section: a HAVING filter compares the aggregate per group, so the same filter can return different cohorts as the dimensions change; prefer the model's documented predicate (e.g. a filtered column) for cohort definitions.

## Testing

`tests/test_help_seed.py` and `tests/test_yaml_memories_mdfiles.py` pass (75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `HAVING` filters are evaluated at the group level.
  * Explained that changing dimensions can affect the resulting cohort.
  * Recommended using documented cohort predicates, such as filtered columns, instead of aggregate proxy filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->