### PR TITLE
DEV-1848: trim comment/docstring density in test files to the 15% text-ratio cap

### DIFF
--- a/tests/test_dev1746_consumer_materialization.py
+++ b/tests/test_dev1746_consumer_materialization.py
@@ -1,54 +1,5 @@
-"""DEV-1746 §5.1 — ``resolve(consumer=…)`` gets its first production caller.
-
-``ScopeFrame.resolve(consumer=…)`` and ``apply_materializations`` implement the
-projection-boundary principle: a value that crosses a join inside a producing
-scope is projected there under a ``_val_<n>`` alias and referenced by that alias
-from the consumer. Both are fully unit-tested — and both have **zero production
-callers**. An API nobody calls does not establish a principle, so §5.1 requires
-a production-path test.
-
-Meanwhile the generator carries its own second materialiser for exactly the same
-job (``allocate_val()`` + a ``value_alias_by_sql`` dict, deduped by resolved SQL
-text). Two mechanisms, one purpose. "The ``consumer=`` materializer becomes the
-ONLY one on the cross-model path" is therefore read as: it REPLACES that
-generator-local flow. Slot-backed public columns keep resolving through
-projected aliases — consuming another scope's projected column by its alias
-already *is* exchanging data through projected columns.
-
-The two sites migrated here are the ones inside ``_render_cross_model_cte``:
-
-* a **crossing grain** — grouping a first/last cross-model aggregate by a
-  derived dimension whose SQL reaches a further join. The ranked subquery
-  re-exports only ``target.*``, so the grain must be projected inside it::
-
-      regions.population AS _val_0        -- inside the ranked subquery
-      ...
-      GROUP BY _val_0                     -- the outer CTE reads the alias
-
-* a **crossing value** — the aggregated expression itself crosses a join.
-
-The generator's own ``_val_`` flow for the host-rooted ranked path was the last
-holdout; ``RankedAggregatePlan`` (DEV-1748) replaced it, so ``ScopeFrame`` is now
-the single materialiser on every isolated-CTE path. The class at the bottom of
-this module pinned that deferral and now pins its removal — the boundary was
-asserted rather than assumed, so it could not drift silently in either
-direction.
-
-Both dedup on the resolved SQL text — ``ScopeFrame``'s key is
-``(scope_id, rendered_ast, dialect)`` — so the migration was byte-preserving for
-every shape that materialises through ONE of the two sites.
-
-One shape was NOT, and it is a defect the migration fixes: when a first/last
-cross-model aggregate is grouped by the same crossing expression it aggregates,
-both sites fired and each kept its own dedup map, so the expression was
-projected twice (``_val_0`` and ``_val_1``). ``ScopeFrame`` holds one table per
-scope, so they collapse to one. See
-``TestDedupParity::test_one_expression_is_materialised_once_per_scope``.
-
-The pinned CTE bodies below are the DEV-1836 target-rooted producer (``_cm_``)
-shape: the ranked subquery is rooted at the target, aliases are canonical
-(``customers_v2.*``), and the producer measure keeps its canonical alias (the
-user name lands on the outer projection via the placeholder substitution).
+"""``ScopeFrame.resolve(consumer=…)`` becomes the single materialiser on the cross-model path.
+It projects a join-crossing value inside the producing scope under a ``_val_<n>`` alias and references it from the consumer, replacing the generator's own ``allocate_val()`` flow. Migrated sites (inside ``_render_cross_model_cte``): a crossing grain (grouping a first/last cross-model aggregate by a derived dimension whose SQL reaches a further join) and a crossing value (the aggregated expression itself crosses a join). Both dedup on resolved SQL text, so the swap is byte-preserving — except one fixed defect: grouping a first/last aggregate by the same expression it aggregates used to project it twice; one per-scope table collapses it to one.
 """
 
 from __future__ import annotations
@@ -66,11 +17,7 @@ from slayer.sql.scope import ScopeFrame
 from tests._cross_model_chain import _gen
 from tests._engine_helpers import _extract_cte_body, _norm
 
-# --------------------------------------------------------------------------- #
-# Byte-parity baselines — the emitted SQL these shapes produce today. The
-# migration swaps WHICH materialiser mints ``_val_0``; it must not change the
-# SQL, so these are pinned verbatim (normalised for whitespace only).
-# --------------------------------------------------------------------------- #
+# Byte-parity baselines: swapping which materialiser mints ``_val_0`` must not change this SQL.
 CROSSING_GRAIN_CTE = _norm(
     """
     SELECT _val_0 AS "customers_v2.deep_pop",
@@ -103,7 +50,6 @@ CROSSING_VALUE_CTE = _norm(
 
 
 def _crossing_grain_query() -> SlayerQuery:
-    """First/last cross-model aggregate grouped by a CROSSING derived grain."""
     return SlayerQuery(
         source_model="orders_x",
         dimensions=[ColumnRef(name="customers_v2.deep_pop")],
@@ -114,7 +60,6 @@ def _crossing_grain_query() -> SlayerQuery:
 
 
 def _crossing_value_query() -> SlayerQuery:
-    """First/last cross-model aggregate whose VALUE crosses a join."""
     return SlayerQuery(
         source_model="orders_x",
         dimensions=[ColumnRef(name="customers_v2.status")],
@@ -135,18 +80,7 @@ def _two_distinct_crossing_values_query() -> SlayerQuery:
 
 class _ResolveSpy:
     """Records every close of a scoped value and whether it named a consumer.
-
-    Spies on ``ScopeFrame._close`` — the Law-2 branch itself — rather than on
-    ``resolve``. Both public entry points funnel through it: ``resolve(ref,
-    consumer=…)`` for a value the scope anchors from a key, and
-    ``materialize_for(expr, consumer=…)`` for one the producer anchored itself.
-
-    The cross-model CTE uses the second. It must: the expressions it
-    materialises are a date-truncated grain and a value carrying its column's
-    declared CAST, and re-deriving those by anchoring a ref would project a
-    different expression than the one the aggregate consumes. What §5.1 asks
-    for is that the materialisation branch runs on the production path with a
-    named consumer, which is exactly what this observes.
+    Spies on ``ScopeFrame._close`` (the branch both ``resolve`` and ``materialize_for`` funnel through), so a named-consumer close is observable on the production path.
     """
 
     def __init__(self) -> None:
@@ -183,9 +117,6 @@ class _MaterializeSpy:
         monkeypatch.setattr(ScopeFrame, "_materialize", _wrapped, raising=True)
 
 
-# =========================================================================== #
-# The production-path proof.
-# =========================================================================== #
 class TestConsumerMaterializationOnTheProductionPath:
 
     @pytest.mark.parametrize(
@@ -196,8 +127,6 @@ class TestConsumerMaterializationOnTheProductionPath:
     async def test_a_value_is_closed_for_a_named_consumer(
         self, query_factory, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """NEW (§5.1): generating a real query exercises the projection-boundary
-        branch with a named consumer."""
         spy = _ResolveSpy()
         spy.install(monkeypatch)
         await _gen(query_factory(), dialect="postgres")
@@ -217,8 +146,6 @@ class TestConsumerMaterializationOnTheProductionPath:
     async def test_scope_frame_mints_the_val_alias(
         self, query_factory, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The alias in the emitted SQL is the one ``ScopeFrame`` minted — not a
-        coincidentally-identical one from the generator's own allocator."""
         spy = _MaterializeSpy()
         spy.install(monkeypatch)
         sql = await _gen(query_factory(), dialect="postgres")
@@ -235,15 +162,7 @@ class TestConsumerMaterializationOnTheProductionPath:
     async def test_what_the_scope_materialises_is_what_gets_projected(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The other half of the contract: the scope's materialisation table is
-        the SOURCE of the producing SELECT's extra projections.
-
-        Asserted on the table's contents reaching the SQL rather than on
-        ``apply_materializations`` being the call used. The producing scope here
-        is a ranked subquery the generator assembles from parts, so it reads the
-        table directly; what must hold either way is that every materialisation
-        is projected under its own alias and that nothing else invents one.
-        """
+        """Every entry in the scope's materialisation table is projected under its own alias in the producing SELECT, and nothing else invents one."""
         captured: List[List[Tuple[str, str]]] = []
         original = ScopeFrame._materialize
 
@@ -266,9 +185,6 @@ class TestConsumerMaterializationOnTheProductionPath:
             )
 
 
-# =========================================================================== #
-# Byte-parity: swapping the materialiser must not change emitted SQL.
-# =========================================================================== #
 class TestMigrationIsBytePreserving:
 
     async def test_crossing_grain_cte_is_unchanged(self) -> None:
@@ -290,38 +206,18 @@ class TestMigrationIsBytePreserving:
         )
 
 
-# =========================================================================== #
-# Dedup parity with the flow being replaced.
-# =========================================================================== #
 class TestDedupParity:
 
     async def test_two_distinct_crossing_values_get_distinct_aliases(
         self,
     ) -> None:
-        """Different values must never collapse onto one alias — that would
-        silently aggregate the wrong column."""
+        """Different values must never collapse onto one alias (would aggregate the wrong column)."""
         sql = await _gen(_two_distinct_crossing_values_query(), dialect="postgres")
         assert "_val_0" in sql, f"first materialisation missing:\n{sql}"
         assert "_val_1" in sql, f"second materialisation missing:\n{sql}"
 
     async def test_one_expression_is_materialised_once_per_scope(self) -> None:
-        """NEWLY SURFACED DIVERGENCE — grouping a first/last cross-model
-        aggregate by the SAME crossing expression it aggregates materialises it
-        TWICE today::
-
-            regions.weight AS _val_0,      -- minted by the grain loop
-            regions.weight AS _val_1,      -- minted by the value branch
-
-        because the two sites keep SEPARATE dedup maps (the grain loop calls
-        ``allocate_val()`` without consulting the value branch's
-        ``value_alias_by_sql``). ``ScopeFrame`` holds ONE materialisation table
-        per scope keyed on the rendered template, so routing both through
-        ``resolve(consumer=…)`` collapses them to a single projection.
-
-        This is a redundant column rather than a wrong answer, but it is an
-        emitted-SQL change beyond the ratified B-items and belongs on the PR's
-        approval list.
-        """
+        """One per-scope ``ScopeFrame`` table collapses to a single projection what the two old dedup maps materialised twice (grouping a first/last aggregate by the same expression it aggregates)."""
         query = SlayerQuery(
             source_model="orders_x",
             dimensions=[ColumnRef(name="customers_v2.deep_weight")],
@@ -340,10 +236,7 @@ class TestDedupParity:
     async def test_separate_scopes_keep_independent_materialisations(
         self,
     ) -> None:
-        """Dedup is per SCOPE, not global: two ``_cm_`` CTEs are two scopes, so
-        each materialises its own copy. Pinned so the dedup unification above
-        is not over-applied into cross-scope sharing, which would reference an
-        alias that does not exist in the consuming CTE."""
+        """Dedup is per scope: two ``_cm_`` CTEs each materialise their own copy (guards against over-sharing into an alias absent from the consuming CTE)."""
         query = SlayerQuery(
             source_model="orders_x",
             dimensions=[ColumnRef(name="customers_v2.status")],
@@ -360,22 +253,9 @@ class TestDedupParity:
             )
 
 
-# =========================================================================== #
-# The deliberate PR-5 exception, pinned rather than left implicit.
-# =========================================================================== #
 class TestRankedPathUsesTheOneMaterialiser:
-    """The HOST-rooted ranked path, which kept the generator's own ``_val_``
-    flow until ``RankedAggregatePlan`` (DEV-1748) replaced it.
-
-    This class asserted the DEFERRAL — that ``ScopeFrame`` did NOT materialise
-    here — precisely so the boundary between the two PRs could not move
-    silently. It now asserts the migration, which is the same claim with the
-    sign flipped: there is ONE materialiser per scope, and this path uses it.
-
-    To reach that code the aggregate must be rooted at the HOST — a
-    ``customers_v2.…`` measure is cross-model and roots at the target instead.
-    So the host model gets a derived column whose SQL crosses into the joined
-    model, and the first/last aggregate is taken over THAT.
+    """The host-rooted ranked path uses the one per-scope materialiser too.
+    Reaching it needs a HOST-rooted aggregate (a ``customers_v2.…`` measure roots at the target instead), so the host gets a derived column crossing into the joined model and first/last runs over that.
     """
 
     _HOST_CROSSING_COLUMN = [
@@ -394,8 +274,6 @@ class TestRankedPathUsesTheOneMaterialiser:
         )
 
     async def test_local_first_last_still_materialises_correctly(self) -> None:
-        """The corner keeps WORKING while it waits — pinned so PR 5 inherits a
-        test rather than a silent assumption."""
         sql = await _gen(
             self._query(), orders_extra=self._HOST_CROSSING_COLUMN,
             dialect="postgres",
@@ -408,13 +286,7 @@ class TestRankedPathUsesTheOneMaterialiser:
     async def test_every_val_alias_here_comes_from_scopeframe(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The migration, pinned in the same terms the deferral was.
-
-        Every ``_val_`` alias this shape emits must be one ``ScopeFrame``
-        minted. A generator-local materialiser coming back would show up as an
-        alias in the SQL that the spy never saw — which is the failure this
-        catches, and the reason the assertion is by SET rather than by count.
-        """
+        """Every ``_val_`` alias this shape emits must be one ``ScopeFrame`` minted; asserted by SET so a returning generator-local materialiser (an alias the spy never saw) fails."""
         spy = _MaterializeSpy()
         spy.install(monkeypatch)
         sql = await _gen(

--- a/tests/test_dev1769_routed_filter_path_validation.py
+++ b/tests/test_dev1769_routed_filter_path_validation.py
@@ -1,39 +1,5 @@
-"""DEV-1769 — validate multi-hop routed-filter paths in the cross-model
-target-scope renderer.
-
-When a filter is routed into a cross-model CTE, its ``ValueKey`` column leaves
-are re-rooted to the CTE-local scope. The two column-leaf kinds used to validate
-their host-rooted path ASYMMETRICALLY:
-
-* ``ColumnKey`` — rejects an intermediate-hop path (``path[-1] != target``).
-* ``ColumnSqlKey`` — checked only ``model == target``; the PATH was not
-  validated at all, so any path was silently stripped and re-rooted.
-
-DEV-1769's verdict (option (b)): the silently-accepted shape — ``model ==
-target`` but ``path[-1] != target`` — is UNREACHABLE for keys produced by the
-current binder and passed unchanged through the live routing pipeline. The
-binder builds every non-empty-path ``ColumnSqlKey`` with ``model == path[-1]``
-(the terminal hop), and every routed-filter call site passes
-``target_relation == target_model.name``. So the shape can only arise from a
-hand-built / deserialized / rewritten / future-inconsistent key. The fix makes
-both renderers fail closed on it, SYMMETRICALLY with ``ColumnKey``.
-
-Two layers of coverage:
-
-* **E2E (existing behaviour, pinned)** — the reachable shapes the planner
-  actually routes: reachable filters route INTO the CTE, and a filter
-  unreachable from the aggregate's root (intermediate-hop / other-model) is
-  DROPPED from the producer with a warning (DEV-1836 filter inheritance
-  superseded the pre-existing hard rejection at the E2E boundary).
-* **Direct-call layer RETIRED (DEV-1838 2.5)** — the renderer-level
-  ``_reroot_routed_leaf`` seam died with the routed-filter machinery; filters
-  now re-root at plan time through producer inheritance, and the E2E layer
-  above is the surviving coverage.
-
-The aggregate is ``customers_v2.regions.population:sum`` throughout, so the CTE
-target is ``regions`` (a TWO-hop path). That lets a filter path end AT the
-target (``customers_v2.regions.*``) or at the intermediate hop
-(``customers_v2.*``), which single-hop fixtures cannot express.
+"""Multi-hop routed-filter path validation in the cross-model target-scope renderer.
+Two-hop aggregate (``customers_v2.regions.population:sum``) → CTE target ``regions``, so a filter path can end at the target or the intermediate hop; reachable filters route into the CTE, unreachable ones drop from the producer with a warning.
 """
 
 from __future__ import annotations
@@ -53,26 +19,16 @@ from tests._cross_model_chain import (
 )
 from tests._engine_helpers import _assert_valid_sql
 
-# A derived column ON regions, so a filter ``customers_v2.regions.pop_x2`` binds
-# to a ``ColumnSqlKey`` whose path ENDS at the target ``regions``.
+# Derived column on regions: its filter path ends AT the target ``regions``.
 _REGIONS_EXTRA = [Column(name="pop_x2", sql="population * 2", type=DataType.DOUBLE)]
 
-# The aggregate whose source is the two-hop path → CTE target is ``regions``.
 _TWO_HOP_AGG = ModelMeasure(formula="customers_v2.regions.population:sum")
 
-# =========================================================================== #
-# Layer 1 — E2E: the reachable shapes the planner actually routes.
-# =========================================================================== #
+
 class TestRoutedFilterPathE2E:
-    """The planner routes these filters into the ``regions``-rooted CTE. The two
-    ACCEPT cases prove reachable filters land in the CTE WHERE; the two REJECT
-    cases prove the pre-existing rejections still fire (and are what the new
-    ColumnSqlKey guard is made symmetric with)."""
+    """Accept cases: reachable filters land in the CTE WHERE. Reject cases: unreachable filters drop with a warning."""
 
     async def test_plain_column_path_ending_at_target_renders(self) -> None:
-        """A plain-column filter whose path ENDS at the target (``customers_v2.
-        regions.name``) re-roots to the local ``regions`` alias and lands in the
-        CTE WHERE."""
         query = SlayerQuery(
             source_model="orders_x",
             measures=[_TWO_HOP_AGG],
@@ -84,10 +40,6 @@ class TestRoutedFilterPathE2E:
         assert "regions.name = 'x'" in cm_body, cm_body
 
     async def test_derived_column_path_ending_at_target_renders(self) -> None:
-        """A DERIVED-column filter whose path ends at the target
-        (``customers_v2.regions.pop_x2``, owned by ``regions``) expands its
-        ``Column.sql`` rooted at the local ``regions`` alias — the multi-hop
-        ColumnSqlKey ACCEPT case the guard must not reject."""
         query = SlayerQuery(
             source_model="orders_x",
             measures=[_TWO_HOP_AGG],
@@ -99,10 +51,6 @@ class TestRoutedFilterPathE2E:
         assert "CAST(regions.population * 2 AS DOUBLE PRECISION) > 5" in cm_body, cm_body
 
     async def test_intermediate_hop_plain_column_filter_dropped(self) -> None:
-        """DEV-1836: a plain-column filter on the INTERMEDIATE hop
-        (``customers_v2.status`` — unreachable from the ``regions`` aggregate
-        root) is dropped from the producer with a warning, superseding the
-        pre-existing intermediate-hop rejection."""
         query = SlayerQuery(
             source_model="orders_x",
             measures=[_TWO_HOP_AGG],
@@ -121,10 +69,6 @@ class TestRoutedFilterPathE2E:
         ), [str(w.message) for w in caught]
 
     async def test_derived_column_owned_by_other_model_filter_dropped(self) -> None:
-        """DEV-1836: a derived-column filter owned by the intermediate model
-        (``customers_v2.ltv_x2`` — unreachable from the ``regions`` root) is
-        dropped from the producer with a warning, superseding the pre-existing
-        model-ownership rejection."""
         query = SlayerQuery(
             source_model="orders_x",
             measures=[_TWO_HOP_AGG],
@@ -141,8 +85,3 @@ class TestRoutedFilterPathE2E:
             and "customers_v2.ltv_x2" in str(w.message)
             for w in caught
         ), [str(w.message) for w in caught]
-
-
-# =========================================================================== #
-# Layer 2 — direct call: the binder-unreachable inconsistent key (the new guard).
-# =========================================================================== #


### PR DESCRIPTION
Comment/docstring-only cleanup for DEV-1848 (no behaviour change).

Most of the issue's worst offenders were already brought under the 15% cap on main by the DEV-1836/1838/1846 waves; after fast-forwarding, only three files remained individually above it. Two are trimmed here:

- `tests/test_dev1769_routed_filter_path_validation.py`: 43.9% -> 5.7% (65/148 -> 5/87 text-only lines)
- `tests/test_dev1746_consumer_materialization.py`: 33.3% -> 5.0% (143/430 -> 15/302)

`slayer/mcp/server.py` (35.8%) is deliberately left untouched: its docstrings are outward-facing MCP tool documentation introspected by FastMCP, so trimming would change the agent-facing schema.

Verification:
- `check-conventions.py --text-ratio-cap 15` over the issue's 13-file set: source 11.2%, tests 7.0%, 0 violations
- Full non-integration suite: 15,172 passed, 100 skipped, 0 failed
- `ruff check slayer/ tests/`: clean; `git diff` contains no code-line changes (docstrings/comments only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for cross-model and ranked materialization paths, including named consumers, aliases, projections, CTE output, deduplication, and aggregate handling.
  * Updated routed-filter validation coverage for multi-hop paths, including rendered target filters and warnings for unreachable filters.
  * Removed outdated and redundant test scenarios and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->