### PR TITLE
Fix DuckDB cursor type classification

### DIFF
--- a/slayer/sql/client.py
+++ b/slayer/sql/client.py
@@ -192,18 +192,22 @@ def _map_type_code(type_code, db_type: str | None = None) -> str:
     """
     if isinstance(type_code, int) and db_type:
         from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
+
         dialect_category = dialect_for_ds_type(db_type).map_cursor_type_code(type_code)
         if dialect_category is not None:
             return dialect_category
+    if db_type and "duckdb" in db_type.lower():
+        # DuckDB returns ``DuckDBPyType`` objects whose string form is the type name.
+        type_code = str(type_code)
     if isinstance(type_code, str):
-        # DuckDB returns type name strings like 'INTEGER', 'VARCHAR', etc.
         tc = type_code.upper()
+        # Check temporal names before numeric ones: INTERVAL contains "INT".
+        if any(t in tc for t in ("TIMESTAMP", "DATE", "TIME", "INTERVAL")):
+            return "time"
         if any(t in tc for t in ("INT", "FLOAT", "DOUBLE", "DECIMAL", "NUMERIC", "REAL")):
             return "number"
         if any(t in tc for t in ("VARCHAR", "TEXT", "CHAR", "STRING", "BLOB", "ENUM")):
             return "string"
-        if any(t in tc for t in ("TIMESTAMP", "DATE", "TIME", "INTERVAL")):
-            return "time"
         if "BOOL" in tc:
             return "boolean"
         return "string"

--- a/slayer/sql/client.py
+++ b/slayer/sql/client.py
@@ -12,10 +12,13 @@ import sqlalchemy as sa
 import sqlalchemy.engine.url
 import sqlalchemy.event as sa_event
 import sqlalchemy.exc
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import StaticPool
 
 from slayer.core.models import DatasourceConfig
 from slayer.engine import timing
+from slayer.sql import engine_factory
+from slayer.sql.dialects import dialect_for_ds_type
 from slayer.sql.dialects.sqlite import SqliteDialect
 
 # Module-level singleton — its ``register_udfs`` is the SQLAlchemy
@@ -156,8 +159,6 @@ def _get_async_engine(connection_string: str):
     compared to the query itself, and the connection pool handles reuse within
     a single engine's lifetime.
     """
-    from sqlalchemy.ext.asyncio import create_async_engine
-
     return create_async_engine(connection_string, pool_pre_ping=True)
 
 
@@ -191,8 +192,6 @@ def _map_type_code(type_code, db_type: str | None = None) -> str:
     Postgres-OID / MySQL-fieldtype / ODBC paths below.
     """
     if isinstance(type_code, int) and db_type:
-        from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
-
         dialect_category = dialect_for_ds_type(db_type).map_cursor_type_code(type_code)
         if dialect_category is not None:
             return dialect_category
@@ -403,7 +402,6 @@ def _apply_type_probe_timeout(conn, db_type: str | None, timeout_seconds: int) -
     """
     if not db_type:
         return
-    from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
     timeout_sql = dialect_for_ds_type(db_type).statement_timeout_sql(timeout_seconds)
     if timeout_sql:
         conn.execute(sa.text(timeout_sql))
@@ -413,7 +411,6 @@ async def _apply_type_probe_timeout_async(conn, db_type: str | None, timeout_sec
     """Async sibling of ``_apply_type_probe_timeout``."""
     if not db_type:
         return
-    from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
     timeout_sql = dialect_for_ds_type(db_type).statement_timeout_sql(timeout_seconds)
     if timeout_sql:
         await conn.execute(sa.text(timeout_sql))
@@ -528,7 +525,6 @@ class SlayerSQLClient:
             self._sync_engine = _create_in_memory_sqlite_engine(conn_str)
             return self._sync_engine
         # Cached factory engine — dialect hooks attach listeners + creator=.
-        from slayer.sql import engine_factory  # noqa: PLC0415
         self._sync_engine = engine_factory.get_engine(self.datasource)
         return self._sync_engine
 
@@ -544,7 +540,6 @@ class SlayerSQLClient:
         """
         if not _is_auth_failure(exc):
             return False
-        from slayer.sql import engine_factory  # noqa: PLC0415
         self._sync_engine = None
         try:
             engine_factory.invalidate_engine(self.datasource)
@@ -845,7 +840,6 @@ async def _execute_sql_async(
             # SqlDialect returns None — only dialects with a custom
             # statement_timeout_sql (currently SnowflakeDialect) emit a
             # SET.
-            from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
             timeout_sql = dialect_for_ds_type(db_type).statement_timeout_sql(timeout_seconds)
             if timeout_sql:
                 await conn.execute(sa.text(timeout_sql))
@@ -951,7 +945,6 @@ def _execute_sql_sync(
             # SqlDialect returns None — only dialects with a custom
             # statement_timeout_sql (currently SnowflakeDialect) emit a
             # SET.
-            from slayer.sql.dialects import dialect_for_ds_type  # noqa: PLC0415
             timeout_sql = dialect_for_ds_type(db_type).statement_timeout_sql(timeout_seconds)
             if timeout_sql:
                 conn.execute(sa.text(timeout_sql))

--- a/tests/integration/test_schema_drift_duckdb.py
+++ b/tests/integration/test_schema_drift_duckdb.py
@@ -156,6 +156,33 @@ async def test_no_drift_returns_empty(duckdb_drift_env) -> None:
     assert result == []
 
 
+async def test_sql_model_typed_columns_do_not_report_false_drift(
+    duckdb_drift_env,
+) -> None:
+    engine, _ = duckdb_drift_env
+    await engine.storage.save_model(
+        SlayerModel(
+            name="typed_sql",
+            data_source="dduckdb",
+            sql=(
+                "SELECT 7::INTEGER AS qty, TRUE AS active, "
+                "TIMESTAMP '2026-01-02 03:04:05' AS occurred_at, "
+                "'ok'::VARCHAR AS label"
+            ),
+            columns=[
+                Column(name="qty", type=DataType.INT),
+                Column(name="active", type=DataType.BOOLEAN),
+                Column(name="occurred_at", type=DataType.TIMESTAMP),
+                Column(name="label", type=DataType.TEXT),
+            ],
+        )
+    )
+
+    result = await engine.validate_models(data_source="dduckdb")
+
+    assert result == []
+
+
 async def test_drop_column_yields_edit_model_delete(duckdb_drift_env) -> None:
     engine, db_path = duckdb_drift_env
     conn = duckdb.connect(db_path)

--- a/tests/integration/test_schema_drift_duckdb.py
+++ b/tests/integration/test_schema_drift_duckdb.py
@@ -8,10 +8,6 @@ from __future__ import annotations
 
 import pytest
 
-pytest.importorskip("duckdb")
-
-import duckdb
-
 from slayer.async_utils import run_sync
 from slayer.core.enums import DataType
 from slayer.core.models import (
@@ -24,6 +20,7 @@ from slayer.engine.query_engine import SlayerQueryEngine
 from slayer.engine.schema_drift import EditModelDelete, WholeModelDelete
 from slayer.storage.yaml_storage import YAMLStorage
 
+duckdb = pytest.importorskip("duckdb")
 
 pytestmark = pytest.mark.integration
 

--- a/tests/test_sql_client.py
+++ b/tests/test_sql_client.py
@@ -84,6 +84,23 @@ class TestMapTypeCode:
     def test_duckdb_timestamp(self) -> None:
         assert _map_type_code("TIMESTAMP") == "time"
 
+    def test_duckdb_driver_type_objects(self) -> None:
+        duckdb = pytest.importorskip("duckdb")
+        connection = duckdb.connect()
+        try:
+            description = connection.execute(
+                "SELECT 1::INTEGER AS i, TRUE AS b, CURRENT_TIMESTAMP AS t, INTERVAL 1 DAY AS iv"
+            ).description
+        finally:
+            connection.close()
+
+        assert {column[0]: _map_type_code(type_code=column[1], db_type="duckdb") for column in description} == {
+            "i": "number",
+            "b": "boolean",
+            "t": "time",
+            "iv": "time",
+        }
+
     # --- Dialect-aware OID mapping ---
 
     def test_pg_oid_16_is_boolean(self) -> None:


### PR DESCRIPTION
## Summary

- normalize DuckDB `DuckDBPyType` cursor metadata through its canonical type name;
- classify temporal names before numeric substrings so `INTERVAL` is not mistaken for an integer;
- cover the real DuckDB driver objects and SQL-model schema-drift path with regressions.

## Why

DuckDB SQL-backed model validation currently treats every cursor type as text. Valid numeric, boolean, and temporal fields are then reported as drift and can be removed from semantic metadata by force-clean workflows.

Fixes #335.

## Validation

- `poetry run pytest tests/ -v -m "not integration" --timeout=120` — 13,491 passed, 167 skipped, 2 xfailed.
- `poetry run pytest tests/ -v -m "integration and not metabase_e2e" --timeout=180` with the three CI dialect exclusions and `test_integration_flight.py` excluded locally — 434 passed, 32 skipped, 2 xpassed. The JDBC-only file was unavailable because this Mac has no JVM; GitHub CI provisions JDK 17 and runs it.
- `pytest tests/test_sql_client.py tests/integration/test_schema_drift_duckdb.py -v --timeout=180` — 103 passed.
- `ruff check slayer/ tests/` — passed.
- Ruff format checks for all touched ranges and `git diff --check` — passed.

No public API, persisted schema, configuration, or documentation changes are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DuckDB column type recognition for numeric, boolean, interval, and timestamp values.
  * Prevented false schema drift reports for SQL models using explicitly typed DuckDB columns.
  * Improved model validation accuracy when working with typed SQL query results.

* **Tests**
  * Added coverage for DuckDB driver type objects and typed SQL model validation.
  * Added integration coverage for schema drift detection with typed SQL expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->