### PR TITLE
Rename PG facade to SQL API in docs

### DIFF
--- a/docs/concepts/query-cache.md
+++ b/docs/concepts/query-cache.md
@@ -3,7 +3,7 @@
 SLayer has an optional, in-memory, per-query result cache **local to a single
 `SlayerQueryEngine` instance**. It is opt-in per call via `cache=True`, modelled
 on [Cube's in-memory cache](https://cube.dev/docs/product/caching). This is a
-**Python-API-only** feature — there is no REST / MCP / CLI / Flight / pg-facade
+**Python-API-only** feature — there is no REST / MCP / CLI / Flight / SQL API
 surface, and no `SlayerClient` plumbing.
 
 Two engines with different connection settings keep separate caches, so a cached
@@ -140,5 +140,5 @@ script use.
   (last-writer-wins on store).
 - **Unbounded.** There is no LRU or size cap; manage memory with `evict` /
   `clear_cache`.
-- **Python API only.** No REST / MCP / CLI / Flight / pg-facade / `SlayerClient`
+- **Python API only.** No REST / MCP / CLI / Flight / SQL API / `SlayerClient`
   surface.

--- a/docs/configuration/datasources.md
+++ b/docs/configuration/datasources.md
@@ -63,7 +63,7 @@ These databases are verified by integration tests and runnable Docker examples. 
 | `snowflake` | `motley-slayer[snowflake]` | `snowflake://?connection_name=default` (TOML-driven) or `snowflake://user:pw@account/db/schema?warehouse=wh&role=role` (inline). See [Snowflake](#snowflake) below. |
 
 `duckdb` has no install extra because `duckdb` and `duckdb-engine` are core
-dependencies — the bundled demo datasource and the Postgres facade both need
+dependencies — the bundled demo datasource and the SQL API both need
 them, so they are always present.
 
 #### Additional support

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -28,7 +28,7 @@ SLayer works with most SQL databases. The base install includes SQLite support (
 | Snowflake, BigQuery, Redshift, Trino, Databricks, MS SQL, Oracle | Covered by sqlglot | SQL generation tested |
 
 DuckDB ships by default rather than behind an extra: the bundled
-`slayer datasources create demo` datasource and the Postgres facade both
+`slayer datasources create demo` datasource and the SQL API both
 require it, so `pip install motley-slayer` alone gives you a working driver.
 
 ## Next Steps

--- a/docs/interfaces/flight-sql.md
+++ b/docs/interfaces/flight-sql.md
@@ -10,7 +10,7 @@ The endpoint is **read-only**: catalog introspection plus a constrained SQL subs
 translates to a `SlayerQuery` and executes against the engine. SQL `INSERT` / `UPDATE` /
 `DELETE` / `CREATE` / `ALTER` / `DROP` are refused with a `read-only` error.
 
-> Prefer a no-Java option? The [Postgres facade](pg-facade.md) (`slayer pg-serve`) exposes
+> Prefer a no-Java option? The [SQL API](pg-facade.md) (`slayer pg-serve`) exposes
 > the same query surface over the Postgres wire protocol, so any Postgres-connector BI
 > tool — or `psql` / `asyncpg` — can connect without a JDBC/Arrow driver.
 

--- a/docs/interfaces/pg-facade.md
+++ b/docs/interfaces/pg-facade.md
@@ -1,6 +1,7 @@
-# Postgres Facade
+# SQL API
 
-SLayer speaks the [Postgres wire protocol](https://www.postgresql.org/docs/current/protocol.html)
+SLayer's SQL API is Postgres-based: the server speaks the
+[Postgres wire protocol](https://www.postgresql.org/docs/current/protocol.html)
 on port **5145** by default (REST is 5143, Flight SQL is 5144). Any tool that ships a
 Postgres connector — Metabase, Superset, Tableau, Power BI, Looker, `psql`, `asyncpg`,
 `psycopg` — can connect to SLayer as if it were a Postgres database, with no Java or
@@ -105,7 +106,7 @@ SLayer model as a table under schema `public`, and lets you build questions/dash
 against them. Project named metrics (`revenue_sum`) or write `SUM(amount)` /
 `COUNT(*)` — both map to SLayer measures.
 
-> Phase-1 note: BI tools may issue `pg_catalog` queries beyond the six tables the facade
+> Phase-1 note: BI tools may issue `pg_catalog` queries beyond the six tables the SQL API
 > implements; if a tool trips on one, that's the set to extend.
 
 ## Authentication
@@ -120,7 +121,7 @@ against them. Project named metrics (`revenue_sum`) or write `SUM(amount)` /
 
 ## SQL Surface
 
-The same translator the [Flight SQL facade](flight-sql.md) uses powers this endpoint, so
+The same translator [Flight SQL](flight-sql.md) uses powers this endpoint, so
 the query surface is identical:
 
 * Project **named metrics** and **dimensions** the catalog advertises, e.g.
@@ -219,7 +220,7 @@ expression` error.
 #### CAST coarse-OID mapping
 
 CAST is a **coarse wire-OID hint**, not a precision-preserving conversion.
-The SLayer engine projects the bare column unchanged; the pg-facade encoder
+The SLayer engine projects the bare column unchanged; the SQL API's encoder
 is OID-driven, so the wire bytes always match the OID we advertise. Some
 PostgreSQL types the user can write in a CAST don't have a one-to-one
 SLayer equivalent — those collapse onto the nearest broader SLayer type:
@@ -272,7 +273,7 @@ per column — `asyncpg` (which requests binary results) and `psql` (text) both 
 
 ## Install
 
-The facade is pure-stdlib — no extra is needed. It ships with the base install:
+The SQL API is pure-stdlib — no extra is needed. It ships with the base install:
 
 ```bash
 pip install motley-slayer

--- a/zensical.toml
+++ b/zensical.toml
@@ -46,7 +46,7 @@ nav = [
   ]},
   { "Wire Protocols (BI Tools)" = [
     { "Flight SQL" = "interfaces/flight-sql.md" },
-    { "Postgres Facade" = "interfaces/pg-facade.md" },
+    { "SQL API" = "interfaces/pg-facade.md" },
   ]},
   { "dbt" = [
     { "SLayer vs dbt" = "dbt/slayer_vs_dbt.md" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the “Postgres Facade” interface to “SQL API” throughout the documentation and navigation.
  - Clarified that the SQL API is Postgres-based and uses the pure standard library.
  - Updated DuckDB setup requirements for the demo datasource and SQL API.
  - Refined query-cache and Flight SQL documentation to reference the SQL API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->