### PR TITLE
DEV-1897 follow-up: name all four sql children in sql.arc42.md

### DIFF
--- a/architecture/sql.arc42.md
+++ b/architecture/sql.arc42.md
@@ -4,9 +4,10 @@
 
 `slayer/sql` turns a `PlannedQuery` (built by `engine`) into dialect-correct SQL
 text. Children: `render` (AST assembly: value keys, order terms, joins, CTE
-assembly) and `dialects` (per-dialect emission strategies). It must not know how
-plans are made — it consumes the shared representation in `slayer/ir`, never
-`engine` internals.
+assembly) and `dialects` (per-dialect emission strategies), plus the leaf
+modules `sql_predicate` and `window_detect` that the grandfathered `core`
+`#legacy` doors land on. It must not know how plans are made — it consumes the
+shared representation in `slayer/ir`, never `engine` internals.
 
 ## 2. Building blocks
 
@@ -48,9 +49,6 @@ flowchart TD
 ```
 *Dashed arrows: legacy edges slated to die.*
 <!-- /likec4:sql_focus -->
-
-Children: `render`
-(value keys, aggregates, order terms, joins, node assembly) and `dialects`.
 
 ## 3. Principles
 


### PR DESCRIPTION
The `sql` node declares four children in the model (`render`, `dialects`, `sql_predicate`, `window_detect`), but `sql.arc42.md` §1 named only `render` and `dialects` (and a post-diagram caption repeated the same two). `sql_predicate` and `window_detect` are the leaf modules the grandfathered `core` `#legacy` doors land on — declared children so those doors are expressed at child granularity.

This names all four in §1 and drops the redundant caption, so the prose matches the model. Doc-only; `arch_check` green (diagram unchanged, edit is outside the marker block).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the SQL generation architecture documentation to include predicate handling and window detection modules.
  - Clarified how these modules integrate with the legacy core.
  - Removed outdated details about the previous rendering and dialect scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->