### PR TITLE
Fix AssociatedGrainWarning xdist reconstruction + legacy string-strict migration

### DIFF
--- a/slayer/core/errors.py
+++ b/slayer/core/errors.py
@@ -396,11 +396,14 @@ class AssociatedGrainWarning(UserWarning):
     """An aggregate resolved by distinct-entity association over unattributable dimension(s); cells' populations may overlap and are not additive. Visibility warning, not an error."""
 
     def __init__(self, measure: str, dimensions: str) -> None:
+        super().__init__(measure, dimensions)  # args mirror params so cls(*w.args) reconstructs across pytest-xdist
         self.measure = measure
         self.dimensions = dimensions
-        super().__init__(
-            f"Metric {measure!r} associated over unattributable dimension(s) "
-            f"{dimensions}; cell populations may overlap and are not additive."
+
+    def __str__(self) -> str:
+        return (
+            f"Metric {self.measure!r} associated over unattributable dimension(s) "
+            f"{self.dimensions}; cell populations may overlap and are not additive."
         )
 
 

--- a/slayer/storage/migrations.py
+++ b/slayer/storage/migrations.py
@@ -66,6 +66,9 @@ def _query_v3_to_v4(data: dict) -> dict:
     if "strict" not in data:
         return data
     strict = data.pop("strict")
+    if isinstance(strict, str):
+        # migration precedes Pydantic bool coercion; mirror it so a legacy quoted ``strict: "false"`` stays broadcast
+        strict = strict.strip().lower() in ("1", "true", "t", "yes", "y", "on")
     if strict:
         data.setdefault("to_many_handling", "error")
     return data

--- a/slayer/storage/migrations.py
+++ b/slayer/storage/migrations.py
@@ -59,6 +59,12 @@ def _model_v9_to_v10(data: dict) -> dict:
     return data
 
 
+# Legacy quoted ``strict`` tokens; blank/whitespace counts as false. Anything
+# outside both sets fails closed rather than silently reading as broadcast.
+_STRICT_TRUE_TOKENS = frozenset({"1", "true", "t", "yes", "y", "on"})
+_STRICT_FALSE_TOKENS = frozenset({"0", "false", "f", "no", "n", "off", ""})
+
+
 @register_migration(entity="SlayerQuery", source_version=3)
 def _query_v3_to_v4(data: dict) -> dict:
     """v4: retire ``strict`` — ``strict: true`` → ``to_many_handling: "error"``;
@@ -67,8 +73,15 @@ def _query_v3_to_v4(data: dict) -> dict:
         return data
     strict = data.pop("strict")
     if isinstance(strict, str):
-        # migration precedes Pydantic bool coercion; mirror it so a legacy quoted ``strict: "false"`` stays broadcast
-        strict = strict.strip().lower() in ("1", "true", "t", "yes", "y", "on")
+        token = strict.strip().lower()
+        if token in _STRICT_TRUE_TOKENS:
+            strict = True
+        elif token in _STRICT_FALSE_TOKENS:
+            strict = False
+        else:
+            raise ValueError(
+                f"Unrecognized legacy strict value {strict!r}; use to_many_handling instead"
+            )
     if strict:
         data.setdefault("to_many_handling", "error")
     return data

--- a/tests/test_dev1841_mode_field.py
+++ b/tests/test_dev1841_mode_field.py
@@ -99,6 +99,13 @@ class TestStorageMigration:
             out = self._migrate(strict=raw)
             assert out["to_many_handling"] == "error", raw
 
+    def test_strict_unrecognized_string_fails_closed(self) -> None:
+        """An unrecognized legacy token raises rather than silently broadcasting."""
+        for raw in ("error", "treu", "maybe", "broadcast"):
+            with pytest.raises(ValueError) as ei:
+                self._migrate(strict=raw)
+            assert "to_many_handling" in str(ei.value), raw
+
     def test_strict_absent_maps_to_default(self) -> None:
         out = self._migrate()
         assert out.get("to_many_handling", "broadcast") == "broadcast"

--- a/tests/test_dev1841_mode_field.py
+++ b/tests/test_dev1841_mode_field.py
@@ -87,6 +87,18 @@ class TestStorageMigration:
         assert out.get("to_many_handling", "broadcast") == "broadcast"
         assert "strict" not in out
 
+    def test_strict_string_false_maps_to_default(self) -> None:
+        """A legacy quoted ``strict: "false"`` stays broadcast (migration precedes
+        Pydantic bool coercion, so the raw string must not read as truthy)."""
+        for raw in ("false", "False", "0", "no", "off", ""):
+            out = self._migrate(strict=raw)
+            assert out.get("to_many_handling", "broadcast") == "broadcast", raw
+
+    def test_strict_string_true_becomes_error_mode(self) -> None:
+        for raw in ("true", "True", "1", "yes", "on"):
+            out = self._migrate(strict=raw)
+            assert out["to_many_handling"] == "error", raw
+
     def test_strict_absent_maps_to_default(self) -> None:
         out = self._migrate()
         assert out.get("to_many_handling", "broadcast") == "broadcast"

--- a/tests/test_dev1866_fail_closed.py
+++ b/tests/test_dev1866_fail_closed.py
@@ -165,11 +165,9 @@ class TestFailClosed:
         cross-model ``regions.name`` alongside ``orders.status`` fails closed; the
         full path ``customers.regions.name`` resolves to orders. Route-aware rootless
         inference is deferred to DEV-1871 (one binder)."""
+        query = SlayerQuery(dimensions=["orders.status", "regions.name"])
         with pytest.raises(PopulationInferenceError) as ei:
-            await infer_population(
-                query=SlayerQuery(dimensions=["orders.status", "regions.name"]),
-                storage=storage,
-            )
+            await infer_population(query=query, storage=storage)
         assert ei.value.reason is PopulationErrorReason.NO_VIABLE_CANDIDATE
         choice = await infer_population(
             query=SlayerQuery(dimensions=["orders.status", "customers.regions.name"]),

--- a/tests/test_xdist_warning_serialization.py
+++ b/tests/test_xdist_warning_serialization.py
@@ -14,7 +14,11 @@ import pytest
 from xdist.remote import serialize_warning_message
 from xdist.workermanage import unserialize_warning_message
 
-from slayer.core.errors import BroadcastGrainWarning, UnreachableFilterDroppedWarning
+from slayer.core.errors import (
+    AssociatedGrainWarning,
+    BroadcastGrainWarning,
+    UnreachableFilterDroppedWarning,
+)
 from slayer.core.warnings import NormalizationWarning, SlayerNormalizationWarning
 
 
@@ -27,6 +31,9 @@ def _carriers() -> list[UserWarning]:
     )
     return [
         BroadcastGrainWarning(measure="orders.revenue_sum", reason="no join path"),
+        AssociatedGrainWarning(
+            measure="orders.revenue_sum", dimensions="customers.region"
+        ),
         UnreachableFilterDroppedWarning(
             filter_text="customers.score > 5", reason="unreachable from CTE root"
         ),


### PR DESCRIPTION
Two small bug fixes surfaced by a Codex review of #381, split out so #381 can merge on its own. Both touch DEV-1841 association code (not yet on `main`), so this PR is **stacked on `egor/dev-1866-...`** and will retarget to `main` once #381 merges.

## 1. `AssociatedGrainWarning` breaks pytest-xdist warning transport (major)

`AssociatedGrainWarning.__init__` passed a single formatted string to `UserWarning`, so `w.args` had length 1 — but pytest-xdist reconstructs a forwarded warning via `cls(*w.args)`, which needs two args (`measure`, `dimensions`) → `TypeError` on the worker→controller path. Its sibling warnings (`BroadcastGrainWarning`, `UnreachableFilterDroppedWarning`) already mirror their args into `UserWarning` and define `__str__`; this brings `AssociatedGrainWarning` in line. `str()` output is unchanged. The xdist-contract test (`test_xdist_warning_serialization.py`) covered the two siblings but not this class — gap now closed.

## 2. Legacy quoted `strict: "false"` migrates to the wrong mode (minor)

`_query_v3_to_v4` did `if strict:` on the raw pre-Pydantic dict, so a hand-authored `strict: "false"` (a truthy non-empty string) mapped to `to_many_handling: "error"` — contradicting the migration's own contract (`false`/absent → `broadcast` default). Now coerces string values the way Pydantic v2 bool-parsing would, before the truthiness check.

Both fixes have failing-without-the-fix test coverage. Full non-integration suite green under `-n logical` (16826 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning formatting so associated grain details are displayed consistently.
  * Updated migration handling for legacy `strict` values, rejecting unrecognized values with a clear error instead of silently selecting broadcast behavior.

* **Tests**
  * Added coverage for valid and invalid legacy setting values.
  * Verified associated grain warnings remain intact during test and parallel execution workflows.
  * Improved coverage for fail-closed query handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->