### PR TITLE
Fix async database installs on Apple Silicon

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2267,7 +2267,6 @@ description = "Lightweight in-process concurrent programming"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
-markers = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""
 files = [
     {file = "greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6"},
     {file = "greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82"},
@@ -2329,6 +2328,7 @@ files = [
     {file = "greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705"},
     {file = "greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff"},
 ]
+markers = {dev = "platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\""}
 
 [package.extras]
 docs = ["Sphinx", "furo"]
@@ -7971,4 +7971,4 @@ sqlserver = ["pyodbc"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "2e46970e54d8a8239b9a7415b62f3dd51b80433c97e6ed970d3726caa58510a3"
+content-hash = "4d9bdb693eb32df706fe670ce879f2e36ab016bec99fd9de3ea58559979b9bc4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ Discord = "https://discord.gg/egWxMctHCA"
 python = "^3.11"
 sqlglot = {version = ">=30.17", extras = ["c"]}
 sqlalchemy = ">=2.0"
+greenlet = ">=1"
 pydantic = ">=2.0"
 python-dateutil = ">=2.8"
 pyyaml = ">=6.0"

--- a/tests/test_sqlalchemy_async_dependency.py
+++ b/tests/test_sqlalchemy_async_dependency.py
@@ -1,0 +1,14 @@
+"""SQLAlchemy's async runtime must be installed on every supported platform."""
+
+import tomllib
+from pathlib import Path
+
+
+def test_greenlet_is_a_core_dependency() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    dependencies = tomllib.loads(pyproject.read_text())["tool"]["poetry"]["dependencies"]
+
+    greenlet = dependencies["greenlet"]
+    if isinstance(greenlet, dict):
+        assert not greenlet.get("optional")
+        assert not greenlet.get("markers")


### PR DESCRIPTION
## Summary

- install `greenlet` as an unconditional core dependency so SQLAlchemy's async
  runtime works when macOS reports `platform_machine() == "arm64"`
- regenerate the Poetry lockfile without the main-group platform marker
- add a regression test for the required, unmarked dependency invariant

Closes #342.

## Why

SLayer's PostgreSQL and MySQL integrations use SQLAlchemy's async engine, but a
clean Apple Silicon install omitted `greenlet`. SQLAlchemy's transitive marker
covers `aarch64` and `x86_64`, not macOS's `arm64`, so every query failed before
the driver attempted a connection.

A direct dependency is intentional: with Poetry 2.4.1, declaring
`sqlalchemy[asyncio]` still retained the transitive platform marker in the
lockfile and omitted `greenlet` on this machine.

## Validation

- `poetry install -E all --with dev`
- `pytest tests/ -v -m 'not integration' --timeout=120` — 13,738 passed,
  97 skipped, 699 deselected, 2 xfailed
- `pytest tests/integration/test_integration_flight.py -q --timeout=180` —
  17 passed, 1 xfailed
- `pytest tests/integration/test_notebooks.py -q --timeout=300` — 13 passed,
  2 xpassed
- `pytest -m metabase_e2e tests/integration/test_metabase_e2e.py -v
  --timeout=900` — 60 passed, 2 xfailed (local fixture generation exceeded
  the workflow's 300-second per-test cap before Docker startup)
- `ruff check slayer/ tests/`
- `ruff format --check tests/test_sqlalchemy_async_dependency.py`
- `poetry check --lock`
- built and installed the wheel in a clean Python 3.13 `arm64` environment;
  `greenlet` 3.5.5 installed and imported successfully

## Documentation

No documentation changes are needed. This restores the documented Tier 1
PostgreSQL and MySQL behavior without changing user-facing configuration or APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation and runtime reliability for asynchronous database functionality by making the required greenlet support available by default.

* **Tests**
  * Added coverage to verify that greenlet is included as a required, non-optional dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->