### PR TITLE
Bump lightning-talk example models to storage version 9

### DIFF
--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/customers.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/customers.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: customers
 sql_table: customers
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/items.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/items.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: items
 sql_table: items
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/orders.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/orders.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: orders
 sql_table: orders
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/products.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/products.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: products
 sql_table: products
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/stores.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/stores.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: stores
 sql_table: stores
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/supplies.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/supplies.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: supplies
 sql_table: supplies
 query_variables: {}

--- a/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/tweets.yaml
+++ b/docs/examples/09_lightning_talk/slayer_models/models/jaffle_shop/tweets.yaml
@@ -1,4 +1,4 @@
-version: 8
+version: 9
 name: tweets
 sql_table: tweets
 query_variables: {}


### PR DESCRIPTION
The tracked model snapshot under `docs/examples/09_lightning_talk/slayer_models/models/` was saved at storage version 8. `YAMLStorage` runs migrations on load and writes the result back in place, so any test or notebook run that loads the example dirties the working tree with a `version: 8` → `version: 9` bump (this kept surfacing as stray modifications during unrelated work).

Committing the migrated snapshot stops the churn until the next storage migration. The diff is exactly the seven version lines — no content changes.

The underlying behavior (a read path rewriting user files) is worth fixing separately: migrations could apply in memory on load and persist only on explicit save.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example semantic model configurations to version 9.
  * Applied the update consistently across customers, items, orders, products, stores, supplies, and tweets.
  * No model fields, measures, joins, or other settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->